### PR TITLE
Updates for issue #678

### DIFF
--- a/docs/constant_rules.rst
+++ b/docs/constant_rules.rst
@@ -358,6 +358,28 @@ This rule checks the structure of multiline constants that contain arrays.
      32768
    );
 
+constant_100
+############
+
+|phase_2| |error| |whitespace|
+
+This rule checks for a single space after the := assignment in constant declarations.
+Having a space makes it clearer where the assignment occurs on the line.
+
+**Violation**
+
+.. code-block:: vhdl
+
+   constant size : integer :=1;
+   constant width : t_type :=(
+
+**Fix**
+
+.. code-block:: vhdl
+
+   constant size : integer := 1;
+   constant width : t_type := (
+
 constant_600
 ############
 

--- a/vsg/rules/constant/__init__.py
+++ b/vsg/rules/constant/__init__.py
@@ -15,5 +15,7 @@ from .rule_014 import rule_014
 from .rule_015 import rule_015
 from .rule_016 import rule_016
 
+from .rule_100 import rule_100
+
 from .rule_600 import rule_600
 

--- a/vsg/rules/constant/rule_100.py
+++ b/vsg/rules/constant/rule_100.py
@@ -1,0 +1,31 @@
+
+from vsg.rules import single_space_after_token as Rule
+
+from vsg import token
+
+lTokens = []
+lTokens.append(token.constant_declaration.assignment_operator)
+
+
+class rule_100(Rule):
+    '''
+    This rule checks for a single space after the := assignment in constant declarations.
+    Having a space makes it clearer where the assignment occurs on the line.
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+       constant size : integer :=1;
+       constant width : t_type :=(
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+       constant size : integer := 1;
+       constant width : t_type := (
+    '''
+
+    def __init__(self):
+        Rule.__init__(self, 'constant', '100', lTokens)

--- a/vsg/tests/constant/rule_100_test_input.fixed.vhd
+++ b/vsg/tests/constant/rule_100_test_input.fixed.vhd
@@ -1,0 +1,19 @@
+
+architecture RTL of FIFO is
+
+  constant c_width : integer := 16;
+  constant c_depth : integer := 512;
+  constant c_word : integer := (12, 13, 15);
+
+begin
+
+  process
+
+    constant c_width : integer := 16;
+    constant c_depth : integer := 512;
+    constant c_word : integer := (12, 13, 15);
+    constant c_word : integer := (12, 13, 15);
+
+  begin end process;
+
+end architecture RTL;

--- a/vsg/tests/constant/rule_100_test_input.vhd
+++ b/vsg/tests/constant/rule_100_test_input.vhd
@@ -1,0 +1,19 @@
+
+architecture RTL of FIFO is
+
+  constant c_width : integer := 16;
+  constant c_depth : integer := 512;
+  constant c_word : integer := (12, 13, 15);
+
+begin
+
+  process
+
+    constant c_width : integer :=    16;
+    constant c_depth : integer :=512;
+    constant c_word : integer :=(12, 13, 15);
+    constant c_word : integer :=          (12, 13, 15);
+
+  begin end process;
+
+end architecture RTL;

--- a/vsg/tests/constant/test_rule_100.py
+++ b/vsg/tests/constant/test_rule_100.py
@@ -1,0 +1,48 @@
+
+import os
+import unittest
+
+from vsg.rules import constant
+from vsg import vhdlFile
+from vsg.tests import utils
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError =vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir,'rule_100_test_input.vhd'))
+
+dIndentMap = utils.read_indent_file()
+
+lExpected = []
+lExpected.append('')
+utils.read_file(os.path.join(sTestDir, 'rule_100_test_input.fixed.vhd'), lExpected)
+
+
+class test_constant_rule(unittest.TestCase):
+
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+        self.oFile.set_indent_map(dIndentMap)
+
+    def test_rule_100(self):
+        oRule = constant.rule_100()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, 'constant')
+        self.assertEqual(oRule.identifier, '100')
+
+        lExpected = [12, 13, 14, 15]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_100(self):
+        oRule = constant.rule_100()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])


### PR DESCRIPTION
Adding rule constant_100 to add a space after the assignment operator.

This addresses an issues where constant arrays were not being alignmed correctly.

