### PR TITLE
Updates for issue #619

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -82,6 +82,7 @@ The command line tool can be invoked with:
 | --backup                      | Creates a copy of the input file before         |
 |                               | applying any fixes.  This can be used to        |
 |                               | compare the fixed file against the original.    |
+|                               | NOTE:  This is only valid when using --fix.     |
 +-------------------------------+-------------------------------------------------+
 | --output_configuration        | Writes a JSON configuration file of the current |
 |                               | run.  It includes a file_list, local_rules (if  |

--- a/vsg/__main__.py
+++ b/vsg/__main__.py
@@ -3,7 +3,6 @@
 import sys
 import os
 import json
-import shutil
 import glob
 import yaml
 import functools
@@ -19,11 +18,6 @@ from . import rule_list
 from . import severity
 from . import version
 from . import vhdlFile
-
-
-def create_backup_file(sFileName):
-    '''Copies existing file and adds .bak to the end.'''
-    shutil.copy2(sFileName, sFileName + '.bak')
 
 
 def generate_output_configuration(commandLineArguments, oConfig):

--- a/vsg/apply_rules.py
+++ b/vsg/apply_rules.py
@@ -1,7 +1,15 @@
+
+import shutil
+
 from . import config
 from . import rule_list
 from . import utils
 from . import vhdlFile
+
+
+def create_backup_file(sFileName):
+    '''Copies existing file and adds .bak to the end.'''
+    shutil.copy2(sFileName, sFileName + '.bak')
 
 
 def configure_rules(oConfig, oRules, configuration, iIndex, sFileName):

--- a/vsg/cmd_line_args.py
+++ b/vsg/cmd_line_args.py
@@ -58,6 +58,8 @@ def parse_command_line_arguments():
 
     args_ = parser.parse_args()
 
+    validate_backup_argument(args_)
+
     if sys.platform == "win32":
         # Work around https://bugs.python.org/issue26903
         args_.jobs = min(args_.jobs, 60)
@@ -87,4 +89,11 @@ def get_predefined_styles():
             lReturn.append(tempConfiguration['name'])
     return lReturn
 
+def validate_backup_argument(args_):
+    '''
+    The function validates the backup option is only present when the fix option is also present.
+    '''
+    if args_.backup and not args_.fix:
+        print('ERROR:  --backup argument requires --fix argument')
+        sys.exit(1)
 

--- a/vsg/tests/vsg/test_main.py
+++ b/vsg/tests/vsg/test_main.py
@@ -1,8 +1,10 @@
+import filecmp
 import pathlib
 import unittest
 from unittest import mock
-import subprocess
 import os
+import subprocess
+import shutil
 import sys
 
 import contextlib
@@ -368,3 +370,58 @@ class testVsg(unittest.TestCase):
             pass
 
         mock_stdout.write.assert_has_calls(lExpected)
+
+    @mock.patch('sys.stdout')
+    def test_backup_file(self, mock_stdout):
+
+        if os.path.isfile('vsg/tests/vsg/deleteme.vhd'):
+            os.remove('vsg/tests/vsg/deleteme.vhd')
+
+        if os.path.isfile('vsg/tests/vsg/deleteme.vhd.bak'):
+            os.remove('vsg/tests/vsg/deleteme.vhd.bak')
+
+        shutil.copyfile('vsg/tests/vsg/entity1.vhd', 'vsg/tests/vsg/deleteme.vhd')
+
+        lExpected = []
+
+        sys.argv = ['vsg']
+        sys.argv.extend(['--output_format', 'syntastic'])
+        sys.argv.extend(['-f', 'vsg/tests/vsg/deleteme.vhd'])
+        sys.argv.extend(['--fix'])
+        sys.argv.extend(['--backup'])
+
+        try:
+            __main__.main()
+        except SystemExit:
+            pass
+
+        self.assertTrue(os.path.isfile('vsg/tests/vsg/deleteme.vhd.bak'))
+
+        self.assertTrue(filecmp.cmp('vsg/tests/vsg/entity1.vhd', 'vsg/tests/vsg/deleteme.vhd.bak'))
+
+        mock_stdout.write.assert_has_calls(lExpected)
+
+        if os.path.isfile('vsg/tests/vsg/deleteme.vhd'):
+            os.remove('vsg/tests/vsg/deleteme.vhd')
+
+        if os.path.isfile('vsg/tests/vsg/deleteme.vhd.bak'):
+            os.remove('vsg/tests/vsg/deleteme.vhd.bak')
+
+    @mock.patch('sys.stdout')
+    def test_backup_file_without_fix(self, mock_stdout):
+
+        lExpected = []
+        lExpected.append(mock.call('ERROR:  --backup argument requires --fix argument'))
+        lExpected.append(mock.call('\n'))
+
+        sys.argv = ['vsg']
+        sys.argv.extend(['--output_format', 'syntastic'])
+        sys.argv.extend(['-f', 'vsg/tests/vsg/entity1.vhd'])
+        sys.argv.extend(['--backup'])
+
+        with self.assertRaises(SystemExit) as cm:
+            __main__.main()
+
+        mock_stdout.write.assert_has_calls(lExpected)
+        self.assertEqual(cm.exception.code, 1)
+        self.assertFalse(os.path.isfile('vsg/tests/vsg/entity1.vhd.bak'))


### PR DESCRIPTION
Adding validation for --backup command line argument.

  1)  Updated documentation to say --backup is only valid with --fix
  2)  Added tests
      a)  Testing --backup works with --fix
      b)  Testing --backup without --fix returns an error
  3)  Updated checking of --backup after parsing command line arguments

