### PR TITLE
An attempt at issue #353

### DIFF
--- a/vsg/__main__.py
+++ b/vsg/__main__.py
@@ -84,35 +84,11 @@ def read_predefined_style(sStyleName):
     return dReturn
 
 
-def open_fix_file(sFileName):
-    '''Attempts to open a configuration file and read it's contents.'''
-    try:
-        with open(sFileName) as yaml_file:
-            temp = yaml.full_load(yaml_file)
-            return temp
-    except IOError:
-        print('ERROR: Could not find JSON fix file: ' + sFileName)
-        write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
-        sys.exit(1)
-    except yaml.scanner.ScannerError as e:
-        print('ERROR: Invalid JSON fix file: ' + sFileName)
-        print(e)
-        write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
-        exit()
-    except yaml.parser.ParserError as e:
-        print('ERROR: Invalid JSON fix file: ' + sFileName)
-        print(e)
-        write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
-        exit()
-    except TypeError:
-        return None
-
-
 def open_configuration_file(sFileName, sJUnitFileName=None):
     '''Attempts to open a configuration file and read it's contents.'''
     try:
         with open(sFileName) as yaml_file:
-            tempConfiguration = yaml.full_load(yaml_file)
+            return yaml.full_load(yaml_file)
     except IOError:
         print('ERROR: Could not find configuration file: ' + sFileName)
         write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
@@ -127,7 +103,8 @@ def open_configuration_file(sFileName, sJUnitFileName=None):
         print(e)
         write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
         exit()
-    return tempConfiguration
+    except TypeError:
+        return None
 
 
 def validate_file_exists(sFilename, sConfigName):
@@ -394,7 +371,7 @@ def main():
 
     dIndent = read_indent_configuration(configuration)
 
-    fix_only = open_fix_file(commandLineArguments.fix_only)
+    fix_only = open_configuration_file(commandLineArguments.fix_only)
 
     update_command_line_arguments(commandLineArguments, configuration)
 

--- a/vsg/__main__.py
+++ b/vsg/__main__.py
@@ -146,10 +146,7 @@ def read_configuration_files(dStyle, commandLineArguments):
     dConfiguration = dStyle
     if commandLineArguments.configuration:
         for sConfigFilename in commandLineArguments.configuration:
-            try:
-                tempConfiguration = open_configuration_file(sConfigFilename, commandLineArguments.junit)
-            except AttributeError:
-                tempConfiguration = open_configuration_file(sConfigFilename)
+            tempConfiguration = open_configuration_file(sConfigFilename, commandLineArguments.junit)
 
             for sKey in tempConfiguration.keys():
                 if sKey == 'file_list':

--- a/vsg/report/vsg_stdout.py
+++ b/vsg/report/vsg_stdout.py
@@ -24,7 +24,7 @@ def print_header(sFilename):
     Returns: Nothing
     '''
     print('=' * iLineLength)
-    print('File:  ' + sFilename)
+    print('File:  ' + str(sFilename))
     print('=' * iLineLength)
 
 

--- a/vsg/settings.py
+++ b/vsg/settings.py
@@ -1,0 +1,110 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2013 Timothy Edmund Crosley
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import os
+import sys
+import yaml
+import logging
+
+from functools import lru_cache
+from pathlib import Path, PurePath
+from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Pattern, Set, Tuple
+
+from . import junit
+# The number of parent directories to for a config file within
+MAX_CONFIG_SEARCH_DEPTH: int = 25
+STOP_CONFIG_SEARCH_ON_DIRS: Tuple[str, ...] = (".git", ".hg")
+CONFIG_SOURCES: Tuple[str, ...] = (
+    "vsg_conf.yaml",
+    "vsg_conf.yml",
+)
+
+
+@lru_cache()
+def open_configuration_file(sFileName, sJUnitFileName=None):
+    '''Attempts to open a configuration file and read it's contents.'''
+    try:
+        with open(sFileName) as yaml_file:
+            return yaml.full_load(yaml_file)
+    except IOError:
+        print('ERROR: Could not find configuration file: ' + sFileName)
+        write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
+        raise Exception
+    except yaml.scanner.ScannerError as e:
+        print('ERROR: Invalid configuration file: ' + sFileName)
+        print(e)
+        write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
+        raise Exception
+    except yaml.parser.ParserError as e:
+        print('ERROR: Invalid configuration file: ' + sFileName)
+        print(e)
+        write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
+        raise Exception
+    except TypeError:
+        return None
+
+
+def write_invalid_configuration_junit_file(sFileName, sJUnitFileName):
+    if sJUnitFileName:
+        oJunitFile = junit.xmlfile(sJUnitFileName)
+        oJunitTestsuite = junit.testsuite('vhdl-style-guide', str(0))
+        oJunitTestcase = junit.testcase(sFileName, str(0), 'failure')
+        oFailure = junit.failure('Failure')
+        oFailure.add_text('Invalid JSON format.  Review configuration for errors.')
+        oJunitTestcase.add_failure(oFailure)
+        oJunitTestsuite.add_testcase(oJunitTestcase)
+        oJunitFile.add_testsuite(oJunitTestsuite)
+        write_junit_xml_file(oJunitFile)
+
+
+def write_junit_xml_file(oJunitFile):
+    with open(oJunitFile.filename, 'w') as oFile:
+        for sLine in oJunitFile.build_junit():
+            oFile.write(sLine + '\n')
+
+
+@lru_cache()
+def find_config(path: PurePath) -> str:
+    current_directory = path.resolve()
+    tries = 0
+    while current_directory and tries < MAX_CONFIG_SEARCH_DEPTH:
+        for config_file_name in CONFIG_SOURCES:
+            potential_config_file = current_directory / config_file_name
+            if potential_config_file.is_file():
+                config_data: Dict[str, Any]
+                try:
+                    return open_configuration_file(potential_config_file)
+                except Exception:
+                    print(f"WARN: Failed to pull configuration information from {potential_config_file}")
+
+        for stop_dir in STOP_CONFIG_SEARCH_ON_DIRS:
+            if (current_directory / stop_dir).exists():
+                return None
+
+        new_directory = current_directory.parent
+        if new_directory == current_directory:
+            break
+
+        current_directory = new_directory
+        tries += 1
+
+    return None

--- a/vsg/settings.py
+++ b/vsg/settings.py
@@ -32,7 +32,7 @@ from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Pat
 from . import junit
 # The number of parent directories to for a config file within
 MAX_CONFIG_SEARCH_DEPTH: int = 25
-STOP_CONFIG_SEARCH_ON_DIRS: Tuple[str, ...] = (".git", ".hg")
+STOP_CONFIG_SEARCH_ON_DIRS: Tuple[str, ...] = (".git", ".hg", ".svn")
 CONFIG_SOURCES: Tuple[str, ...] = (
     "vsg_conf.yaml",
     "vsg_conf.yml",


### PR DESCRIPTION
**Description**
An attempt at issue #353, it's some quick work with still some rough edges, but I wanted to put it already here to see if you would be interested in this attempt.

As I stated in issue #353 I think the current way vsg deals with configuration is not that convenient.

The way this pull requests deals with it:
When run without `--configuration` vsg will search for a configuration file for each file that is passed to `--filename` (if that's a folder it will recursively search in there). it searches for `vsg_conf.yaml` in the folder, and then in the parent folder, etc. After 25 levels or reaching a root git or hg folder it stops and applies the default configuration (searching in $XDG_CONFIG_HOME and/or another environment variable before adding default configuration can also be added). The first file found is used and nothing is merged. 

When run with `--configuration` it does no discovery of configuration files.

Also, when run with `--filename`, the filenames in `file_list` from the configuration are ignored, but their specific rules still apply if the file passed to `--filename` is in there. (At least, that's what is supposed to happen, I still have to debug somewhat.)

Another thing that could be easily added is that `--configuration` also accepts directories. and finds all configuration files in that directory.

I think that covers most use cases mentioned in #367, with not that much added complexity:
* `vsg --configuration vsg_conf.yml --filename file.vhd` will work as it does now (except for also excluding the file_list)
* `vsg --configuration .` will find all configuration files and only work on the files in`file_list`
* `vsg --filename .` will find all vhld files and their configuration file. That could be one per project or different ones per folder.