### PR TITLE
Don't use config file_list when file args supplied

### DIFF
--- a/vsg/__main__.py
+++ b/vsg/__main__.py
@@ -57,7 +57,7 @@ def write_junit_xml_file(oJunitFile):
 
 def update_command_line_arguments(commandLineArguments, configuration):
     if configuration:
-        if 'file_list' in configuration:
+        if 'file_list' in configuration and not commandLineArguments.filename:
             for sFilename in configuration['file_list']:
                 try:
                     commandLineArguments.filename.append(expand_filename(sFilename))


### PR DESCRIPTION
Only use the file_list from the JSON configuration if no filename
arguments are supplied.

This allows local_rules and rule settings from a common configuration
file to be used when analysing only a single file.

This is particularly useful when VSG is being used as a checker by an
editor plugin such as Syntastic.