### PR TITLE
Block support

### DIFF
--- a/vsg/tests/block/block_test_input.vhd
+++ b/vsg/tests/block/block_test_input.vhd
@@ -1,13 +1,23 @@
 
-architecture ARCH of ENTITY is
+entity BLOCK_EXAMPLE is
+end entity BLOCK_EXAMPLE;
+
+architecture RTL of BLOCK_EXAMPLE is
 
 begin
 
   -- correct block format
   BLK : block is
-    signal private : std_logic;
+    signal private : integer;
+
+    type int_array is array (natural range <>) of integer;
+
+    constant vals : int_array(1 downto 0) := (
+      3, 10
+    );
   begin
+    private <= vals(1);
   end block BLK;
 
-end architecture ARCH;
+end architecture RTL;
 

--- a/vsg/tests/vhdlFile/test_vhdlFile_block.py
+++ b/vsg/tests/vhdlFile/test_vhdlFile_block.py
@@ -9,54 +9,26 @@ class testVhdlFileMethods(unittest.TestCase):
 
     def test_insideBlock_assignment(self):
         lExpected = range(10,21)
-        # Generic actual list
-        lActual = []
-        for iIndex, oLine in enumerate(oFileBlock.lines):
-            if oLine.insideBlock:
-                lActual.append(iIndex)
-        # Compare
+        lActual = [i for i, l in enumerate(oFileBlock.lines) if l.insideBlock]
         self.assertEqual(lActual, lExpected)
 
     def test_isBlockBegin_assignment(self):
         lExpected = [18]
-        # Generic actual list
-        lActual = []
-        for iIndex, oLine in enumerate(oFileBlock.lines):
-            if oLine.isBlockBegin:
-                lActual.append(iIndex)
-        # Compare
+        lActual = [i for i, l in enumerate(oFileBlock.lines) if l.isBlockBegin]
         self.assertEqual(lActual, lExpected)
 
     def test_isBlockKeyword_assignment(self):
         lExpected = [10]
-        # Generic actual list
-        lActual = []
-        for iIndex, oLine in enumerate(oFileBlock.lines):
-            if oLine.isBlockKeyword:
-                lActual.append(iIndex)
-        # Compare
+        lActual = [i for i, l in enumerate(oFileBlock.lines) if l.isBlockKeyword]
         self.assertEqual(lActual, lExpected)
 
     def test_isEndBlock_assignment(self):
         lExpected = [20]
-        # Generic actual list
-        lActual = []
-        for iIndex, oLine in enumerate(oFileBlock.lines):
-            if oLine.isEndBlock:
-                lActual.append(iIndex)
-        # Compare
+        lActual = [i for i, l in enumerate(oFileBlock.lines) if l.isEndBlock]
         self.assertEqual(lActual, lExpected)
 
     def test_block_indent_assignment(self):
-        self.maxDiff = None
 #       lExpected = [   0,   1,2,3,   4,5,   6,7,   8,9,10,11,  12,13,  14,15,16,17,18,19,20,  21,22,  23]
         lExpected = [None,None,0,0,None,0,None,0,None,1, 1, 2,None, 2,None, 2, 3, 2, 1, 2, 1,None, 0,None]
-        # Generic actual list
-        lActual = []
-        iMaxCheck = len(lExpected)
-        for iIndex, oLine in enumerate(oFileBlock.lines):
-            if iIndex == iMaxCheck:
-                break
-            lActual.append(oLine.indentLevel)
-        # Compare
+        lActual = [oLine.indentLevel for oLine in oFileBlock.lines]
         self.assertEqual(lActual, lExpected)

--- a/vsg/tests/vhdlFile/test_vhdlFile_block.py
+++ b/vsg/tests/vhdlFile/test_vhdlFile_block.py
@@ -8,7 +8,7 @@ oFileBlock = vhdlFile.vhdlFile(os.path.join(os.path.dirname(__file__),'..','bloc
 class testVhdlFileMethods(unittest.TestCase):
 
     def test_insideBlock_assignment(self):
-        lExpected = [7,8,9,10]
+        lExpected = range(10,21)
         # Generic actual list
         lActual = []
         for iIndex, oLine in enumerate(oFileBlock.lines):
@@ -18,7 +18,7 @@ class testVhdlFileMethods(unittest.TestCase):
         self.assertEqual(lActual, lExpected)
 
     def test_isBlockBegin_assignment(self):
-        lExpected = [9]
+        lExpected = [18]
         # Generic actual list
         lActual = []
         for iIndex, oLine in enumerate(oFileBlock.lines):
@@ -28,7 +28,7 @@ class testVhdlFileMethods(unittest.TestCase):
         self.assertEqual(lActual, lExpected)
 
     def test_isBlockKeyword_assignment(self):
-        lExpected = [7]
+        lExpected = [10]
         # Generic actual list
         lActual = []
         for iIndex, oLine in enumerate(oFileBlock.lines):
@@ -38,7 +38,7 @@ class testVhdlFileMethods(unittest.TestCase):
         self.assertEqual(lActual, lExpected)
 
     def test_isEndBlock_assignment(self):
-        lExpected = [10]
+        lExpected = [20]
         # Generic actual list
         lActual = []
         for iIndex, oLine in enumerate(oFileBlock.lines):
@@ -49,8 +49,8 @@ class testVhdlFileMethods(unittest.TestCase):
 
     def test_block_indent_assignment(self):
         self.maxDiff = None
-#       lExpected = [   0,   1,2,   3,4,   5,6,7,8,9,10,  11,12,  13]
-        lExpected = [None,None,0,None,0,None,1,1,2,1, 1,None, 0,None]
+#       lExpected = [   0,   1,2,3,   4,5,   6,7,   8,9,10,11,  12,13,  14,15,16,17,18,19,20,  21,22,  23]
+        lExpected = [None,None,0,0,None,0,None,0,None,1, 1, 2,None, 2,None, 2, 3, 2, 1, 2, 1,None, 0,None]
         # Generic actual list
         lActual = []
         iMaxCheck = len(lExpected)

--- a/vsg/vhdlFile/classify/constant.py
+++ b/vsg/vhdlFile/classify/constant.py
@@ -6,7 +6,7 @@ def constant(dVars, oLine):
     if re.match('^\s*constant', oLine.lineLower) and \
        not oLine.insideFunction and not oLine.insideProcedure:
         oLine.isConstant = True
-        oLine.indentLevel = 1
+        oLine.indentLevel = dVars['iCurrentIndentLevel']
         oLine.insideConstant = True
         dVars['iCurrentIndentLevel'] += 1
     if oLine.insideConstant:


### PR DESCRIPTION
Fix indentation for multi-line constant definitions within blocks.

Add more scenarios and tidy up the block unit test.