### PR TITLE
Speedup report_violations

### DIFF
--- a/vsg/rule.py
+++ b/vsg/rule.py
@@ -78,6 +78,14 @@ class Rule():
 
         return lReturn
 
+    def get_violations(self):
+        lReturn = []
+
+        for violation in self.violations:
+            lReturn.append(self._build_violation_dict_from_violation_object(violation))
+
+        return lReturn
+
     def fix(self, oFile, dFixOnly=None):
         '''
         Applies fixes for any rule violations.

--- a/vsg/rule_list.py
+++ b/vsg/rule_list.py
@@ -240,13 +240,12 @@ class rule_list():
         dRunInfo['stopPhase'] = 7
         dRunInfo['violations'] = []
 
-        for iLineNumber in range(0, self.oVhdlFile.get_line_count() + 1):
-            for oRule in self.rules:
-                if oRule.has_violations():
-                    lViolations = oRule.get_violations_at_linenumber(iLineNumber)
+        for oRule in self.rules:
+            if oRule.has_violations():
+                lViolations = oRule.get_violations()
 #                    print(f'{oRule.name}_{oRule.identifier} | {iLineNumber} | {len(lViolations)}')
-                    dRunInfo['violations'].extend(lViolations)
-
+                dRunInfo['violations'].extend(lViolations)
+        dRunInfo['violations'] = sorted(dRunInfo['violations'], key=lambda x: int(x['lineNumber']))
         dRunInfo['stopPhase'] = self.lastPhaseRan
         dRunInfo['num_rules_checked'] = self.get_number_of_rules_ran()
         dRunInfo['total_violations'] = len(dRunInfo['violations'])


### PR DESCRIPTION
**Description**
Instead of getting violations on each line, get all violations per rule and sort later by line.

Speedups up to ~50% when running vsg on many files.

I suggest you try to confirm this by running on your own files, I don't have that much files to test on.
