### PR TITLE
Updates for issue #664

### DIFF
--- a/vsg/rules/process/rule_033.py
+++ b/vsg/rules/process/rule_033.py
@@ -10,6 +10,7 @@ lAlign.append(token.constant_declaration.colon)
 lAlign.append(token.variable_declaration.colon)
 
 lUnless = []
+lUnless.append([token.subprogram_body.is_keyword,token.subprogram_body.begin_keyword])
 
 
 class rule_033(align_tokens_in_region_between_tokens_unless_between_tokens):

--- a/vsg/tests/process/rule_033_test_input.fixed.vhd
+++ b/vsg/tests/process/rule_033_test_input.fixed.vhd
@@ -24,5 +24,20 @@ begin
   begin
   end process;
 
+  process
+
+    procedure some_procedure (count : integer) is
+
+      variable v_count      : std_logic_vector(SOME_CONSTANT - 1 downto 0);
+
+    begin
+
+    end procedure;
+
+    variable var1  : integer := 0;
+    file     file1 : load_file_file open read_mode is load_file_name;
+    constant con1  : std_logic := '1';
+
+  begin end process;
 
 end architecture RTL;

--- a/vsg/tests/process/rule_033_test_input.vhd
+++ b/vsg/tests/process/rule_033_test_input.vhd
@@ -24,5 +24,20 @@ begin
   begin
   end process;
 
+  process
+
+    procedure some_procedure (count : integer) is
+
+      variable v_count      : std_logic_vector(SOME_CONSTANT - 1 downto 0);
+
+    begin
+
+    end procedure;
+
+    variable var1  : integer := 0;
+    file     file1 : load_file_file open read_mode is load_file_name;
+    constant con1  : std_logic := '1';
+
+  begin end process;
 
 end architecture RTL;


### PR DESCRIPTION
Colons in subprogram_declarative_parts were being aligned with process_declarative_parts.

  1)  Updated tests to expose the issue
  2)  Updated rule process_033 to exclude subprogram_declarative_parts