### PR TITLE
Updates for issue #688

### DIFF
--- a/docs/library_rules.rst
+++ b/docs/library_rules.rst
@@ -269,3 +269,28 @@ This rule checks the **use** keyword is on it's own line.
    context c1 is library ieee;
        use ieee.std_logic_1164.all; end context c1;
 
+library_600
+###########
+
+|phase_6| |error| |case| |case_name|
+
+This rule checks the logical_name in a library_clause has proper case.
+
+Refer to the section `Configuring Uppercase and Lowercase Rules <configuring.html#configuring-uppercase-and-lowercase-rules>`_ for information on changing the default case.
+
+**Violation**
+
+.. code-block:: vhdl
+
+   library IEEE;
+
+   library FIFO_dsn;
+
+**Fix**
+
+.. code-block:: vhdl
+
+   library ieee;
+
+   library fifo_dsn;
+

--- a/vsg/rules/library/__init__.py
+++ b/vsg/rules/library/__init__.py
@@ -10,3 +10,5 @@ from .rule_008 import rule_008
 from .rule_009 import rule_009
 from .rule_010 import rule_010
 from .rule_011 import rule_011
+
+from .rule_600 import rule_600

--- a/vsg/rules/library/rule_600.py
+++ b/vsg/rules/library/rule_600.py
@@ -1,0 +1,35 @@
+
+from vsg.rules import token_case
+
+from vsg import token
+
+lTokens = []
+lTokens.append(token.logical_name_list.logical_name)
+
+
+class rule_600(token_case):
+    '''
+    This rule checks the logical_name in a library_clause has proper case.
+
+    Refer to the section `Configuring Uppercase and Lowercase Rules <configuring.html#configuring-uppercase-and-lowercase-rules>`_ for information on changing the default case.
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+       library IEEE;
+
+       library FIFO_dsn;
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+       library ieee;
+
+       library fifo_dsn;
+    '''
+
+    def __init__(self):
+        token_case.__init__(self, 'library', '600', lTokens)
+        self.groups.append('case::name')

--- a/vsg/styles/jcl.yaml
+++ b/vsg/styles/jcl.yaml
@@ -35,6 +35,9 @@ rule :
     case : upper
   process_019 :
     case : upper
+  # Ignored rules
+  library_600 :
+    disable : True
   # Set alignment rules
   architecture_026 :
     compact_alignment : false

--- a/vsg/tests/library/rule_600_test_input.fixed_lower.vhd
+++ b/vsg/tests/library/rule_600_test_input.fixed_lower.vhd
@@ -1,0 +1,5 @@
+
+library ieee;
+
+library ieee;
+

--- a/vsg/tests/library/rule_600_test_input.fixed_upper.vhd
+++ b/vsg/tests/library/rule_600_test_input.fixed_upper.vhd
@@ -1,0 +1,5 @@
+
+library IEEE;
+
+library IEEE;
+

--- a/vsg/tests/library/rule_600_test_input.vhd
+++ b/vsg/tests/library/rule_600_test_input.vhd
@@ -1,0 +1,5 @@
+
+library ieee;
+
+library IEEE;
+

--- a/vsg/tests/library/test_rule_600.py
+++ b/vsg/tests/library/test_rule_600.py
@@ -1,0 +1,73 @@
+
+import os
+import unittest
+
+from vsg.rules import library
+from vsg import vhdlFile
+from vsg.tests import utils
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError =vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir,'rule_600_test_input.vhd'))
+
+lExpected_lower = []
+lExpected_lower.append('')
+utils.read_file(os.path.join(sTestDir, 'rule_600_test_input.fixed_lower.vhd'), lExpected_lower)
+
+lExpected_upper = []
+lExpected_upper.append('')
+utils.read_file(os.path.join(sTestDir, 'rule_600_test_input.fixed_upper.vhd'), lExpected_upper)
+
+class test_library_rule(unittest.TestCase):
+
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_600_lower(self):
+        oRule = library.rule_600()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, 'library')
+        self.assertEqual(oRule.identifier, '600')
+
+        lExpected = [4]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(utils.extract_violation_lines_from_violation_object(oRule.violations), lExpected)
+
+    def test_rule_600_upper(self):
+        oRule = library.rule_600()
+        oRule.case = 'upper'
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, 'library')
+        self.assertEqual(oRule.identifier, '600')
+
+        lExpected = [2]
+        oRule.analyze(self.oFile)
+        self.assertEqual(utils.extract_violation_lines_from_violation_object(oRule.violations), lExpected)
+
+    def test_fix_rule_600_lower(self):
+        oRule = library.rule_600()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_lower, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])
+
+    def test_fix_rule_600_upper(self):
+        oRule = library.rule_600()
+        oRule.case = 'upper'
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_upper, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])
+

--- a/vsg/tests/rule_group/config_1.yaml
+++ b/vsg/tests/rule_group/config_1.yaml
@@ -8,3 +8,5 @@ rule:
       case: 'lower'
   signal_010:
     disable: True    
+  library_600:
+    disable: True

--- a/vsg/tests/rule_group/config_2.yaml
+++ b/vsg/tests/rule_group/config_2.yaml
@@ -8,3 +8,5 @@ rule:
       case: 'upper'
   signal_010:
     disable: True    
+  library_600:
+    disable: True

--- a/vsg/tests/rule_group/config_3.yaml
+++ b/vsg/tests/rule_group/config_3.yaml
@@ -10,3 +10,5 @@ rule:
     disable: True    
   architecture_004:
     case: 'upper'
+  library_600:
+    disable: True


### PR DESCRIPTION
Adding rule library_600 to enforce capitalization of library logical names.

  1)  Added test
  2)  Added documentation
  3)  Added rule library_600
  4)  Disabled rule in jcl style

**Description**
State a clear description of the problem and your solution.

**Screenshots**
If applicable, add screenshots to help explain your solution.

**Additional context**
Add any other context about the problem here including related issue numbers.
