### PR TITLE
Replace 3 extract_'vhdl_class'_name(s) functions with single extract function.

### DIFF
--- a/vsg/rules/constant/rule_013.py
+++ b/vsg/rules/constant/rule_013.py
@@ -19,7 +19,7 @@ class rule_013(rule.rule):
 
     def _analyze(self, oFile, oLine, iLineNumber):
         if oLine.isConstant:
-            self.dDatabase['constant'].append(utils.extract_constant_name(oLine))
+            self.dDatabase['constant'].append(utils.extract_class_identifier_list('constant', oLine)[0])
         if oLine.insideArchitecture:
             if oLine.insideProcess:
                 lWords = extract_word_list(oLine)

--- a/vsg/rules/signal/rule_004.py
+++ b/vsg/rules/signal/rule_004.py
@@ -16,11 +16,11 @@ class rule_004(rule.rule):
 
     def _analyze(self, oFile, oLine, iLineNumber):
         if oLine.isSignal:
-            for sWord in utils.extract_signal_names(oLine):
+            for sWord in utils.extract_class_identifier_list('signal', oLine):
                 check.is_lowercase(self, sWord, iLineNumber)
 
     def _fix_violations(self, oFile):
         for iLineNumber in self.violations:
             oLine = oFile.lines[iLineNumber]
-            for sWord in utils.extract_signal_names(oLine):
+            for sWord in utils.extract_class_identifier_list('signal', oLine):
                 fix.lower_case(self, oLine, sWord)

--- a/vsg/rules/signal/rule_014.py
+++ b/vsg/rules/signal/rule_014.py
@@ -19,7 +19,7 @@ class rule_014(rule.rule):
 
     def _analyze(self, oFile, oLine, iLineNumber):
         if oLine.isSignal:
-            self.dDatabase['signal'].extend(utils.extract_signal_names(oLine))
+            self.dDatabase['signal'].extend(utils.extract_class_identifier_list('signal', oLine))
         if oLine.insideArchitecture:
             if oLine.insideProcess and not oLine.isEndProcess and not oLine.isProcessDeclarative:
                 lWords = extract_word_list(oLine)

--- a/vsg/rules/variable/rule_011.py
+++ b/vsg/rules/variable/rule_011.py
@@ -19,7 +19,7 @@ class rule_011(rule.rule):
 
     def _analyze(self, oFile, oLine, iLineNumber):
         if oLine.isVariable:
-            self.dDatabase['variable'].append(utils.extract_variable_name(oLine))
+            self.dDatabase['variable'].append(utils.extract_class_identifier_list('variable', oLine)[0])
         if oLine.insideProcess:
             lWords = extract_word_list(oLine)
             check_violations(self, lWords, iLineNumber)

--- a/vsg/tests/vsg_utils/test_utils.py
+++ b/vsg/tests/vsg_utils/test_utils.py
@@ -172,3 +172,48 @@ class testUtilsProcedures(unittest.TestCase):
         utils.change_word(oLine, 'green', 'red', 2)
         sActual = oLine.line
         self.assertEqual(sExpected, sActual)
+
+class testExtractFunctions(unittest.TestCase):
+
+    def test_extract_class_identifier_list(self):
+        oLine = line.blank_line()
+        oLine.update_line('signal s1, s2, s3 : std_logic := \'1\';')
+        sExpected = ['s1', 's2', 's3']
+        sActual = utils.extract_class_identifier_list('signal', oLine)
+        self.assertEqual(sExpected, sActual)
+
+        oLine = line.blank_line()
+        oLine.update_line('signal s1, s2, s3')
+        sExpected = ['s1', 's2', 's3']
+        sActual = utils.extract_class_identifier_list('signal', oLine)
+        self.assertEqual(sExpected, sActual)
+
+        oLine = line.blank_line()
+        oLine.update_line('signal s_x: std_logic;')
+        sExpected = ['s_x']
+        sActual = utils.extract_class_identifier_list('signal', oLine)
+        self.assertEqual(sExpected, sActual)
+
+        oLine = line.blank_line()
+        oLine.update_line('s1, s2, s3;')
+        sExpected = ['s1', 's2', 's3']
+        sActual = utils.extract_class_identifier_list('signal', oLine)
+        self.assertEqual(sExpected, sActual)
+
+        oLine = line.blank_line()
+        oLine.update_line('sig;')
+        sExpected = ['sig']
+        sActual = utils.extract_class_identifier_list('signal', oLine)
+        self.assertEqual(sExpected, sActual)
+
+        oLine = line.blank_line()
+        oLine.update_line('constant C_VALUE : integer;')
+        sExpected = ['C_VALUE']
+        sActual = utils.extract_class_identifier_list('constant', oLine)
+        self.assertEqual(sExpected, sActual)
+
+        oLine = line.blank_line()
+        oLine.update_line('variable var1, var2 : integer := -32;')
+        sExpected = ['var1', 'var2']
+        sActual = utils.extract_class_identifier_list('variable', oLine)
+        self.assertEqual(sExpected, sActual)

--- a/vsg/utils.py
+++ b/vsg/utils.py
@@ -528,51 +528,33 @@ def extract_non_keywords(sString):
     return lReturn
 
 
-def extract_signal_names(oLine):
+def extract_class_identifier_list(sClass, oLine):
     '''
     Returns a list of signals in a signal declaration.
 
     Parameters:
 
+       sClass: (class according to the VHDL standard)
+
        oLine: (line object)
 
     Returns: (list of strings)
     '''
-    sLine = oLine.line.split(':')[0]
-    return sLine.replace(',', ' ').split()[1:]
+    if sClass not in ['constant', 'variable', 'signal', 'file']:
+        raise Exception("sClass must be one of: constant, variable, signal, file")
 
+    sLine = oLine.line.replace(';', '')
+    sLine = sLine.split(':')[0]
+    sLine = sLine.replace(',', ' ').split()
+    if sLine[0].lower() == sClass:
+        sLine = sLine[1:]
 
-def extract_constant_name(oLine):
-    '''
-    Returns the name of a constant in a constant declaration.
-
-    Parameters:
-
-       oLine: (line object)
-
-    Returns: (string)
-    '''
-    sLine = oLine.line.split(':')[0]
-    return sLine.split()[1]
+    return sLine
 
 
 def extract_type_name(oLine):
     '''
     Returns the name of a type in a type declaration.
-
-    Parameters:
-
-       oLine: (line object)
-
-    Returns: (string)
-    '''
-    sLine = oLine.line.split(':')[0]
-    return sLine.split()[1]
-
-
-def extract_variable_name(oLine):
-    '''
-    Returns the name of a variable in a variable declaration.
 
     Parameters:
 


### PR DESCRIPTION
According to the VHDL standard there are 4 classes:
constant, variable, signal, file.

This change is a preparation change for unifying case rules.
