### PR TITLE
Merge similar functions

### DIFF
--- a/vsg/__main__.py
+++ b/vsg/__main__.py
@@ -62,7 +62,7 @@ def get_predefined_styles():
     for sStyle in lStyles:
         if sStyle.endswith('.yaml'):
             with open(os.path.join(sStylePath, sStyle)) as yaml_file:
-                tempConfiguration = yaml.full_load(yaml_file)
+                tempConfiguration = yaml.safe_load(yaml_file)
             lReturn.append(tempConfiguration['name'])
     return lReturn
 

--- a/vsg/__main__.py
+++ b/vsg/__main__.py
@@ -84,49 +84,20 @@ def read_predefined_style(sStyleName):
     return dReturn
 
 
-def open_fix_file(sFileName):
-    '''Attempts to open a configuration file and read it's contents.'''
-    try:
-        with open(sFileName) as yaml_file:
-            temp = yaml.full_load(yaml_file)
-            return temp
-    except IOError:
-        print('ERROR: Could not find JSON fix file: ' + sFileName)
-        write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
-        sys.exit(1)
-    except yaml.scanner.ScannerError as e:
-        print('ERROR: Invalid JSON fix file: ' + sFileName)
-        print(e)
-        write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
-        exit()
-    except yaml.parser.ParserError as e:
-        print('ERROR: Invalid JSON fix file: ' + sFileName)
-        print(e)
-        write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
-        exit()
-    except TypeError:
-        return None
-
-
 def open_configuration_file(sFileName, sJUnitFileName=None):
     '''Attempts to open a configuration file and read it's contents.'''
     try:
         with open(sFileName) as yaml_file:
             tempConfiguration = yaml.full_load(yaml_file)
-    except IOError:
-        print('ERROR: Could not find configuration file: ' + sFileName)
+    except OSError as e:
+        print(f'ERROR: encountered {e.__class__.__name__}, {e.args[1]} while opening configuration file: ' + sFileName)
         write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
         sys.exit(1)
-    except yaml.scanner.ScannerError as e:
+    except (yaml.parser.ParserError, yaml.scanner.ScannerError) as e:
         print('ERROR: Invalid configuration file: ' + sFileName)
         print(e)
         write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
-        exit()
-    except yaml.parser.ParserError as e:
-        print('ERROR: Invalid configuration file: ' + sFileName)
-        print(e)
-        write_invalid_configuration_junit_file(sFileName, sJUnitFileName)
-        exit()
+        sys.exit(1)
     return tempConfiguration
 
 
@@ -394,7 +365,10 @@ def main():
 
     dIndent = read_indent_configuration(configuration)
 
-    fix_only = open_fix_file(commandLineArguments.fix_only)
+    if commandLineArguments.fix_only:
+        fix_only = open_configuration_file(commandLineArguments.fix_only)
+    else:
+        fix_only = None
 
     update_command_line_arguments(commandLineArguments, configuration)
 

--- a/vsg/tests/vsg/test_vsg.py
+++ b/vsg/tests/vsg/test_vsg.py
@@ -1,3 +1,4 @@
+import pathlib
 import unittest
 from unittest import mock
 import subprocess
@@ -109,10 +110,15 @@ class testVsg(unittest.TestCase):
         lExpected.append('expected the node content, but found \',\'')
         lExpected.append('  in "vsg/tests/vsg/config_error.json", line 2, column 16')
         lExpected.append('')
+        try:
+            lActual = subprocess.check_output(['bin/vsg','--configuration','vsg/tests/vsg/config_error.json','--output_format','syntastic','-f','vsg/tests/vsg/entity1.vhd','--junit','vsg/tests/vsg/config_error.actual.xml'])
+        except subprocess.CalledProcessError as e:
+            lActual = str(e.output.decode('utf-8')).split('\n')
+            iExitStatus = e.returncode
 
-        lActual = subprocess.check_output(['bin/vsg','--configuration','vsg/tests/vsg/config_error.json','--output_format','syntastic','-f','vsg/tests/vsg/entity1.vhd','--junit','vsg/tests/vsg/config_error.actual.xml'])
-        lActual = str(lActual.decode('utf-8')).split('\n')
         self.assertEqual(lActual, lExpected)
+        self.assertEqual(iExitStatus,1)
+
         # Read in the expected JUnit XML file for comparison
         lExpected = []
         utils.read_file(os.path.join(os.path.dirname(__file__),'config_error.expected.xml'), lExpected)
@@ -284,19 +290,35 @@ class testVsg(unittest.TestCase):
         self.assertEqual(lExpected[0], lActual[0])
 
     def test_missing_configuration_file(self):
-        lExpected = []
-        lExpected.append('ERROR: Could not find configuration file: missing_configuration.yaml')
-        lExpected.append('')
+        sExpected = 'ERROR: encountered FileNotFoundError, No such file or directory while opening configuration file: missing_configuration.yaml\n'
 
         try:
-            subprocess.check_output(['bin/vsg','-c', 'missing_configuration.yaml'])
+            subprocess.check_output(['bin/vsg', '-c', 'missing_configuration.yaml'])
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode('utf-8')).split('\n')
+            sActual = str(e.output.decode('utf-8'))
             iExitStatus = e.returncode
 
-        self.assertEqual(iExitStatus,1)
+        self.assertEqual(iExitStatus, 1)
 
-        self.assertEqual(lActual, lExpected)
+        self.assertEqual(sActual, sExpected)
+
+    def test_no_permission_configuration_file(self):
+        sNoPermissionFile = 'no_permission.yml'
+        pathlib.Path(sNoPermissionFile).touch(mode=0o222, exist_ok=True)
+        sExpected = f'ERROR: encountered PermissionError, Permission denied while opening configuration file: {sNoPermissionFile}\n'
+
+        try:
+            subprocess.check_output(['bin/vsg', '-c', sNoPermissionFile])
+        except subprocess.CalledProcessError as e:
+            sActual = str(e.output.decode('utf-8'))
+            iExitStatus = e.returncode
+
+            self.assertEqual(iExitStatus, 1)
+
+            self.assertEqual(sActual, sExpected)
+        finally:
+            if os.path.isfile(sNoPermissionFile):
+                os.remove(sNoPermissionFile)
 
     def test_missing_files_in_configuration_file(self):
         lExpected = []


### PR DESCRIPTION
**Description**
Merge `open_fix_file` and `open_configuration_file` into one function.

Right now when a configuration file is not found vsg exits with exit code 1, when it's an invalid file it exits as well but with an exit code 0. Shouldn't that be 1 too? If so I'll edit that too and update the tests to reflect that.