### PR TITLE
Updates for issue #685

### DIFF
--- a/vsg/rule_list.py
+++ b/vsg/rule_list.py
@@ -142,6 +142,10 @@ class rule_list():
                     self.oVhdlFile.set_token_indent()
                 continue
 
+            # Update indents before checking indent 
+            if phase == 4:
+               self.oVhdlFile.set_token_indent()
+
             for subphase in range(0, 5):
                 lRules = self.get_rules_in_phase(phase)
                 lRules = self.get_rules_in_subphase(lRules, subphase)

--- a/vsg/rule_list.py
+++ b/vsg/rule_list.py
@@ -144,7 +144,7 @@ class rule_list():
 
             # Update indents before checking indent
             if phase == 4:
-               self.oVhdlFile.set_token_indent()
+                self.oVhdlFile.set_token_indent()
 
             for subphase in range(0, 5):
                 lRules = self.get_rules_in_phase(phase)

--- a/vsg/rule_list.py
+++ b/vsg/rule_list.py
@@ -142,7 +142,7 @@ class rule_list():
                     self.oVhdlFile.set_token_indent()
                 continue
 
-            # Update indents before checking indent 
+            # Update indents before checking indent
             if phase == 4:
                self.oVhdlFile.set_token_indent()
 

--- a/vsg/tests/styles/code_examples/library_statements.vhd
+++ b/vsg/tests/styles/code_examples/library_statements.vhd
@@ -1,0 +1,8 @@
+library work;
+use work.tb_utilities.all;
+use work.tb_wait_clock_package.all;
+use work.random_pkg.all;
+
+use work.dsd_types.all;
+--use work.channel_types.all;
+

--- a/vsg/tests/styles/jcl/library_statements.fixed.vhd
+++ b/vsg/tests/styles/jcl/library_statements.fixed.vhd
@@ -1,0 +1,7 @@
+library work;
+  use work.tb_utilities.all;
+  use work.tb_wait_clock_package.all;
+  use work.random_pkg.all;
+  use work.dsd_types.all;
+  -- use work.channel_types.all;
+

--- a/vsg/tests/styles/jcl/test_code_examples.py
+++ b/vsg/tests/styles/jcl/test_code_examples.py
@@ -32,6 +32,10 @@ lPIC, ePICError = vhdlFile.utils.read_vhdlfile(os.path.join(sSourceCodeDir,'PIC.
 oPIC = vhdlFile.vhdlFile(lPIC)
 oPIC.set_indent_map(dIndentMap)
 
+lLibraryStatements, eLibraryStatementsError = vhdlFile.utils.read_vhdlfile(os.path.join(sSourceCodeDir,'library_statements.vhd'))
+oLibraryStatements = vhdlFile.vhdlFile(lLibraryStatements)
+oLibraryStatements.set_indent_map(dIndentMap)
+
 oConfig = utils.read_configuration(os.path.join(os.path.dirname(__file__),'..','..','..','styles', 'jcl.yaml'))
 
 oSeverityList = severity.create_list({})
@@ -44,6 +48,7 @@ class testCodeExample(unittest.TestCase):
         self.assertIsNone(eSpiMasterError)
         self.assertIsNone(eGrpDebouncerError)
         self.assertIsNone(ePICError)
+        self.assertIsNone(eLibraryStatementsError)
 
     def test_timestamp_vhdl(self):
         oRuleList = rule_list.rule_list(oTimestamp, oSeverityList)
@@ -93,3 +98,17 @@ class testCodeExample(unittest.TestCase):
         utils.read_file(os.path.join(os.path.dirname(__file__),'PIC.fixed.vhd'), lExpected)
 
         self.assertEqual(lExpected, oPIC.get_lines())
+
+    def test_library_statements(self):
+        oRuleList = rule_list.rule_list(oLibraryStatements, oSeverityList)
+        oRuleList.configure(oConfig)
+        oRuleList.fix()
+
+        lExpected = ['']
+        utils.read_file(os.path.join(os.path.dirname(__file__),'library_statements.fixed.vhd'), lExpected)
+
+        self.assertEqual(lExpected, oLibraryStatements.get_lines())
+
+        self.assertFalse(oRuleList.violations)
+        oRuleList.check_rules()
+        self.assertFalse(oRuleList.violations)


### PR DESCRIPTION
Rule comment_010 was firing after library_007 removed blank lines.

Details:
  Issue was traced down to not redoing the indent after the structural phase.
  Indenting is performed once after the file is read.
  The rule library_007 removed blank lines, which should have changed in indent on some comments.
  However, the indent was not ran again so it was missed.
  This resulted in VSG saying the file passed, but when VSG was ran again VSG would flag an error on the comment.

1)  Added test to expose the issue
2)  A second indenting is performed before phase 4 (Indenting)

