### PR TITLE
Fixing reporting of version when installed from git working copy.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if install.installing_from_git_repo():
         os.remove(sVersionInfoFileName)
     except FileNotFoundError:
         pass
-    
+
 if not os.path.exists(sVersionInfoFileName):
     install.create_version_info_file(sVersion, sShaNum)
 

--- a/setup.py
+++ b/setup.py
@@ -5,35 +5,21 @@ from setuptools import find_packages
 import os
 
 from vsg import version
+from vsg import install
 
 sVersionInfoFileName = os.path.join('vsg', 'version_info.py')
 
-if not os.path.exists(sVersionInfoFileName):
+sVersion, sShaNum = version.get_version_info()
 
-    sVersion, sShaNum = version.get_version_info(version.sVersion, None)
-
-    lVersionInfo = []
-    lVersionInfo.append('sVersion = \'' + str(sVersion) + "'")
-    lVersionInfo.append('sShaNum = \'' + str(sShaNum) + "'")
-
-    with open(sVersionInfoFileName, 'w') as oFile:
-        for sLine in lVersionInfo:
-            oFile.write(sLine + '\n')
-    oFile.close()
-
-    sInstallVersion = sVersion
-    bRemoveVersionFile = True
-
-else:
-
-    from vsg import version_info
-
+if install.installing_from_git_repo():
     try:
-        sInstallVersion = version_info.sVersion
-    except AttributeError:
-        sInstallVersion = version.sVersion
+        os.remove(sVersionInfoFileName)
+    except FileNotFoundError:
+        pass
+    
+if not os.path.exists(sVersionInfoFileName):
+    install.create_version_info_file(sVersion, sShaNum)
 
-    bRemoveVersionFile = False
 
 def readme():
     with open('README.rst') as f:
@@ -41,7 +27,7 @@ def readme():
 
 setup(
   name='vsg',
-  version=str(sInstallVersion),
+  version=str(sVersion),
   description='VHDL Style Guide',
   long_description=readme(),
   classifiers=[
@@ -76,7 +62,3 @@ setup(
     ]
   }
 )
-
-### Cleanup version information
-if bRemoveVersionFile:
-    os.remove(sVersionInfoFileName)

--- a/vsg/install.py
+++ b/vsg/install.py
@@ -1,0 +1,22 @@
+
+import os
+
+
+def installing_from_git_repo():
+    sPath = os.path.dirname(__file__)
+    if os.path.isdir(os.path.join(sPath, '..', '.git')):
+        return True
+    return False
+
+
+def create_version_info_file(sVersion, sShaNum):
+    sVersionInfoFileName = os.path.join(os.path.dirname(__file__), 'version_info.py')
+
+    lVersionInfo = []
+    lVersionInfo.append('sVersion = \'' + str(sVersion) + "'")
+    lVersionInfo.append('sShaNum = \'' + str(sShaNum) + "'")
+
+    with open(sVersionInfoFileName, 'w') as oFile:
+        for sLine in lVersionInfo:
+            oFile.write(sLine + '\n')
+    oFile.close()

--- a/vsg/version.py
+++ b/vsg/version.py
@@ -2,24 +2,14 @@
 import subprocess
 import os
 
-sVersion = '3.11.0'
-
-try:
-    from vsg import version_info
-    try:
-        sVersion = version_info.sVersion
-    except AttributeError:
-        pass
-    sShaNum = version_info.sShaNum
-except ImportError:
-    sShaNum = None
+from vsg import install
 
 
-def print_version(oCommandLineArguments, sVersion=sVersion, sShaNum=sShaNum):
+def print_version(oCommandLineArguments):
 
     if (oCommandLineArguments.version):
 
-        sVersion, sShaNum = get_version_info(sVersion, sShaNum)
+        sVersion, sShaNum = get_version_info()
 
         print('VHDL Style Guide (VSG) version: ' + str(sVersion))
 
@@ -27,28 +17,56 @@ def print_version(oCommandLineArguments, sVersion=sVersion, sShaNum=sShaNum):
 
         exit(0)
 
-def get_version_info(sVersion, sShaNum):
 
-    if sVersion is not None and sShaNum is not None:
-        return sVersion, sShaNum
+def get_version_info():
 
-    sReturnPath = os.getcwd()
-    sPath = os.path.dirname(__file__)
-    if not os.path.isdir(os.path.join(sPath, '..', '.git')):
+    sVersion = '3.0.0'
+
+    if reporting_from_zip_file():
         return sVersion + '+zip.file', 'Unknown.  Installed via zip file.'
 
-    try:
+    if installed():
+        from vsg import version_info
+        return version_info.sVersion, version_info.sShaNum
+
+    if reporting_from_git_repo():
+        sReturnPath = os.getcwd()
+        sPath = os.path.dirname(__file__)
         os.chdir(sPath)
         lActual = subprocess.check_output(['git', 'describe', '--tags'])
         lActual = str(lActual.decode('utf-8')).split('\n')
         lVersion = lActual[0].split('-')
         try:
             sVersion = str(lVersion[0]) + '.dev' + str(lVersion[1])
-            sShaNum = str(lVersion[-1])
+            sShaNum = str(lVersion[-1][1:])
         except IndexError:
             sVersion = str(lVersion[0])
+            lActual = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])
+            lActual = str(lActual.decode('utf-8')).split('\n')
+            sShaNum = str(lActual[0])
         os.chdir(sReturnPath)
         return sVersion, sShaNum
-    except subprocess.CalledProcessError:
-        os.chdir(sReturnPath)
-        return sVersion + '+zip.file', 'Unknown.  Installed via zip file.'
+
+
+def reporting_from_git_repo():
+    sPath = os.path.dirname(__file__)
+    if os.path.isdir(os.path.join(sPath, '..', '.git')):
+        return True
+    return False
+
+
+def installed():
+    if not reporting_from_git_repo() and version_info_file_exists():
+        return True
+    return False
+
+
+def reporting_from_zip_file():
+    if not reporting_from_git_repo() and not installed():
+        return True
+    return False
+
+
+def version_info_file_exists():
+    sVersionInfoFileName = os.path.join('vsg', 'version_info.py')
+    return os.path.exists(sVersionInfoFileName)

--- a/vsg/version.py
+++ b/vsg/version.py
@@ -2,8 +2,6 @@
 import subprocess
 import os
 
-from vsg import install
-
 
 def print_version(oCommandLineArguments):
 


### PR DESCRIPTION
Once VSG was installed from a git repo, the version would not update due to the version_info.py file being present.
Code was updated to handle this case,

Resolves #587
