### PR TITLE
Updates for issue #632

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -105,6 +105,7 @@ The command line tool can be invoked with:
 +-------------------------------+-------------------------------------------------+
 | --all-phases                  | Executes all phases without stopping if a       |
 |                               | violation is found.                             |
+|                               | NOTE: This is not valid with the --fix option.  |
 +-------------------------------+-------------------------------------------------+
 | --fix_only                    | Restrict which rules are fixed based on JSON    |
 |                               | file.                                           |

--- a/vsg/cmd_line_args.py
+++ b/vsg/cmd_line_args.py
@@ -59,6 +59,7 @@ def parse_command_line_arguments():
     args_ = parser.parse_args()
 
     validate_backup_argument(args_)
+    validate_ap_argument(args_)
 
     if sys.platform == "win32":
         # Work around https://bugs.python.org/issue26903
@@ -89,6 +90,7 @@ def get_predefined_styles():
             lReturn.append(tempConfiguration['name'])
     return lReturn
 
+
 def validate_backup_argument(args_):
     '''
     The function validates the backup option is only present when the fix option is also present.
@@ -97,3 +99,11 @@ def validate_backup_argument(args_):
         print('ERROR:  --backup argument requires --fix argument')
         sys.exit(1)
 
+
+def validate_ap_argument(args_):
+    '''
+    The function validates the ap option is not present when the fix option is also present.
+    '''
+    if args_.all_phases and args_.fix:
+        print('ERROR:  -ap argument is invalid with the --fix argument')
+        sys.exit(1)

--- a/vsg/tests/vsg/test_main.py
+++ b/vsg/tests/vsg/test_main.py
@@ -451,3 +451,22 @@ class testMain(unittest.TestCase):
         mock_stdout.write.assert_has_calls(lExpected)
         self.assertEqual(cm.exception.code, 1)
         self.assertFalse(os.path.isfile('vsg/tests/vsg/entity1.vhd.bak'))
+
+    @mock.patch('sys.stdout')
+    def test_ap_with_fix(self, mock_stdout):
+
+        lExpected = []
+        lExpected.append(mock.call('ERROR:  -ap argument is invalid with the --fix argument'))
+        lExpected.append(mock.call('\n'))
+
+        sys.argv = ['vsg']
+        sys.argv.extend(['--output_format', 'syntastic'])
+        sys.argv.extend(['-f', 'vsg/tests/vsg/entity1.vhd'])
+        sys.argv.extend(['-ap'])
+        sys.argv.extend(['--fix'])
+
+        with self.assertRaises(SystemExit) as cm:
+            __main__.main()
+
+        mock_stdout.write.assert_has_calls(lExpected)
+        self.assertEqual(cm.exception.code, 1)


### PR DESCRIPTION
Fixing invalid command line combination -ap with --fix.

  1)  Updated documentation
  2)  Added test
  3)  Using -ap along with --fix will generate an error

