### PR TITLE
wrong"-f " filepath returns OK

### DIFF
--- a/vsg/CustomArgumentParser.py
+++ b/vsg/CustomArgumentParser.py
@@ -1,0 +1,15 @@
+import argparse
+import sys
+from gettext import gettext as _
+
+
+class CustomArgumentParser(argparse.ArgumentParser):
+    """
+    Custom class derived from argparse to modify the exit code when an error occurs.
+    As told in https://www.python.org/dev/peps/pep-0389/#discussion-sys-stderr-and-sys-exit.
+    """
+
+    def error(self, message):
+        self.print_usage(sys.stderr)
+        args = {'prog': self.prog, 'message': message}
+        self.exit(1, _('%(prog)s: error: %(message)s\n') % args)

--- a/vsg/__parser__.py
+++ b/vsg/__parser__.py
@@ -6,12 +6,13 @@ import sys
 from . import vhdlFile
 
 from vsg.tests import utils
+from .CustomArgumentParser import CustomArgumentParser
 
 
 def parse_command_line_arguments():
     '''Parses the command line arguments and returns them.'''
 
-    parser = argparse.ArgumentParser(
+    parser = CustomArgumentParser(
       prog='VHDL Style Guide (VSG) Parser',
       description='''Outputs the results from parsing a VHDL file.''')
 

--- a/vsg/cmd_line_args.py
+++ b/vsg/cmd_line_args.py
@@ -25,13 +25,23 @@ def parse_command_line_arguments():
             raise argparse.ArgumentTypeError(f"{value} is an invalid value for number of jobs")
         return iValue
 
+    def is_valid_file(value: str) -> str:
+        """
+        Check an argument in argparse to be a path to an existing file
+        :param value: String path to analyze.
+        :return:
+        """
+        if not os.path.isfile(value):
+            raise argparse.ArgumentTypeError(f"The file {value} does not exist.")
+        return value
+
     parser = argparse.ArgumentParser(
       prog='VHDL Style Guide (VSG)',
       description='''Analyzes VHDL files for style guide violations.
                    Reference documentation is located at:
                    http://vhdl-style-guide.readthedocs.io/en/latest/index.html''')
 
-    parser.add_argument('-f', '--filename', nargs='+', help='File to analyze')
+    parser.add_argument('-f', '--filename', type=is_valid_file, nargs='+', help='File to analyze')
     parser.add_argument('-lr', '--local_rules', help='Path to local rules')
     parser.add_argument('-c', '--configuration', nargs='+', help='JSON or YAML configuration file(s)')
     parser.add_argument('--fix', default=False, action='store_true', help='Fix issues found')

--- a/vsg/cmd_line_args.py
+++ b/vsg/cmd_line_args.py
@@ -1,4 +1,3 @@
-
 import sys
 import os
 import json
@@ -17,52 +16,61 @@ import argparse
 from .CustomArgumentParser import CustomArgumentParser
 
 
+def __check_strict_positive(value):
+    iValue: int = int(value)
+    if iValue <= 0:
+        raise argparse.ArgumentTypeError(f"{value} is an invalid value for number of jobs")
+    return iValue
+
+
+def __is_valid_file(value: str) -> str:
+    """
+    Check an argument in argparse to be a path to an existing file
+    :param value: String path to analyze.
+    :return:
+    """
+    if not os.path.isfile(value):
+        raise argparse.ArgumentTypeError(f"The file {value} does not exist.")
+    return value
+
+
 def parse_command_line_arguments():
-    '''Parses the command line arguments and returns them.'''
-
-    def check_strict_positive(value):
-        iValue = int(value)
-        if iValue <= 0:
-            raise argparse.ArgumentTypeError(f"{value} is an invalid value for number of jobs")
-        return iValue
-
-    def is_valid_file(value: str) -> str:
-        """
-        Check an argument in argparse to be a path to an existing file
-        :param value: String path to analyze.
-        :return:
-        """
-        if not os.path.isfile(value):
-            raise argparse.ArgumentTypeError(f"The file {value} does not exist.")
-        return value
+    """Parses the command line arguments and returns them."""
 
     parser = CustomArgumentParser(
-      prog='VHDL Style Guide (VSG)',
-      description='''Analyzes VHDL files for style guide violations.
+        prog='VHDL Style Guide (VSG)',
+        description='''Analyzes VHDL files for style guide violations.
                    Reference documentation is located at:
                    http://vhdl-style-guide.readthedocs.io/en/latest/index.html''')
 
-    parser.add_argument('-f', '--filename', type=is_valid_file, nargs='+', help='File to analyze')
+    parser.add_argument('-f', '--filename', type=__is_valid_file, nargs='+', help='File to analyze')
     parser.add_argument('-lr', '--local_rules', help='Path to local rules')
     parser.add_argument('-c', '--configuration', nargs='+', help='JSON or YAML configuration file(s)')
     parser.add_argument('--fix', default=False, action='store_true', help='Fix issues found')
-    parser.add_argument('-fp', '--fix_phase', default=7, action='store', help='Fix issues up to and including this phase')
+    parser.add_argument('-fp', '--fix_phase', default=7, action='store',
+                        help='Fix issues up to and including this phase')
     parser.add_argument('-j', '--junit', action='store', help='Extract Junit file')
     parser.add_argument('-js', '--json', action='store', help='Extract JSON file')
-    parser.add_argument('-of', '--output_format', action='store', default='vsg', choices=['vsg', 'syntastic', 'summary'], help='Sets the output format.')
-    parser.add_argument('-b', '--backup', default=False, action='store_true', help='Creates a copy of input file for comparison with fixed version.')
-    parser.add_argument('-oc', '--output_configuration', default=None, action='store', help='Write configuration to file name.')
-    parser.add_argument('-rc', '--rule_configuration', default=None, action='store', help='Display configuration of a rule')
-    parser.add_argument('--style', action='store', default=None, choices=get_predefined_styles(), help='Use predefined style')
+    parser.add_argument('-of', '--output_format', action='store', default='vsg',
+                        choices=['vsg', 'syntastic', 'summary'], help='Sets the output format.')
+    parser.add_argument('-b', '--backup', default=False, action='store_true',
+                        help='Creates a copy of input file for comparison with fixed version.')
+    parser.add_argument('-oc', '--output_configuration', default=None, action='store',
+                        help='Write configuration to file name.')
+    parser.add_argument('-rc', '--rule_configuration', default=None, action='store',
+                        help='Display configuration of a rule')
+    parser.add_argument('--style', action='store', default=None, choices=get_predefined_styles(),
+                        help='Use predefined style')
     parser.add_argument('-v', '--version', default=False, action='store_true', help='Displays version information')
-    parser.add_argument('-ap', '--all_phases', default=False, action='store_true', help='Do not stop when a violation is detected.')
+    parser.add_argument('-ap', '--all_phases', default=False, action='store_true',
+                        help='Do not stop when a violation is detected.')
     parser.add_argument('--fix_only', action='store', help='Restrict fixing via JSON file.')
     parser.add_argument(
         "-p",
         "--jobs",
         action="store",
         default=os.cpu_count(),
-        type=check_strict_positive,
+        type=__check_strict_positive,
         help="number of parallel jobs to use, default is the number of cpu cores",
     )
     parser.add_argument('--debug', default=False, action='store_true', help='Displays verbose debug information')

--- a/vsg/cmd_line_args.py
+++ b/vsg/cmd_line_args.py
@@ -1,5 +1,4 @@
 
-import argparse
 import sys
 import os
 import json
@@ -14,6 +13,8 @@ from . import rule_list
 from . import severity
 from . import version
 from . import vhdlFile
+import argparse
+from .CustomArgumentParser import CustomArgumentParser
 
 
 def parse_command_line_arguments():
@@ -35,7 +36,7 @@ def parse_command_line_arguments():
             raise argparse.ArgumentTypeError(f"The file {value} does not exist.")
         return value
 
-    parser = argparse.ArgumentParser(
+    parser = CustomArgumentParser(
       prog='VHDL Style Guide (VSG)',
       description='''Analyzes VHDL files for style guide violations.
                    Reference documentation is located at:

--- a/vsg/cmd_line_args.py
+++ b/vsg/cmd_line_args.py
@@ -45,7 +45,7 @@ def parse_command_line_arguments():
 
     parser.add_argument('-f', '--filename', type=__is_valid_file, nargs='+', help='File to analyze')
     parser.add_argument('-lr', '--local_rules', help='Path to local rules')
-    parser.add_argument('-c', '--configuration', nargs='+', help='JSON or YAML configuration file(s)')
+    parser.add_argument('-c', '--configuration', type=__is_valid_file, nargs='+', help='JSON or YAML configuration file(s)')
     parser.add_argument('--fix', default=False, action='store_true', help='Fix issues found')
     parser.add_argument('-fp', '--fix_phase', default=7, action='store',
                         help='Fix issues up to and including this phase')

--- a/vsg/tests/source_file/test_source_file.py
+++ b/vsg/tests/source_file/test_source_file.py
@@ -18,6 +18,7 @@ sOutputNoFile = os.path.join(os.path.dirname(__file__),'output_no_file.txt')
 sOutputNoPermission = os.path.join(os.path.dirname(__file__),'output_no_permission.txt')
 sOutputEmptyFile = os.path.join(os.path.dirname(__file__),'output_empty_file.txt')
 
+
 class testOSError(unittest.TestCase):
 
     def tearDown(self):
@@ -26,15 +27,11 @@ class testOSError(unittest.TestCase):
 
     def test_file_not_found(self):
         try:
-            subprocess.check_output(['bin/vsg','-f', 'no_file.vhd'])
+            subprocess.check_output(['bin/vsg', '-f', 'no_file.vhd'])
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode('utf-8')).split('\n')
-            iExitStatus = e.returncode
+            exit_status: int = e.returncode
 
-        lExpected = pathlib.Path(sOutputNoFile).read_text().split('\n')
-
-        self.assertEqual(iExitStatus, 1)
-        self.assertEqual(utils.replace_total_count(lActual), lExpected)
+        self.assertEqual(exit_status, 1)
 
     @unittest.skipIf('SUDO_UID' in os.environ.keys() or os.geteuid() == 0, "We are root. Root always has permissions so test will fail.")
     def test_file_no_permission(self):

--- a/vsg/tests/vsg/test_parser.py
+++ b/vsg/tests/vsg/test_parser.py
@@ -25,7 +25,7 @@ class TestParser(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             cmd_line_args.parse_command_line_arguments()
 
-        self.assertEqual(cm.exception.code, 2)
+        self.assertEqual(cm.exception.code, 1)
 
     def test_jobs_invalid_2(self):
         sys.argv[1:] = ["--jobs", "0"]
@@ -33,7 +33,7 @@ class TestParser(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             cmd_line_args.parse_command_line_arguments()
 
-        self.assertEqual(cm.exception.code, 2)
+        self.assertEqual(cm.exception.code, 1)
 
     def test_jobs_invalid_3(self):
         sys.argv[1:] = ["--jobs", "3.5"]
@@ -41,7 +41,7 @@ class TestParser(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             cmd_line_args.parse_command_line_arguments()
 
-        self.assertEqual(cm.exception.code, 2)
+        self.assertEqual(cm.exception.code, 1)
 
     def test_jobs_invalid_4(self):
         sys.argv[1:] = ["--jobs", "notanumber"]
@@ -49,4 +49,4 @@ class TestParser(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             cmd_line_args.parse_command_line_arguments()
 
-        self.assertEqual(cm.exception.code, 2)
+        self.assertEqual(cm.exception.code, 1)

--- a/vsg/tests/vsg/test_vsg.py
+++ b/vsg/tests/vsg/test_vsg.py
@@ -298,16 +298,12 @@ class testVsg(unittest.TestCase):
         self.assertEqual(lExpected[0], lActual[0])
 
     def test_missing_configuration_file(self):
-        sExpected = 'ERROR: encountered FileNotFoundError, No such file or directory while opening configuration file: missing_configuration.yaml\n'
-
         try:
             subprocess.check_output(['bin/vsg', '-c', 'missing_configuration.yaml'])
         except subprocess.CalledProcessError as e:
-            sActual = str(e.output.decode('utf-8'))
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
-        self.assertEqual(sActual, sExpected)
 
     @unittest.skipIf('SUDO_UID' in os.environ.keys() or os.geteuid() == 0, "We are root. Root always has permissions so test will fail.")
     def test_no_permission_configuration_file(self):


### PR DESCRIPTION
**Description**
If a stupid file path is provided with "-f", the program doesn't notice and tries to analyse its style. It doesn't give any warning/error, and obviously, it doesn't analyse anything because the file doesn't exist.

**Screenshots**
Current output of VSG using an "inexistent" file:
![image](https://user-images.githubusercontent.com/55917369/138683740-87d43a00-7f13-4bd9-82c0-cb23eab563eb.png)

New output:
![image](https://user-images.githubusercontent.com/55917369/138684558-51b065ae-6c3b-4af1-8d72-cca73bd17969.png)

** Changes applied**
I have created a patch to use the power of argparse to validate that ALL the files provided with "-f" option exist and are valid files. If any of the filepaths is wrong, argparse fails and aborts the execution of the program. Also, it provides a user-friendly message. 
I have created a custom argparse to be able to change the returned error code, because by default argparse returns 2. As VSG returns 1 when fails, I decided that the program should be consistent with the error codes.
