### PR TITLE
Fixes required to handle double hyphens in quoted strings so they are not considered a comment marker.

### DIFF
--- a/vsg/__main__.py
+++ b/vsg/__main__.py
@@ -103,17 +103,18 @@ def write_invalid_configuration_junit_file(sFileName, commandLineArguments):
 
 
 def write_vhdl_file(oVhdlFile):
-    with open(oVhdlFile.filename, 'w') as oFile:
-        for oLine in oVhdlFile.lines[1:]:
-            oFile.write(oLine.line + '\n')
-    oFile.close()
+    try:
+        with open(oVhdlFile.filename, 'w') as oFile:
+            for oLine in oVhdlFile.lines[1:]:
+                oFile.write(oLine.line + '\n')
+    except PermissionError as err:
+        print (err, "Could not write fixes back to file.")
 
 
 def write_junit_xml_file(oJunitFile):
     with open(oJunitFile.filename, 'w') as oFile:
         for sLine in oJunitFile.build_junit():
             oFile.write(sLine + '\n')
-    oFile.close()
 
 
 def update_command_line_arguments(commandLineArguments, configuration):

--- a/vsg/check/__init__.py
+++ b/vsg/check/__init__.py
@@ -16,6 +16,7 @@ from .is_single_space_before_character import *
 from .is_single_space_before import *
 from .is_uppercase import *
 from .keyword_alignment import *
+from .comment_alignment import *
 from .multiline_alignment import *
 from .multiline_alignment_with_parenthesis import *
 from .has_prefix import *

--- a/vsg/check/comment_alignment.py
+++ b/vsg/check/comment_alignment.py
@@ -1,0 +1,37 @@
+import re
+
+has_comment_re = re.compile(r'^(?:".*"|[^"\n])*?(?P<comment>--.*)', re.IGNORECASE)
+
+def comment_alignment(self, iLineNumber, lGroup):
+    '''
+    Checks comments in a group of line objects are aligned in the same column.
+
+    Parameters:
+
+      self: (rule object)
+
+      iLineNumber: (integer)
+
+      lGroup: (list of line objects)
+    '''
+    CommentColumns = []
+    sViolationRange = str(iLineNumber) + '-' + str(iLineNumber + len(lGroup) - 1)
+
+    self.dFix['violations'].setdefault(sViolationRange, {}).setdefault('line', {})
+
+    for iIndex, oGroupLine in enumerate(lGroup):
+        match = has_comment_re.match(oGroupLine.line)
+        if match is None:
+            continue
+        column = match.start("comment")
+
+        self.dFix['violations'][sViolationRange]['line'][iLineNumber + iIndex] = {}
+        self.dFix['violations'][sViolationRange]['line'][iLineNumber + iIndex]['commentColumn'] = column
+
+        CommentColumns.append(column)
+
+        if CommentColumns[0] != column:
+            if sViolationRange not in self.violations:
+                self.add_violation(sViolationRange)
+
+    self.dFix['violations'][sViolationRange]['maximumCommentColumn'] = max(CommentColumns + [0])

--- a/vsg/check/keyword_alignment.py
+++ b/vsg/check/keyword_alignment.py
@@ -16,11 +16,8 @@ def keyword_alignment(self, iLineNumber, sKeyword, lGroup):
     iKeywordAlignment = None
     iMaximumKeywordColumn = 0
     sViolationRange = str(iLineNumber) + '-' + str(iLineNumber + len(lGroup) - 1)
-    try:
-        self.dFix['violations'][sViolationRange]['line'] = {}
-    except KeyError:
-        self.dFix['violations'][sViolationRange] = {}
-        self.dFix['violations'][sViolationRange]['line'] = {}
+
+    self.dFix['violations'].setdefault(sViolationRange, {}).setdefault('line', {})
 
     for iIndex, oGroupLine in enumerate(lGroup):
         if sKeyword in oGroupLine.line:

--- a/vsg/fix.py
+++ b/vsg/fix.py
@@ -38,6 +38,24 @@ def keyword_alignment(self, oFile):
             oLine.update_line(oLine.line[:iKeywordColumn] + ' '*(iMaximumKeywordColumn - iKeywordColumn) + oLine.line[iKeywordColumn:])
 
 
+def comment_alignment(self, oFile):
+    '''
+    Aligns comments across multiple lines.
+
+    Parameters:
+
+      self: (rule object)
+
+      oFile: (vhdlFile object)
+    '''
+    for sKey in self.dFix['violations']:
+        iMaximumCommentColumn = self.dFix['violations'][sKey]['maximumCommentColumn']
+        for iLineNumber in self.dFix['violations'][sKey]['line']:
+            iCommentColumn = self.dFix['violations'][sKey]['line'][iLineNumber]['commentColumn']
+            oLine = oFile.lines[iLineNumber]
+            oLine.update_line(oLine.line[:iCommentColumn] + ' '*(iMaximumCommentColumn - iCommentColumn) + oLine.line[iCommentColumn:])
+
+
 def multiline_alignment(self, oFile, iLineNumber):
     '''
     Indents successive lines of multiline statements.

--- a/vsg/rules/after/rule_001.py
+++ b/vsg/rules/after/rule_001.py
@@ -24,14 +24,14 @@ class rule_001(rule.rule):
     def _analyze(self, oFile, oLine, iLineNumber):
         if oLine.insideClockProcess:
             if oLine.isSequentialEnd:
-                self.sequentialStatement += oLine.lineNoComment.replace('--', '  ')
+                self.sequentialStatement += oLine.lineNoComment + " "
                 if not re.match('^\s*.*\safter\s', self.sequentialStatement):
                     self.add_violation(iLineNumber)
                 self.sequentialStatement = ""
             elif oLine.insideSequential:
-                self.sequentialStatement += oLine.lineNoComment.replace('--', '  ')
+                self.sequentialStatement += oLine.lineNoComment + " "
             elif oLine.isSequential:
-                self.sequentialStatement = oLine.lineNoComment.replace('--', '  ')
+                self.sequentialStatement = oLine.lineNoComment + " "
 
     def _fix_violations(self, oFile):
         for iLineNumber in self.violations:

--- a/vsg/rules/architecture/rule_023.py
+++ b/vsg/rules/architecture/rule_023.py
@@ -1,17 +1,47 @@
 
-from vsg.rules import keyword_alignment_rule
+from vsg import rule
+from vsg import check
+from vsg import fix
+from vsg import line
 
 
-class rule_023(keyword_alignment_rule):
+class rule_023(rule.rule):
     '''
     Architecture rule 023 ensures the alignment of comments.
     '''
 
     def __init__(self):
-        keyword_alignment_rule.__init__(self, 'architecture', '023')
+        rule.rule.__init__(self, name='architecture', identifier='023')
+        self.phase = 7
         self.solution = 'Inconsistent alignment of comments.'
-        self.sKeyword = '--'
         self.sStartGroupTrigger = 'isArchitectureKeyword'
         self.sEndGroupTrigger = 'isArchitectureBegin'
         self.sLineTrigger = 'hasInlineComment'
-        self.phase = 7
+
+    def _pre_analyze(self):
+        self.lGroup = []
+        self.fGroupFound = False
+        self.iStartGroupIndex = None
+
+    def _analyze(self, oFile, oLine, iLineNumber):
+        if oLine.__dict__[self.sStartGroupTrigger] and not self.fGroupFound:
+            self.fGroupFound = True
+            self.iStartGroupIndex = iLineNumber
+        if oLine.__dict__[self.sEndGroupTrigger] and self.fGroupFound:
+            self.lGroup.append(oLine)
+            self.fGroupFound = False
+            check.comment_alignment(self, self.iStartGroupIndex, self.lGroup)
+            self.lGroup = []
+            self.iStartGroupIndex = None
+        if self.fGroupFound:
+            if isinstance(self.sLineTrigger, list):
+                for sTrigger in self.sLineTrigger:
+                    if oLine.__dict__[sTrigger]:
+                        self.lGroup.append(oLine)
+            elif oLine.__dict__[self.sLineTrigger]:
+                self.lGroup.append(oLine)
+            else:
+                self.lGroup.append(line.line('Removed line'))
+
+    def _fix_violations(self, oFile):
+        fix.comment_alignment(self, oFile)

--- a/vsg/rules/comment/rule_004.py
+++ b/vsg/rules/comment/rule_004.py
@@ -1,12 +1,26 @@
 
-from vsg.rules import single_space_before_character_rule
+from vsg import rule
 
 
-class rule_004(single_space_before_character_rule):
+class rule_004(rule.rule):
     '''
     Comment rule 004 ensures there is at least one space before comments on a line with code.
     '''
 
     def __init__(self):
-        single_space_before_character_rule.__init__(self, 'comment', '004', 'hasInlineComment', '--')
+        rule.rule.__init__(self, name='comment', identifier='004')
+        self.phase = 2
         self.solution = 'Add a space before the comment --'
+
+    def _analyze(self, oFile, oLine, iLineNumber):
+        if oLine.__dict__['hasInlineComment']:
+            if oLine.line[oLine.commentColumn - 1] != ' ':
+                self.add_violation(iLineNumber)
+
+    def _fix_violations(self, oFile):
+        for iLineNumber in self.violations:
+            oLine = oFile.lines[iLineNumber]
+            idx = oLine.commentColumn
+            oLine.update_line(" ".join((oLine.line[:idx],oLine.line[idx:])))
+
+

--- a/vsg/rules/signal/rule_015.py
+++ b/vsg/rules/signal/rule_015.py
@@ -1,6 +1,7 @@
 
 from vsg import rule
 from vsg import utils
+import re
 
 
 class rule_015(rule.rule):
@@ -26,7 +27,9 @@ class rule_015(rule.rule):
         if oLine.insideSignal:
             self.sFullLine += oLine.line
         if oLine.isEndSignal:
-            if self.sFullLine.count(',') > self.consecutive - 1:
+            match = re.match(r'.*?signal\s+(?P<signals>[^:\n]*):', self.sFullLine)
+            sSignalList = match.group("signals")
+            if sSignalList.count(',') > self.consecutive - 1:
                 self.add_violation(self.iFailureLine)
                 self.dFix['violations'][self.iFailureLine] = {}
                 self.dFix['violations'][self.iFailureLine]['endLine'] = iLineNumber

--- a/vsg/rules/whitespace/rule_011.py
+++ b/vsg/rules/whitespace/rule_011.py
@@ -22,11 +22,25 @@ class rule_011(rule.rule):
         if '-' in sLine:
             lLine = sLine.split()
             for sWord in lLine:
-                if '-' in sWord and not sWord == '-':
+                if '-' in sWord:
+                    if sWord == '-':
+                        # already good.
+                        continue
+                    if re.match(".*?'-'", sWord) is not None:
+                        # found a std_logic don't care.
+                        continue
+                    if re.match('.*?[_01LHZXU\-]+"', sWord) is not None:
+                        # found a std_logic_vector constant with a don't care.
+                        continue
+                    #if re.match('^.*\W-[0-9]', sWord) is not None:
+                    #    # found a negative number
+                    #    continue
                     if re.match('^.*\w-', sWord):
                         self.add_violation(iLineNumber)
+                        print("whitespace_011:", iLineNumber, sLine, lLine, sWord)
                     elif not re.match('^.*-[0-9]+\)?$', sWord):
                         self.add_violation(iLineNumber)
+                        print("whitespace_011:", iLineNumber, sLine, lLine, sWord)
         else:
             if re.match('^.*[\w+|\)][+|/|*]', sLine) or re.match('^.*[+|/|*][\w+|\(]', sLine):
                 if not re.match('^.*".*/.*"', sLine):

--- a/vsg/rules/whitespace/rule_011.py
+++ b/vsg/rules/whitespace/rule_011.py
@@ -26,21 +26,20 @@ class rule_011(rule.rule):
                     if sWord == '-':
                         # already good.
                         continue
-                    if re.match(".*?'-'", sWord) is not None:
+                    if re.match(r".*?'-'", sWord) is not None:
                         # found a std_logic don't care.
                         continue
-                    if re.match('.*?[_01LHZXU\-]+"', sWord) is not None:
-                        # found a std_logic_vector constant with a don't care.
+                    if re.match(r'(?:".*"|[^"\n])*?-', sWord) is None:
+                        # The - was in a quoted string.
+                        # e.g. found a std_logic_vector constant with a don't care.
                         continue
                     #if re.match('^.*\W-[0-9]', sWord) is not None:
                     #    # found a negative number
                     #    continue
                     if re.match('^.*\w-', sWord):
                         self.add_violation(iLineNumber)
-                        print("whitespace_011:", iLineNumber, sLine, lLine, sWord)
                     elif not re.match('^.*-[0-9]+\)?$', sWord):
                         self.add_violation(iLineNumber)
-                        print("whitespace_011:", iLineNumber, sLine, lLine, sWord)
         else:
             if re.match('^.*[\w+|\)][+|/|*]', sLine) or re.match('^.*[+|/|*][\w+|\(]', sLine):
                 if not re.match('^.*".*/.*"', sLine):

--- a/vsg/tests/comment/comment_test_input.vhd
+++ b/vsg/tests/comment/comment_test_input.vhd
@@ -29,7 +29,7 @@ begin
       e <= f           -- Comment
                    -- Comment
     end if
-    
+
   end process PROC_1:
 
 end architecture
@@ -39,7 +39,7 @@ entity ENTITY is
     G_GENERIC_1 : std_logic := '1';-- Comment
     G_GENERIC_2 : std_logic := '0';   -- Comment
     -- Comment
-    G_GENERIC_3 : std_logic := '1';  -- Comment
+    G_GENERIC_3 : std_logic := '1';
     G_GENERIC_3 : std_logic := '1'; -- Comment
     G_GENERIC_3 : std_logic := '1';  -- Comment
      -- Comment
@@ -52,7 +52,14 @@ entity ENTITY is
     G_GENERIC_3 : std_logic := '1';  -- Comment
     G_GENERIC_3 : std_logic := '1';  -- Comment
     G_GENERIC_3 : std_logic := '1';   -- Comment
-    -- Comment
+    ----------------------------------------------------------
+    G_GENERIC_4 : std_logic_vector := "--";
+    G_GENERIC_4 : std_logic_vector := "--" & "---"; -- Comment
+    G_GENERIC_4 : std_logic_vector := "--";-- Comment --
+    G_GENERIC_4 : string := "-- not a comment --";
+    G_GENERIC_4 : string := "--not a comment--"; -- but this is.
+    G_GENERIC_4 : string := "-- not a comment --";--but--this--is--
+    G_GENERIC_4 : string := "-- not a comment --"--but this is.
   );
   port (
     I_PORT_1 : in   std_logic;  -- Comment

--- a/vsg/tests/comment/test_rule_comment.py
+++ b/vsg/tests/comment/test_rule_comment.py
@@ -25,7 +25,7 @@ class testRuleCommentMethods(unittest.TestCase):
         self.assertTrue(oRule)
         self.assertEqual(oRule.name, 'comment')
         self.assertEqual(oRule.identifier, '010')
-        dExpected = [3,7,12,13,17,19,21,23,27,30,45,49,64,68]
+        dExpected = [3,7,12,13,17,19,21,23,27,30,45,49,71,75]
         oRule.analyze(oFile)
         self.assertEqual(oRule.violations, dExpected)
 
@@ -58,7 +58,7 @@ class testRuleCommentMethods(unittest.TestCase):
 
     def test_rule_004(self):
         oRule = comment.rule_004()
-        dExpected = [39]
+        dExpected = [39, 58, 61, 62]
         oRule.analyze(oFile)
         self.assertEqual(oRule.violations, dExpected)
 

--- a/vsg/tests/vhdlFile/test_vhdlFile_comment_assignments.py
+++ b/vsg/tests/vhdlFile/test_vhdlFile_comment_assignments.py
@@ -13,7 +13,7 @@ class testVhdlFileCommentAssignments(unittest.TestCase):
 
 
     def test_isComment_assignment(self):
-        lExpected = [2,3,7,8,12,13,14,17,19,20,21,22,23,27,30,41,45,49,55,60,64,68,74,79]
+        lExpected = [2,3,7,8,12,13,14,17,19,20,21,22,23,27,30,41,45,49,55,67,71,75,81,86]
         # Generic actual list
         lActual = []
         for iIndex, oLine in enumerate(oFile.lines):
@@ -23,7 +23,7 @@ class testVhdlFileCommentAssignments(unittest.TestCase):
         self.assertEqual(lActual, lExpected)
 
     def test_hasComment_assignment(self):
-        lExpected = [2,3,7,8,12,13,14,15,16,17,18,19,20,21,22,23,25,26,27,28,29,30,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,79]
+        lExpected = [2,3,7,8,12,13,14,15,16,17,18,19,20,21,22,23,25,26,27,28,29,30,39,40,41,43,44,45,46,47,48,49,50,51,52,53,54,55,57,58,60,61,62,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,86,]
         # Generic actual list
         lActual = []
         for iIndex, oLine in enumerate(oFile.lines):
@@ -33,7 +33,7 @@ class testVhdlFileCommentAssignments(unittest.TestCase):
         self.assertEqual(lActual, lExpected)
 
     def test_hasInlineComment_assignment(self):
-        lExpected = [15,16,18,25,26,28,29,39,40,42,43,44,46,47,48,50,51,52,53,54,58,59,61,62,63,65,66,67,69,70,71,72,73]
+        lExpected = [15,16,18,25,26,28,29,39,40,43,44,46,47,48,50,51,52,53,54,57,58,60,61,62,65,66,68,69,70,72,73,74,76,77,78,79,80]
         # Generic actual list
         lActual = []
         for iIndex, oLine in enumerate(oFile.lines):
@@ -43,7 +43,7 @@ class testVhdlFileCommentAssignments(unittest.TestCase):
         self.assertEqual(lActual, lExpected)
 
     def test_commentColumn_assignment(self):
-        lExpected = [0,1,0,2,0,2,4,18,18,18,19,18,4,5,4,3,23,22,23,23,23,19,35,38,4,37,36,37,5,37,37,37,35,37,38,37,37,38,4,32,33,4,32,31,32,6,32,32,32,30,32,33,32,32,33,4,0]
+        lExpected = [0,1,0,2,0,2,4,18,18,18,19,18,4,5,4,3,23,22,23,23,23,19,35,38,4,36,37,5,37,37,37,35,37,38,37,37,38,4,52,43,49,50,49,32,33,4,32,31,32,6,32,32,32,30,32,33,32,32,33,4,0]
         # Generic actual list
         lActual = []
         for oLine in oFile.lines:

--- a/vsg/utils.py
+++ b/vsg/utils.py
@@ -104,7 +104,7 @@ def change_word(oLine, sWord, sNewWord, iMax=1):
       sNewWord: (string)
     '''
     sLine = oLine.line
-    tLine = re.subn(r'\b' + sWord + r'\b', sNewWord, sLine, iMax, flags=re.IGNORECASE)
+    tLine = re.subn(r'\b' + re.escape(sWord) + r'\b', sNewWord, sLine, iMax, flags=re.IGNORECASE)
     sLine = tLine[0]
     if tLine[1] == 0:
         tLine = re.subn(' ' + sWord + ';', sNewWord + ';', sLine, iMax, flags=re.IGNORECASE)
@@ -317,7 +317,7 @@ def search_for_and_remove_keyword(oFile, iLineNumber, sKeyword):
 
 # Regex to find comments that ignores contents of double quoted strings,
 # for example, "--" : a two bit std_logic_vector literal of don't cares.
-has_comment_re = re.compile(r'.*?(?:".*?(?=").*?)*(?P<comment>--.*$)', re.IGNORECASE)
+has_comment_re = re.compile(r'^(?:".*"|[^"\n])*?(?P<comment>--.*$)', re.IGNORECASE)
 
 def remove_comment(sString):
     '''
@@ -333,7 +333,7 @@ def remove_comment(sString):
     if match is None:
         return sString
 
-    return sString[:match.start("comment")]
+    return sString[:match.start("comment")].rstrip()
 
 
 def remove_blank_line(oFile, iLineNumber):

--- a/vsg/utils.py
+++ b/vsg/utils.py
@@ -315,6 +315,9 @@ def search_for_and_remove_keyword(oFile, iLineNumber, sKeyword):
         if not oLine.isBlank:
             break
 
+# Regex to find comments that ignores contents of double quoted strings,
+# for example, "--" : a two bit std_logic_vector literal of don't cares.
+has_comment_re = re.compile(r'.*?(?:".*?(?=").*?)*(?P<comment>--.*$)', re.IGNORECASE)
 
 def remove_comment(sString):
     '''
@@ -326,10 +329,11 @@ def remove_comment(sString):
 
     Returns: (string)
     '''
-    if '--' in sString:
-        return sString[0:sString.find('--') + len('--')]
-    else:
+    match = has_comment_re.match(sString)
+    if match is None:
         return sString
+
+    return sString[:match.start("comment")]
 
 
 def remove_blank_line(oFile, iLineNumber):
@@ -470,7 +474,7 @@ def end_of_line_index(oLine):
     Returns: (integer)
     '''
 
-    sLine = remove_comment(oLine.line).replace('--', '')
+    sLine = remove_comment(oLine.line)
     for iIndex, sChar in enumerate(sLine[::-1]):
         if not sChar == ' ':
             return len(sLine) - iIndex
@@ -522,7 +526,7 @@ def extract_non_keywords(sString):
     Returns: (list of strings)
     '''
     lReturn = []
-    sMyString = remove_comment(sString).replace('--', ' ')
+    sMyString = remove_comment(sString)
     sMyString = sMyString.replace(':', ' ')
     sMyString = sMyString.replace(',', ' ')
     sMyString = sMyString.replace('\'', ' ')

--- a/vsg/vhdlFile/classify/comment.py
+++ b/vsg/vhdlFile/classify/comment.py
@@ -1,13 +1,20 @@
 import re
 
+# Regex to find comments that ignores contents of double quoted strings,
+# for example, "--" : a two bit std_logic_vector literal of don't cares.
+has_comment_re = re.compile(r'.*?(?:".*?(?=").*?)*(?P<comment>--.*$)', re.IGNORECASE)
+
+comment_only_re = re.compile(r'^\s*--')
 
 def comment(dVars, oLine):
     # Check for comment lines
-    if '--' in oLine.line:
-        oLine.hasComment = True
-        oLine.commentColumn = oLine.line.find('--')
-        if re.match('^\s*--', oLine.line):
-            oLine.isComment = True
-            oLine.indentLevel = dVars['iCurrentIndentLevel']
-        else:
-            oLine.hasInlineComment = True
+    match = has_comment_re.match(oLine.line)
+    if match is None:
+        return
+    oLine.hasComment = True
+    oLine.commentColumn = match.start("comment")
+    if comment_only_re.match(oLine.line) is not None:
+        oLine.isComment = True
+        oLine.indentLevel = dVars['iCurrentIndentLevel']
+    else:
+        oLine.hasInlineComment = True

--- a/vsg/vhdlFile/classify/comment.py
+++ b/vsg/vhdlFile/classify/comment.py
@@ -2,7 +2,7 @@ import re
 
 # Regex to find comments that ignores contents of double quoted strings,
 # for example, "--" : a two bit std_logic_vector literal of don't cares.
-has_comment_re = re.compile(r'.*?(?:".*?(?=").*?)*(?P<comment>--.*$)', re.IGNORECASE)
+has_comment_re = re.compile(r'^(?:".*"|[^"\n])*?(?P<comment>--.*)', re.IGNORECASE)
 
 comment_only_re = re.compile(r'^\s*--')
 

--- a/vsg/vhdlFile/classify/type_definition.py
+++ b/vsg/vhdlFile/classify/type_definition.py
@@ -35,7 +35,7 @@ def type_definition(dVars, oLine):
         oLine.insideTypeEnumerated = True
         oLine.indentLevel = dVars['iCurrentIndentLevel']
         dVars['iCurrentIndentLevel'] += 1
-    elif re.match('^\s*type', oLine.line, re.IGNORECASE):
+    elif re.match('^\s*type\s', oLine.line, re.IGNORECASE):
         if not oLine.insideEntity and not oLine.insideComponent and \
            not oLine.insideInstantiation and not oLine.insideConcurrent and \
            not (oLine.insideProcess and not oLine.isProcessDeclarative):


### PR DESCRIPTION
**Description**
The code assumes that anywhere there is a double hyphen (--) that this indicates a comment. This is not entirely true as '-' is also used by std_logic_1164 as the symbol for don't care. Two hyphens within double quotes may indicate a two bit std_logic_vector ("--") or x"0--0" a 16-bit std_logic_vector with 8 bits of don't care.
Double hyphens might also occur in strings (also within double quotes), e.g. "This -- is not a comment."

These code fixes distinguish between double hyphens within a quoted string and comment markers (outside quotes).
The proposed change to tokenisation may make this obsolete.

Couple of other minor fixes that my VHDL code base threw up: dbcebf0, ab97fcb, 3856fc8.

I've also included a few other non-functional changes that make the code more pythonic: 41c3b72, 
3856fc8 
