### PR TITLE
Several fixes in port and port_map rules documentation.

### DIFF
--- a/docs/port_map_rules.rst
+++ b/docs/port_map_rules.rst
@@ -49,10 +49,10 @@ Refer to the section `Configuring Uppercase and Lowercase Rules <configuring.htm
 .. code-block:: vhdl
 
      port map (
-       WR_EN              => wr_en,
-       RD_EN              => rd_en,
-       OVERFLOW           => overflow,
-       UNDERFLOW(c_index) => underflow
+       wr_en              => wr_en,
+       rd_en              => rd_en,
+       overflow           => overflow,
+       underflow(c_index) => underflow
      );
 
 port_map_003
@@ -60,7 +60,7 @@ port_map_003
 
 |phase_1| |error|
 
-This rule checks the ( is on the same line as the **port map** keywords.
+This rule checks the "(" character is on the same line as the **port map** keywords.
 
 **Violation**
 
@@ -90,7 +90,7 @@ port_map_004
 
 |phase_1| |error|
 
-This rule checks the closing ) for the port map is on it's own line.
+This rule checks the closing ")" character for the port map is on it's own line.
 
 **Violation**
 

--- a/docs/port_rules.rst
+++ b/docs/port_rules.rst
@@ -219,7 +219,7 @@ port_010
 
 |phase_6| |error|
 
-This rule checks port names are uppercase.
+This rule checks the port names have proper case.
 
 Refer to the section `Configuring Uppercase and Lowercase Rules <configuring.html#configuring-uppercase-and-lowercase-rules>`_ for information on changing the default case.
 
@@ -239,10 +239,10 @@ Refer to the section `Configuring Uppercase and Lowercase Rules <configuring.htm
 .. code-block:: vhdl
 
    port (
-     WR_EN     : in    std_logic;
-     RD_EN     : in    std_logic;
-     OVERFLOW  : out   std_logic;
-     UNDERFLOW : out   std_logic
+     wr_en     : in    std_logic;
+     rd_en     : in    std_logic;
+     overflow  : out   std_logic;
+     underflow : out   std_logic
    );
 
 port_011


### PR DESCRIPTION
**Description**
According to the documentation in https://vhdl-style-guide.readthedocs.io/en/latest/configuring.html#configuring-uppercase-and-lowercase-rules, the default case format is "lower". However, several rules in the documentation show examples where the default value is "upper". Or they even say that the rule changes the case format to uppercase (which is not true unless you modify the default value in the configuration file).
So I have fixed the examples to be consistent with the default values of the rules.

**Screenshots**
Error 1:
![image](https://user-images.githubusercontent.com/55917369/136796284-0b4ac88d-9bfc-43f8-9c63-cc3664693d95.png)
Error 2:
![image](https://user-images.githubusercontent.com/55917369/136796660-56e3e000-1e80-4f71-b76a-7449bc523987.png)

