### PR TITLE
Update docs.

### DIFF
--- a/docs/attribute_rules.rst
+++ b/docs/attribute_rules.rst
@@ -33,7 +33,9 @@ This rule checks the indent of **attribute** declarations.
 attribute_002
 #############
 
-This rule checks the **attribute** keyword is lowercase.
+This rule checks the **attribute** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/case_rules.rst
+++ b/docs/case_rules.rst
@@ -289,7 +289,9 @@ This rule checks the indent of the **null** keyword.
 case_014
 ########
 
-This rule checks the **case** keyword is lowercase.
+This rule checks the **case** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -314,7 +316,9 @@ This rule checks the **case** keyword is lowercase.
 case_015
 ########
 
-This rule checks the **is** keyword is lowercase.
+This rule checks the **is** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -339,7 +343,9 @@ This rule checks the **is** keyword is lowercase.
 case_016
 ########
 
-This rule checks the **when** keyword is lowercase.
+This rule checks the **when** has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -360,7 +366,9 @@ This rule checks the **when** keyword is lowercase.
 case_017
 ########
 
-This rule checks the **end** keyword is lowercase in the **end case**.
+This rule checks the **end** keyword in the **end case** has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -381,7 +389,9 @@ This rule checks the **end** keyword is lowercase in the **end case**.
 case_018
 ########
 
-This rule checks the **case** keyword is lowercase in the **end case**.
+This rule checks the **case** keyword has proper case in the **end case**.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/component_rules.rst
+++ b/docs/component_rules.rst
@@ -69,7 +69,9 @@ This rule checks for a blank line above the **component** declaration.
 component_004
 #############
 
-This rule checks the **component** keyword is lowercase.
+This rule checks the **component** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -151,7 +153,9 @@ This rule checks for a single space before the **is** keyword.
 component_008
 #############
 
-This rule checks the component name is uppercase in the component declaration.
+This rule checks the component name has proper case in the component declaration.
+
+.. NOTE::  The default is uppercase.
 
 **Violation**
 
@@ -190,7 +194,9 @@ This rule checks the indent of the **end component** keywords.
 component_010
 #############
 
-This rule checks the **end** keyword is lowercase.
+This rule checks the **end** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/constant_rules.rst
+++ b/docs/constant_rules.rst
@@ -28,7 +28,9 @@ This rule checks the indent of a constant declaration.
 constant_002
 ############
 
-This rule checks the **constant** keyword is lowercase.
+This rule checks the **constant** keyword is has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -184,7 +186,9 @@ Having a space makes it clearer where the assignment occurs on the line.
 constant_011
 ############
 
-This rule checks the constant type is lowercase.
+This rule checks the constant type has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/entity_rules.rst
+++ b/docs/entity_rules.rst
@@ -63,7 +63,9 @@ This rule checks for a blank line above the entity keyword.
 entity_004
 ##########
 
-This rule checks the **entity** keyword is lowercase.
+This rule checks the **entity** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -136,7 +138,9 @@ This rule checks for a single space before the **is** keyword.
 entity_008
 ##########
 
-This rule checks the entity name is uppercase in the entity declaration.
+This rule checks the entity name has proper case in the entity declaration.
+
+.. NOTE::  The default is uppercase.
 
 **Violation**
 
@@ -176,7 +180,9 @@ This rule checks the indent of the **end** keyword.
 entity_010
 ##########
 
-This rule checks the **end** keyword is lowercase.
+This rule checks the **end** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/file_rules.rst
+++ b/docs/file_rules.rst
@@ -35,7 +35,9 @@ This rule checks the indent of **file** declarations.
 file_002
 ########
 
-This rule checks the **file** keyword is lowercase.
+This rule checks the **file** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/function_rules.rst
+++ b/docs/function_rules.rst
@@ -72,7 +72,9 @@ This rule checks for a single space after the function name and the (.'
 function_004
 ############
 
-This rule checks the **begin** keyword is lowercase.
+This rule checks the **begin** keyword has proper case.
+ 
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/generate_rules.rst
+++ b/docs/generate_rules.rst
@@ -163,7 +163,9 @@ This rule checks for a single space after the **end** keyword.
 generate_009
 ############
  
-This rule checks the **end** keyword is lowercase.
+This rule checks the **end** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/generic_rules.rst
+++ b/docs/generic_rules.rst
@@ -167,7 +167,9 @@ This rule checks the indent of the closing parenthesis.
 generic_009
 ###########
 
-This rule checks the **generic** keyword is lowercase.
+This rule checks the **generic** keyword has proper case.
+ 
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/if_rules.rst
+++ b/docs/if_rules.rst
@@ -433,7 +433,9 @@ This rule checks for code after the **then** keyword.
 if_025
 ######
 
-This rule checks the **if** keyword is lowercase.
+This rule checks the **if** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -450,7 +452,9 @@ This rule checks the **if** keyword is lowercase.
 if_026
 ######
 
-This rule checks the **elsif** keyword is lowercase.
+This rule checks the **elsif** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -467,7 +471,9 @@ This rule checks the **elsif** keyword is lowercase.
 if_027
 ######
 
-This rule checks the **else** keyword is lowercase.
+This rule checks the **else** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/instantiation_rules.rst
+++ b/docs/instantiation_rules.rst
@@ -146,7 +146,9 @@ This rule checks the closing ) for the port map is on it's own line.
 instantiation_008
 #################
 
-This rule checks the instance name is uppercase.
+This rule checks the instance name has proper case.
+
+.. NOTE::  The default is uppercase.
 
 **Violation**
 

--- a/docs/library_rules.rst
+++ b/docs/library_rules.rst
@@ -62,7 +62,9 @@ This rule checks for a blank line above the **library** keyword.
 library_004
 ###########
 
-This rule checks the **library** keyword is lower case.
+This rule checks the **library** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -83,7 +85,9 @@ This rule checks the **library** keyword is lower case.
 library_005
 ###########
 
-This rule checks the **use** keyword is lower case.
+This rule checks the **use** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/package_rules.rst
+++ b/docs/package_rules.rst
@@ -62,7 +62,9 @@ This rule checks for a blank line above the **package** keyword.
 package_004
 ###########
 
-This rule checks the package keyword is lowercase.
+This rule checks the package keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/port_rules.rst
+++ b/docs/port_rules.rst
@@ -414,7 +414,9 @@ This rule checks for a port definition on the same line as the **port** keyword.
 port_017
 ########
 
-This rule checks the **port** keyword is lowercase.
+This rule checks the **port** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/process_rules.rst
+++ b/docs/process_rules.rst
@@ -158,7 +158,9 @@ This rule checks for a single space after the **end** keyword.
 process_008
 ###########
  
-This rule checks the **end** keyword is lowercase.
+This rule checks the **end** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/signal_rules.rst
+++ b/docs/signal_rules.rst
@@ -31,7 +31,9 @@ This rule checks the indent of signal declarations.
 signal_002
 ##########
 
-This rule checks the **signal** keyword is lowercase.
+This rule checks the **signal** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -189,9 +191,9 @@ This rule has be renumbered signal_013.
 signal_010
 ##########
 
-This rule checks the signal type is lowercase if it is a VHDL keyword.
+This rule checks the signal type has proper case if it is a VHDL keyword.
 
-.. NOTE:: This rule is disabled by default.
+.. NOTE:: This rule is disabled by default. The default is lowercase.
 
 **Violation**
 

--- a/docs/type_rules.rst
+++ b/docs/type_rules.rst
@@ -29,7 +29,9 @@ This rule checks the indent of the **type** declaration.
 type_002
 ########
 
-This rule checks the **type** keyword is lowercase.
+This rule checks the **type** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -72,7 +74,9 @@ This rule checks for spaces after the **type** keyword.
 type_004
 ########
 
-This rule checks the type name is lowercase.
+This rule checks the type name has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -265,7 +269,9 @@ This rule checks the indent of record elements in record types.
 type_013
 ########
 
-This rule checks the **is** keyword is lower case in type definitions.
+This rule checks the **is** keyword in type definitions has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 

--- a/docs/variable_rules.rst
+++ b/docs/variable_rules.rst
@@ -31,7 +31,9 @@ This rule checks the indent of variable declarations.
 variable_002
 ############
 
-This rule checks the **variable** keyword is lowercase.
+This rule checks the **variable** keyword has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 
@@ -65,7 +67,9 @@ This rule checks for a single space after the **variable** keyword.
 variable_004
 ############
 
-This rule checks the variable name is lowercase.
+This rule checks the variable name has proper case.
+
+.. NOTE::  The default is lowercase.
 
 **Violation**
 


### PR DESCRIPTION
While updating the docs I have realized, that there are still some case rules that use fixed lowercase, they should also be refactored to used `case_rule`. What is more, the docs should probably also inform user, how to change case from default to lower or upper.
