### PR TITLE
Tighten requirements for classification as signal

### DIFF
--- a/vsg/vhdlFile/classify/signal.py
+++ b/vsg/vhdlFile/classify/signal.py
@@ -3,7 +3,7 @@ import re
 
 def signal(dVars, oLine):
 
-    if re.match('^\s*signal', oLine.lineLower) and \
+    if re.match('^\s*signal\s', oLine.lineLower) and \
        not oLine.insideFunction and not oLine.insideProcedure:
         oLine.isSignal = True
         oLine.indentLevel = 1


### PR DESCRIPTION
Require the "signal" keyword to be followed by whitespace.

This prevents lines beginning with identifiers made up of "signal"
and some suffix (such as "signal1" or "signal_a") from being classified
as signals.

Fixes #162 