### PR TITLE
fix invalid yaml in docs

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -33,7 +33,7 @@ This is the basic form of a configuration file in YAML:
 .. code-block:: yaml
 
    ---
-   file_list:[
+   file_list:
      - fifo.vhd
      - source/spi.vhd:
          rule:


### PR DESCRIPTION
**Description**
The current yaml example in the docs is invalid, this should fix it.
