### PR TITLE
Updates for issue #646

### DIFF
--- a/vsg/rules/procedure/rule_410.py
+++ b/vsg/rules/procedure/rule_410.py
@@ -7,6 +7,7 @@ lAlign = []
 lAlign.append(token.interface_signal_declaration.colon)
 lAlign.append(token.interface_constant_declaration.colon)
 lAlign.append(token.interface_variable_declaration.colon)
+lAlign.append(token.interface_unknown_declaration.colon)
 
 
 class rule_410(align_tokens_in_region_between_tokens):

--- a/vsg/rules/procedure/rule_411.py
+++ b/vsg/rules/procedure/rule_411.py
@@ -7,6 +7,7 @@ lAlign = []
 lAlign.append(token.interface_signal_declaration.assignment)
 lAlign.append(token.interface_constant_declaration.assignment)
 lAlign.append(token.interface_variable_declaration.assignment)
+lAlign.append(token.interface_unknown_declaration.assignment)
 
 
 class rule_411(align_tokens_in_region_between_tokens):

--- a/vsg/tests/procedure/rule_410_test_input.fixed.vhd
+++ b/vsg/tests/procedure/rule_410_test_input.fixed.vhd
@@ -8,14 +8,16 @@ package FIFO_PKG is
   procedure AVERAGE_SAMPLES (
     constant a : in integer;
     signal b   : in std_logic;
-    variable c : in std_logic);
+    variable c : in std_logic;
+    some_sig   : inout t_some_type);
 
   -- Violations below this line
 
   procedure AVERAGE_SAMPLES (
     constant a   : in integer;
     signal b     : in std_logic;
-    variable ccc : in std_logic);
+    variable ccc : in std_logic;
+    some_sig     : inout t_some_type);
 
 end package FIFO_PKG;
 

--- a/vsg/tests/procedure/rule_410_test_input.vhd
+++ b/vsg/tests/procedure/rule_410_test_input.vhd
@@ -8,14 +8,16 @@ package FIFO_PKG is
   procedure AVERAGE_SAMPLES (
     constant a : in integer;
     signal b   : in std_logic;
-    variable c : in std_logic);
+    variable c : in std_logic;
+    some_sig   : inout t_some_type);
 
   -- Violations below this line
 
   procedure AVERAGE_SAMPLES (
     constant a : in integer;
     signal b : in std_logic;
-    variable ccc : in std_logic);
+    variable ccc : in std_logic;
+    some_sig   : inout t_some_type);
 
 end package FIFO_PKG;
 

--- a/vsg/tests/procedure/rule_411_test_input.fixed.vhd
+++ b/vsg/tests/procedure/rule_411_test_input.fixed.vhd
@@ -6,16 +6,18 @@ package FIFO_PKG is
   procedure AVERAGE_SAMPLES (constant a : in integer := 0; signal b : in std_logic := 'X'; variable c : in std_logic := 'X');
 
   procedure AVERAGE_SAMPLES (
-    constant a : in integer   := 0;
-    signal b   : in std_logic := 'X';
-    variable c : in std_logic := 'X');
+    constant a : in integer        := 0;
+    signal b   : in std_logic      := 'X';
+    variable c : in std_logic      := 'X';
+    some_sig   : inout t_some_type := '0');
 
   -- Violations below this line
 
   procedure AVERAGE_SAMPLES (
-    constant a : in integer     := 0;
-    signal b : in std_logic     := 'X';
-    variable ccc : in std_logic := 'X');
+    constant a : in integer        := 0;
+    signal b : in std_logic        := 'X';
+    variable ccc : in std_logic    := 'X';
+    some_sig   : inout t_some_type := '0');
 
 end package FIFO_PKG;
 

--- a/vsg/tests/procedure/rule_411_test_input.vhd
+++ b/vsg/tests/procedure/rule_411_test_input.vhd
@@ -6,16 +6,18 @@ package FIFO_PKG is
   procedure AVERAGE_SAMPLES (constant a : in integer := 0; signal b : in std_logic := 'X'; variable c : in std_logic := 'X');
 
   procedure AVERAGE_SAMPLES (
-    constant a : in integer   := 0;
-    signal b   : in std_logic := 'X';
-    variable c : in std_logic := 'X');
+    constant a : in integer        := 0;
+    signal b   : in std_logic      := 'X';
+    variable c : in std_logic      := 'X';
+    some_sig   : inout t_some_type := '0');
 
   -- Violations below this line
 
   procedure AVERAGE_SAMPLES (
     constant a : in integer          := 0;
     signal b : in std_logic   := 'X';
-    variable ccc : in std_logic   := 'X');
+    variable ccc : in std_logic   := 'X';
+    some_sig   : inout t_some_type          := '0');
 
 end package FIFO_PKG;
 

--- a/vsg/tests/procedure/test_rule_410.py
+++ b/vsg/tests/procedure/test_rule_410.py
@@ -30,7 +30,7 @@ class test_procedure_rule(unittest.TestCase):
         self.assertEqual(oRule.name, 'procedure')
         self.assertEqual(oRule.identifier, '410')
 
-        lExpected = [16, 17, 34, 35, 54, 55, 74, 75]
+        lExpected = [17, 18, 20, 36, 37, 56, 57, 76, 77]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))

--- a/vsg/tests/procedure/test_rule_411.py
+++ b/vsg/tests/procedure/test_rule_411.py
@@ -30,7 +30,7 @@ class test_procedure_rule(unittest.TestCase):
         self.assertEqual(oRule.name, 'procedure')
         self.assertEqual(oRule.identifier, '411')
 
-        lExpected = [16, 17, 18, 34, 35, 36, 54, 55, 56, 74, 75, 76]
+        lExpected = [17, 18, 19, 20, 36, 37, 38, 56, 57, 58, 76, 77, 78]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))


### PR DESCRIPTION
Fixing issue where procedure parameter colons were not aligning.

  1)  Added tests to expose the issue
  2)  Updated rules
      a)  procedure_410
      b)  procedure_411

