### PR TITLE
Better fix for issue #550

### DIFF
--- a/vsg/__main__.py
+++ b/vsg/__main__.py
@@ -9,6 +9,7 @@ import yaml
 import functools
 import multiprocessing
 
+from . import apply_rules
 from . import cmd_line_args
 from . import config
 from . import utils
@@ -136,7 +137,7 @@ def main():
 
     dJson = {'files'}
 
-    f = functools.partial(apply_rules, commandLineArguments, oConfig)
+    f = functools.partial(apply_rules.apply_rules, commandLineArguments, oConfig)
     # It's easier to debug when not using multiprocessing.Pool()
     lReturn = []
     if commandLineArguments.jobs == 1:
@@ -178,81 +179,3 @@ def main():
 
 
     sys.exit(fExitStatus)
-
-
-def apply_rules(commandLineArguments, oConfig, tIndexFileName):
-    configuration = oConfig.dConfig
-
-    dIndent = oConfig.dIndent
-    fix_only = oConfig.dFixOnly
-    
-    iIndex, sFileName = tIndexFileName
-    dJsonEntry = {}
-    lFileContent, eError = vhdlFile.utils.read_vhdlfile(sFileName)
-    oVhdlFile = vhdlFile.vhdlFile(lFileContent, sFileName, eError)
-    oVhdlFile.set_indent_map(dIndent)
-    try:
-        oRules = rule_list.rule_list(oVhdlFile, oConfig.severity_list, commandLineArguments.local_rules)
-    except OSError as e:
-        sOutputStd = f'ERROR: encountered {e.__class__.__name__}, {e.args[1]} ' + commandLineArguments.local_rules + ' when trying to open local rules file.'
-        sOutputErr = None
-        return 1, None, dJsonEntry, sOutputStd, sOutputErr
-
-    configure_rules(oConfig, oRules, configuration, iIndex, sFileName)
-
-
-    if commandLineArguments.fix:
-        if commandLineArguments.backup:
-            create_backup_file(sFileName)
-        oRules.fix(commandLineArguments.fix_phase, commandLineArguments.skip_phase, fix_only)
-        write_vhdl_file(oVhdlFile)
-
-    oRules.clear_violations()
-    oRules.check_rules(bAllPhases=commandLineArguments.all_phases, lSkipPhase=commandLineArguments.skip_phase)
-    sOutputStd, sOutputErr = oRules.report_violations(commandLineArguments.output_format)
-    fExitStatus = oRules.violations
-
-    if commandLineArguments.junit:
-        testCase = oRules.extract_junit_testcase(sFileName)
-    else:
-        testCase = None
-
-    if commandLineArguments.json:
-        dJsonEntry['file_path'] = sFileName
-        dJsonEntry['violations'] = oRules.extract_violation_dictionary()['violations']
-
-    return fExitStatus, testCase, dJsonEntry, sOutputStd, sOutputErr
-
-
-def configure_rules(oConfig, oRules, configuration, iIndex, sFileName):
-
-    oRules.configure(oConfig)
-    if is_filename_in_file_list(configuration, sFileName):
-        iMyIndex = get_index_of_filename_in_file_list(configuration, sFileName)
-        oRuleConfig = config.config()
-        if does_file_have_rule_configuration(configuration, iMyIndex, sFileName):
-            oRuleConfig.dConfig = configuration['file_list'][iMyIndex][sFileName]
-            oRules.configure(oRuleConfig)
-        
-
-def is_filename_in_file_list(configuration, sFileName):
-    try:
-        lFileNames = utils.extract_file_names_from_file_list(configuration['file_list'])
-        if sFileName in lFileNames:
-            return True
-        return False
-    except KeyError:
-        return False
-
-
-def get_index_of_filename_in_file_list(configuration, sFileName):
-    lFileNames = utils.extract_file_names_from_file_list(configuration['file_list'])
-    return lFileNames.index(sFileName)
-
-
-def does_file_have_rule_configuration(configuration, iMyIndex, sFileName):
-    try:
-       sTemp = configuration['file_list'][iMyIndex][sFileName]
-       return True
-    except:
-       return False

--- a/vsg/apply_rules.py
+++ b/vsg/apply_rules.py
@@ -1,0 +1,96 @@
+from . import config
+from . import rule_list
+from . import utils
+from . import vhdlFile
+
+
+def configure_rules(oConfig, oRules, configuration, iIndex, sFileName):
+
+    oRules.configure(oConfig)
+    if is_filename_in_file_list(configuration, sFileName):
+        iMyIndex = get_index_of_filename_in_file_list(configuration, sFileName)
+        oRuleConfig = config.config()
+        if does_file_have_rule_configuration(configuration, iMyIndex, sFileName):
+            oRuleConfig.dConfig = configuration["file_list"][iMyIndex][sFileName]
+            oRules.configure(oRuleConfig)
+
+
+def is_filename_in_file_list(configuration, sFileName):
+    try:
+        lFileNames = utils.extract_file_names_from_file_list(configuration["file_list"])
+        if sFileName in lFileNames:
+            return True
+        return False
+    except KeyError:
+        return False
+
+
+def get_index_of_filename_in_file_list(configuration, sFileName):
+    lFileNames = utils.extract_file_names_from_file_list(configuration["file_list"])
+    return lFileNames.index(sFileName)
+
+
+def does_file_have_rule_configuration(configuration, iMyIndex, sFileName):
+    try:
+        sTemp = configuration["file_list"][iMyIndex][sFileName]
+        return True
+    except:
+        return False
+
+
+# This function is in a separate module from __main__ as a workaround for https://bugs.python.org/issue25053
+# see also https://stackoverflow.com/questions/41385708/multiprocessing-example-giving-attributeerror/42383397#42383397
+def apply_rules(commandLineArguments, oConfig, tIndexFileName):
+    configuration = oConfig.dConfig
+
+    dIndent = oConfig.dIndent
+    fix_only = oConfig.dFixOnly
+
+    iIndex, sFileName = tIndexFileName
+    dJsonEntry = {}
+    lFileContent, eError = vhdlFile.utils.read_vhdlfile(sFileName)
+    oVhdlFile = vhdlFile.vhdlFile(lFileContent, sFileName, eError)
+    oVhdlFile.set_indent_map(dIndent)
+    try:
+        oRules = rule_list.rule_list(
+            oVhdlFile, oConfig.severity_list, commandLineArguments.local_rules
+        )
+    except OSError as e:
+        sOutputStd = (
+            f"ERROR: encountered {e.__class__.__name__}, {e.args[1]} "
+            + commandLineArguments.local_rules
+            + " when trying to open local rules file."
+        )
+        sOutputErr = None
+        return 1, None, dJsonEntry, sOutputStd, sOutputErr
+
+    configure_rules(oConfig, oRules, configuration, iIndex, sFileName)
+
+    if commandLineArguments.fix:
+        if commandLineArguments.backup:
+            create_backup_file(sFileName)
+        oRules.fix(
+            commandLineArguments.fix_phase, commandLineArguments.skip_phase, fix_only
+        )
+        write_vhdl_file(oVhdlFile)
+
+    oRules.clear_violations()
+    oRules.check_rules(
+        bAllPhases=commandLineArguments.all_phases,
+        lSkipPhase=commandLineArguments.skip_phase,
+    )
+    sOutputStd, sOutputErr = oRules.report_violations(
+        commandLineArguments.output_format
+    )
+    fExitStatus = oRules.violations
+
+    if commandLineArguments.junit:
+        testCase = oRules.extract_junit_testcase(sFileName)
+    else:
+        testCase = None
+
+    if commandLineArguments.json:
+        dJsonEntry["file_path"] = sFileName
+        dJsonEntry["violations"] = oRules.extract_violation_dictionary()["violations"]
+
+    return fExitStatus, testCase, dJsonEntry, sOutputStd, sOutputErr

--- a/vsg/cmd_line_args.py
+++ b/vsg/cmd_line_args.py
@@ -50,8 +50,7 @@ def parse_command_line_arguments():
         "-p",
         "--jobs",
         action="store",
-        default=1,
-#        default=os.cpu_count(),
+        default=os.cpu_count(),
         type=check_strict_positive,
         help="number of parallel jobs to use, default is the number of cpu cores",
     )


### PR DESCRIPTION
**Description**
As stated in issue #550, the current fix is more a workaround (disabling multiprocessing altogether by default) than a fix (fixing multiprocessing on Windows). This is a cleaner fix for the issue. By placing the `apply_rules` function in a separate file we can work around the bug/design flaw in Python's multiprocessing module.