### PR TITLE
Ignored Pycharm and VSCode internal files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ _build
 
 # This version file should never be committed
 vsg/version_info.py
+
+# IDE files
+.idea/
+.vscode/


### PR DESCRIPTION
**Description**
Pycharm and VSCode generate internal files when this project is opened in any of those softwares.
In order to have a git status cleaner and help to reduce the amount of useless files, it is a good practice to ignore these two folders in any python project.
More ignore rules could be added in the future in case of other users use other IDEs.
