### PR TITLE
Use assertSequenceEqual to compare list and range

### DIFF
--- a/vsg/tests/vhdlFile/test_vhdlFile_block.py
+++ b/vsg/tests/vhdlFile/test_vhdlFile_block.py
@@ -10,7 +10,7 @@ class testVhdlFileMethods(unittest.TestCase):
     def test_insideBlock_assignment(self):
         lExpected = range(10,29)
         lActual = [i for i, l in enumerate(oFileBlock.lines) if l.insideBlock]
-        self.assertEqual(lActual, lExpected)
+        self.assertSequenceEqual(lActual, lExpected)
 
     def test_isBlockBegin_assignment(self):
         lExpected = [18]


### PR DESCRIPTION
Using assertEqual was causing the check to fail under Python 3, where
range() returns an object rather than a list.