### PR TITLE
Updates for issue #671

### DIFF
--- a/vsg/tests/tokens/test_token_method.py
+++ b/vsg/tests/tokens/test_token_method.py
@@ -665,3 +665,175 @@ class testTokenMethod(unittest.TestCase):
   
         self.assertEqual(lTokens, lActual)
 
+    def test_backward_slashes(self):
+        sLine = '  function \?=\ (L, R : ufixed) return STD_ULOGIC;'
+        lTokens = []
+        lTokens.append('  ')
+        lTokens.append('function')
+        lTokens.append(' ')
+        lTokens.append('\\' + '?=' + '\\')
+        lTokens.append(' ')
+        lTokens.append('(')
+        lTokens.append('L')
+        lTokens.append(',')
+        lTokens.append(' ')
+        lTokens.append('R')
+        lTokens.append(' ')
+        lTokens.append(':')
+        lTokens.append(' ')
+        lTokens.append('ufixed')
+        lTokens.append(')')
+        lTokens.append(' ')
+        lTokens.append('return')
+        lTokens.append(' ')
+        lTokens.append('STD_ULOGIC')
+        lTokens.append(';')
+  
+        lActual = tokens.create(sLine)
+  
+        self.assertEqual(lTokens, lActual)
+
+    def test_combine_backslash_characters_into_symbols(self):
+        sLine = ' function \?=\ hello'
+        lLine = []
+        for sChar in sLine:
+            lLine.append(sChar)
+         
+        lActual = tokens.combine_whitespace(lLine)
+
+        lExpected = lLine
+        self.assertEqual(lExpected, lActual)
+
+        lActual = tokens.combine_backslash_characters_into_symbols(lActual)
+
+        lExpected = []
+        lExpected.append(' ')
+        lExpected.extend(['f', 'u', 'n', 'c', 't', 'i', 'o', 'n'])
+        lExpected.append(' ')
+        lExpected.append('\\?=\\')
+        lExpected.append(' ')
+        lExpected.extend(['h', 'e', 'l', 'l', 'o'])
+
+        self.assertEqual(lExpected, lActual)
+
+
+        sLine = ' function \?=\\'
+        lLine = []
+        for sChar in sLine:
+            lLine.append(sChar)
+         
+        lActual = tokens.combine_whitespace(lLine)
+
+        lExpected = lLine
+        self.assertEqual(lExpected, lActual)
+
+        lActual = tokens.combine_backslash_characters_into_symbols(lActual)
+
+        lExpected = []
+        lExpected.append(' ')
+        lExpected.extend(['f', 'u', 'n', 'c', 't', 'i', 'o', 'n'])
+        lExpected.append(' ')
+        lExpected.append('\\?=\\')
+
+        self.assertEqual(lExpected, lActual)
+
+        
+        sLine = ' function \?=\\('
+        lLine = []
+        for sChar in sLine:
+            lLine.append(sChar)
+         
+        lActual = tokens.combine_whitespace(lLine)
+
+        lExpected = lLine
+        self.assertEqual(lExpected, lActual)
+
+        lActual = tokens.combine_backslash_characters_into_symbols(lActual)
+
+        lExpected = []
+        lExpected.append(' ')
+        lExpected.extend(['f', 'u', 'n', 'c', 't', 'i', 'o', 'n'])
+        lExpected.append(' ')
+        lExpected.append('\\?=\\')
+        lExpected.append('(')
+
+        self.assertEqual(lExpected, lActual)
+
+        
+        sLine = ' function \?=\\ '
+        lLine = []
+        for sChar in sLine:
+            lLine.append(sChar)
+         
+        lActual = tokens.combine_whitespace(lLine)
+
+        lExpected = lLine
+        self.assertEqual(lExpected, lActual)
+
+        lActual = tokens.combine_backslash_characters_into_symbols(lActual)
+
+        lExpected = []
+        lExpected.append(' ')
+        lExpected.extend(['f', 'u', 'n', 'c', 't', 'i', 'o', 'n'])
+        lExpected.append(' ')
+        lExpected.append('\\?=\\')
+        lExpected.append(' ')
+
+        self.assertEqual(lExpected, lActual)
+
+        
+        sLine = ' function \?=\\;'
+        lLine = []
+        for sChar in sLine:
+            lLine.append(sChar)
+         
+        lActual = tokens.combine_whitespace(lLine)
+
+        lExpected = lLine
+        self.assertEqual(lExpected, lActual)
+
+        lActual = tokens.combine_backslash_characters_into_symbols(lActual)
+
+        lExpected = []
+        lExpected.append(' ')
+        lExpected.extend(['f', 'u', 'n', 'c', 't', 'i', 'o', 'n'])
+        lExpected.append(' ')
+        lExpected.append('\\?=\\')
+        lExpected.append(';')
+
+        self.assertEqual(lExpected, lActual)
+
+        sLine = ' function \\?>\\  ('
+        lLine = []
+        for sChar in sLine:
+            lLine.append(sChar)
+         
+        lActual = tokens.combine_whitespace(lLine)
+
+        lExpected = []
+        lExpected.append(' ')
+        lExpected.extend(['f', 'u', 'n', 'c', 't', 'i', 'o', 'n'])
+        lExpected.append(' ')
+        lExpected.append('\\')
+        lExpected.append('?')
+        lExpected.append('>')
+        lExpected.append('\\')
+        lExpected.append('  ')
+        lExpected.append('(')
+
+        self.assertEqual(lExpected, lActual)
+
+        lActual = tokens.combine_backslash_characters_into_symbols(lActual)
+
+        lExpected = []
+        lExpected.append(' ')
+        lExpected.extend(['f', 'u', 'n', 'c', 't', 'i', 'o', 'n'])
+        lExpected.append(' ')
+        lExpected.append('\\?>\\')
+        lExpected.append('  ')
+        lExpected.append('(')
+
+        self.assertEqual(lExpected, lActual)
+
+        
+        

--- a/vsg/tokens.py
+++ b/vsg/tokens.py
@@ -2,6 +2,7 @@
 lSingleCharacterSymbols = [',', ':', '(', ')', '\'', '"', '+', '&', '-', '*', '/', '<', '>', ';', '=', '[', ']', '?']
 lTwoCharacterSymbols = ['=>','**', ':=', '/=', '>=', '<=', '<>', '??', '?=', '?<', '?>', '<<', '>>', '--']
 lThreeCharacterSymbols = ['?/=', '?<', '?<=', '?>=']
+lFourCharacterSymbols = ['\\?=\\']
 
 
 def create(sString):
@@ -13,6 +14,7 @@ def create(sString):
     for sChar in sString:
         lCharacters.append(sChar)
     lCharacters = combine_whitespace(lCharacters)
+    lCharacters = combine_backslash_characters_into_symbols(lCharacters)
     lCharacters = combine_two_character_symbols(lCharacters)
     lCharacters = combine_characters_into_words(lCharacters)
     lCharacters = combine_string_literals(lCharacters)
@@ -48,6 +50,27 @@ def combine_comments(lChars):
     if bComment:
         lReturn.append(sComment)
 
+    return lReturn
+
+lStopChars = [' ', '(', ';']
+
+def combine_backslash_characters_into_symbols(lChars):
+    lReturn = []
+    sLiteral = ''
+    bLiteral = False
+    for iChar, sChar in enumerate(lChars):
+        if (sChar in lStopChars  or ' ' in sChar) and bLiteral:
+            bLiteral = False
+            lReturn.append(sLiteral)
+            sLiteral = ''
+        if sChar == '\\':
+            bLiteral = True
+        if not bLiteral:
+            lReturn.append(sChar)
+        else:
+            sLiteral += sChar
+    if len(sLiteral) > 0:
+        lReturn.append(sLiteral)
     return lReturn
 
 

--- a/vsg/tokens.py
+++ b/vsg/tokens.py
@@ -58,20 +58,31 @@ lStopChars = [' ', '(', ';']
 
 def combine_backslash_characters_into_symbols(lChars):
     lReturn = []
-    sLiteral = ''
-    bLiteral = False
+    sSymbol = ''
+    bSymbol = False
     for sChar in lChars:
-        if stop_character_found(sChar, bLiteral):
-            bLiteral = False
-            lReturn.append(sLiteral)
-            sLiteral = ''
+        if stop_character_found(sChar, bSymbol):
+            bSymbol = False
+            lReturn.append(sSymbol)
+            sSymbol = ''
         if backslash_character_found(sChar):
-            bLiteral = True
-        if bLiteral:
-            sLiteral += sChar
-        else:
-            lReturn.append(sChar)
-    lReturn = add_trailing_string(lReturn, sLiteral)
+            bSymbol = True
+        sSymbol = append_to_symbol(bSymbol, sSymbol, sChar)
+        lReturn = append_to_list(bSymbol, lReturn, sChar)
+    lReturn = add_trailing_string(lReturn, sSymbol)
+    return lReturn
+
+
+def append_to_symbol(bSomething, sSymbol, sChar):
+    if bSomething:
+        return sSymbol + sChar
+    return sSymbol
+
+
+def append_to_list(bSomething, lChars, sChar):
+    lReturn = lChars
+    if not bSomething:
+       lReturn.append(sChar)
     return lReturn
 
 
@@ -91,7 +102,6 @@ def add_trailing_string(lReturn, sString):
     if len(sString) > 0:
         lReturn.append(sString)
     return lReturn
-
 
 
 def combine_string_literals(lChars):

--- a/vsg/tokens.py
+++ b/vsg/tokens.py
@@ -52,26 +52,46 @@ def combine_comments(lChars):
 
     return lReturn
 
+
 lStopChars = [' ', '(', ';']
+
 
 def combine_backslash_characters_into_symbols(lChars):
     lReturn = []
     sLiteral = ''
     bLiteral = False
-    for iChar, sChar in enumerate(lChars):
-        if (sChar in lStopChars  or ' ' in sChar) and bLiteral:
+    for sChar in lChars:
+        if stop_character_found(sChar, bLiteral):
             bLiteral = False
             lReturn.append(sLiteral)
             sLiteral = ''
-        if sChar == '\\':
+        if backslash_character_found(sChar):
             bLiteral = True
-        if not bLiteral:
-            lReturn.append(sChar)
-        else:
+        if bLiteral:
             sLiteral += sChar
-    if len(sLiteral) > 0:
-        lReturn.append(sLiteral)
+        else:
+            lReturn.append(sChar)
+    lReturn = add_trailing_string(lReturn, sLiteral)
     return lReturn
+
+
+def backslash_character_found(sChar):
+    if sChar == '\\':
+        return True
+    return False
+
+
+def stop_character_found(sChar, bLiteral):
+    if (sChar in lStopChars or ' ' in sChar) and bLiteral:
+        return True
+    return False
+
+
+def add_trailing_string(lReturn, sString):
+    if len(sString) > 0:
+        lReturn.append(sString)
+    return lReturn
+
 
 
 def combine_string_literals(lChars):

--- a/vsg/tokens.py
+++ b/vsg/tokens.py
@@ -65,24 +65,29 @@ def combine_backslash_characters_into_symbols(lChars):
             bSymbol = False
             lReturn.append(sSymbol)
             sSymbol = ''
-        if backslash_character_found(sChar):
-            bSymbol = True
+        bSymbol = inside_backslash_symbol(bSymbol, sChar)
         sSymbol = append_to_symbol(bSymbol, sSymbol, sChar)
         lReturn = append_to_list(bSymbol, lReturn, sChar)
     lReturn = add_trailing_string(lReturn, sSymbol)
     return lReturn
 
 
-def append_to_symbol(bSomething, sSymbol, sChar):
-    if bSomething:
+def inside_backslash_symbol(bSymbol, sChar):
+    if backslash_character_found(sChar):
+        return True
+    return bSymbol
+
+
+def append_to_symbol(bSymbol, sSymbol, sChar):
+    if bSymbol:
         return sSymbol + sChar
     return sSymbol
 
 
-def append_to_list(bSomething, lChars, sChar):
+def append_to_list(bSymbol, lChars, sChar):
     lReturn = lChars
-    if not bSomething:
-       lReturn.append(sChar)
+    if not bSymbol:
+        lReturn.append(sChar)
     return lReturn
 
 


### PR DESCRIPTION
VSG could not parse identifiers with backslashes (\).

  1)  Updated tests
  2)  Fixed tokenizer to combine backslashes and the following characters into symbols
