### PR TITLE
fixed AttributeError

### DIFF
--- a/vsg/rules/signal/rule_015.py
+++ b/vsg/rules/signal/rule_015.py
@@ -25,7 +25,7 @@ class rule_015(rule.rule):
             self.sFullLine = ''
             self.iFailureLine = iLineNumber
         if oLine.insideSignal:
-            self.sFullLine += oLine.line
+            self.sFullLine += oLine.lineLower
         if oLine.isEndSignal:
             match = re.match(r'.*?signal\s+(?P<signals>[^:\n]*):', self.sFullLine)
             if match:

--- a/vsg/rules/signal/rule_015.py
+++ b/vsg/rules/signal/rule_015.py
@@ -28,12 +28,13 @@ class rule_015(rule.rule):
             self.sFullLine += oLine.line
         if oLine.isEndSignal:
             match = re.match(r'.*?signal\s+(?P<signals>[^:\n]*):', self.sFullLine)
-            sSignalList = match.group("signals")
-            if sSignalList.count(',') > self.consecutive - 1:
-                dViolation = utils.create_violation_dict(self.iFailureLine)
-                dViolation['endLine'] = iLineNumber
-                dViolation['line'] = self.sFullLine
-                self.add_violation(dViolation)
+            if match:
+                sSignalList = match.group("signals")
+                if sSignalList.count(',') > self.consecutive - 1:
+                    dViolation = utils.create_violation_dict(self.iFailureLine)
+                    dViolation['endLine'] = iLineNumber
+                    dViolation['line'] = self.sFullLine
+                    self.add_violation(dViolation)
 
     def _fix_violations(self, oFile):
         for dViolation in self.violations[::-1]:


### PR DESCRIPTION
AttributeError: 'NoneType' object has no attribute 'group' if a file has no signal

**Description**
vsg crashes with "AttributeError: 'NoneType' object has no attribute 'group'" because match returns NoneType if expression is not matched