### PR TITLE
Updates for issue #784:

### DIFF
--- a/docs/architecture_rules.rst
+++ b/docs/architecture_rules.rst
@@ -756,6 +756,31 @@ This rule checks for a blank line below the end architecture statement.
 
    library ieee;
 
+architecture_400
+################
+
+|phase_5| |error| |alignment|
+
+This rule checks the colons are in the same column for all attribute specifications.
+
+|configuring_keyword_alignment_rules_link|
+
+**Violation**
+
+.. code-block:: vhdl
+
+     attribute mark_debug of wr_en : signal is "true";
+     attribute mark_debug of almost_empty : signal is "true";
+     attribute mark_debug of full : signal is "true";
+
+**Fix**
+
+.. code-block:: vhdl
+
+     attribute mark_debug of wr_en        : signal is "true";
+     attribute mark_debug of almost_empty : signal is "true";
+     attribute mark_debug of full         : signal is "true";
+
 architecture_600
 ################
 

--- a/docs/block_rules.rst
+++ b/docs/block_rules.rst
@@ -463,6 +463,31 @@ This rule checks the colons are in the same column for all declarations in the b
    constant c_period  : time;
    file my_test_input : my_file_type;
 
+block_402
+#########
+
+|phase_5| |error| |alignment|
+
+This rule checks the colons are in the same column for all attribute specifications.
+
+|configuring_keyword_alignment_rules_link|
+
+**Violation**
+
+.. code-block:: vhdl
+
+     attribute mark_debug of wr_en : signal is "true";
+     attribute mark_debug of almost_empty : signal is "true";
+     attribute mark_debug of full : signal is "true";
+
+**Fix**
+
+.. code-block:: vhdl
+
+     attribute mark_debug of wr_en        : signal is "true";
+     attribute mark_debug of almost_empty : signal is "true";
+     attribute mark_debug of full         : signal is "true";
+
 block_500
 #########
 

--- a/docs/package_body_rules.rst
+++ b/docs/package_body_rules.rst
@@ -301,6 +301,31 @@ This rule checks the colons are in the same column for all declarations in the p
 
    end package my_package;
 
+package_body_402
+################
+
+|phase_5| |error| |alignment|
+
+This rule checks the colons are in the same column for all attribute specifications.
+
+|configuring_keyword_alignment_rules_link|
+
+**Violation**
+
+.. code-block:: vhdl
+
+     attribute mark_debug of wr_en : signal is "true";
+     attribute mark_debug of almost_empty : signal is "true";
+     attribute mark_debug of full : signal is "true";
+
+**Fix**
+
+.. code-block:: vhdl
+
+     attribute mark_debug of wr_en        : signal is "true";
+     attribute mark_debug of almost_empty : signal is "true";
+     attribute mark_debug of full         : signal is "true";
+
 package_body_500
 ################
 

--- a/docs/package_rules.rst
+++ b/docs/package_rules.rst
@@ -484,3 +484,28 @@ This rule checks the alignment of inline comments in the package declarative par
 
    end package my_package;
 
+package_402
+###########
+
+|phase_5| |error| |alignment|
+
+This rule checks the colons are in the same column for all attribute specifications.
+
+|configuring_keyword_alignment_rules_link|
+
+**Violation**
+
+.. code-block:: vhdl
+
+     attribute mark_debug of wr_en : signal is "true";
+     attribute mark_debug of almost_empty : signal is "true";
+     attribute mark_debug of full : signal is "true";
+
+**Fix**
+
+.. code-block:: vhdl
+
+     attribute mark_debug of wr_en        : signal is "true";
+     attribute mark_debug of almost_empty : signal is "true";
+     attribute mark_debug of full         : signal is "true";
+

--- a/docs/process_rules.rst
+++ b/docs/process_rules.rst
@@ -1056,6 +1056,31 @@ Following extra configurations are supported:
    rd_en      <= '0';
    v_variable := 10;
 
+process_401
+###########
+
+|phase_5| |error| |alignment|
+
+This rule checks the colons are in the same column for all attribute specifications.
+
+|configuring_keyword_alignment_rules_link|
+
+**Violation**
+
+.. code-block:: vhdl
+
+     attribute mark_debug of wr_en : signal is "true";
+     attribute mark_debug of almost_empty : signal is "true";
+     attribute mark_debug of full : signal is "true";
+
+**Fix**
+
+.. code-block:: vhdl
+
+     attribute mark_debug of wr_en        : signal is "true";
+     attribute mark_debug of almost_empty : signal is "true";
+     attribute mark_debug of full         : signal is "true";
+
 process_600
 ###########
 

--- a/docs/subprogram_body_rules.rst
+++ b/docs/subprogram_body_rules.rst
@@ -183,3 +183,28 @@ Following extra configurations are supported:
    rd_en      <= '0';
    v_variable := 10;
 
+subprogram_body_401
+###################
+
+|phase_5| |error| |alignment|
+
+This rule checks the colons are in the same column for all attribute specifications.
+
+|configuring_keyword_alignment_rules_link|
+
+**Violation**
+
+.. code-block:: vhdl
+
+     attribute mark_debug of wr_en : signal is "true";
+     attribute mark_debug of almost_empty : signal is "true";
+     attribute mark_debug of full : signal is "true";
+
+**Fix**
+
+.. code-block:: vhdl
+
+     attribute mark_debug of wr_en        : signal is "true";
+     attribute mark_debug of almost_empty : signal is "true";
+     attribute mark_debug of full         : signal is "true";
+

--- a/vsg/rules/architecture/__init__.py
+++ b/vsg/rules/architecture/__init__.py
@@ -33,5 +33,7 @@ from .rule_033 import rule_033
 
 from .rule_200 import rule_200
 
+from .rule_400 import rule_400
+
 from .rule_600 import rule_600
 from .rule_601 import rule_601

--- a/vsg/rules/architecture/rule_400.py
+++ b/vsg/rules/architecture/rule_400.py
@@ -7,7 +7,7 @@ lAlign = []
 lAlign.append(token.entity_specification.colon)
 
 lUnless = []
-lUnless.append([token.subprogram_body.is_keyword,token.subprogram_body.begin_keyword])
+lUnless.append([token.subprogram_body.is_keyword, token.subprogram_body.begin_keyword])
 
 
 class rule_400(Rule):

--- a/vsg/rules/architecture/rule_400.py
+++ b/vsg/rules/architecture/rule_400.py
@@ -1,0 +1,38 @@
+
+from vsg.rules import align_tokens_in_region_between_tokens_unless_between_tokens as Rule
+
+from vsg import token
+
+lAlign = []
+lAlign.append(token.entity_specification.colon)
+
+lUnless = []
+lUnless.append([token.subprogram_body.is_keyword,token.subprogram_body.begin_keyword])
+
+
+class rule_400(Rule):
+    '''
+    This rule checks the colons are in the same column for all attribute specifications.
+
+    |configuring_keyword_alignment_rules_link|
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+         attribute mark_debug of wr_en : signal is "true";
+         attribute mark_debug of almost_empty : signal is "true";
+         attribute mark_debug of full : signal is "true";
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+         attribute mark_debug of wr_en        : signal is "true";
+         attribute mark_debug of almost_empty : signal is "true";
+         attribute mark_debug of full         : signal is "true";
+    '''
+
+    def __init__(self):
+        Rule.__init__(self, 'architecture', '400', lAlign, token.architecture_body.is_keyword, token.architecture_body.begin_keyword, lUnless)
+        self.solution = 'Align colon.'

--- a/vsg/rules/block/__init__.py
+++ b/vsg/rules/block/__init__.py
@@ -23,6 +23,7 @@ from .rule_302 import rule_302
 
 from .rule_400 import rule_400
 from .rule_401 import rule_401
+from .rule_402 import rule_402
 
 from .rule_500 import rule_500
 from .rule_501 import rule_501

--- a/vsg/rules/block/rule_402.py
+++ b/vsg/rules/block/rule_402.py
@@ -1,0 +1,38 @@
+
+from vsg.rules import align_tokens_in_region_between_tokens_unless_between_tokens as Rule
+
+from vsg import token
+
+lAlign = []
+lAlign.append(token.entity_specification.colon)
+
+lUnless = []
+lUnless.append([token.subprogram_body.is_keyword,token.subprogram_body.begin_keyword])
+
+
+class rule_402(Rule):
+    '''
+    This rule checks the colons are in the same column for all attribute specifications.
+
+    |configuring_keyword_alignment_rules_link|
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+         attribute mark_debug of wr_en : signal is "true";
+         attribute mark_debug of almost_empty : signal is "true";
+         attribute mark_debug of full : signal is "true";
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+         attribute mark_debug of wr_en        : signal is "true";
+         attribute mark_debug of almost_empty : signal is "true";
+         attribute mark_debug of full         : signal is "true";
+    '''
+
+    def __init__(self):
+        Rule.__init__(self, 'block', '402', lAlign, token.block_statement.block_keyword, token.block_statement.begin_keyword, lUnless)
+        self.solution = 'Align colon.'

--- a/vsg/rules/block/rule_402.py
+++ b/vsg/rules/block/rule_402.py
@@ -7,7 +7,7 @@ lAlign = []
 lAlign.append(token.entity_specification.colon)
 
 lUnless = []
-lUnless.append([token.subprogram_body.is_keyword,token.subprogram_body.begin_keyword])
+lUnless.append([token.subprogram_body.is_keyword, token.subprogram_body.begin_keyword])
 
 
 class rule_402(Rule):

--- a/vsg/rules/package/__init__.py
+++ b/vsg/rules/package/__init__.py
@@ -21,3 +21,4 @@ from .rule_019 import rule_019
 
 from .rule_400 import rule_400
 from .rule_401 import rule_401
+from .rule_402 import rule_402

--- a/vsg/rules/package/rule_402.py
+++ b/vsg/rules/package/rule_402.py
@@ -10,7 +10,7 @@ oStart = token.package_declaration.is_keyword
 oEnd = token.package_declaration.end_keyword
 
 lUnless = []
-lUnless.append([token.subprogram_body.is_keyword,token.subprogram_body.begin_keyword])
+lUnless.append([token.subprogram_body.is_keyword, token.subprogram_body.begin_keyword])
 
 
 class rule_402(Rule):

--- a/vsg/rules/package/rule_402.py
+++ b/vsg/rules/package/rule_402.py
@@ -1,0 +1,41 @@
+
+from vsg.rules import align_tokens_in_region_between_tokens_unless_between_tokens as Rule
+
+from vsg import token
+
+lAlign = []
+lAlign.append(token.entity_specification.colon)
+
+oStart = token.package_declaration.is_keyword
+oEnd = token.package_declaration.end_keyword
+
+lUnless = []
+lUnless.append([token.subprogram_body.is_keyword,token.subprogram_body.begin_keyword])
+
+
+class rule_402(Rule):
+    '''
+    This rule checks the colons are in the same column for all attribute specifications.
+
+    |configuring_keyword_alignment_rules_link|
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+         attribute mark_debug of wr_en : signal is "true";
+         attribute mark_debug of almost_empty : signal is "true";
+         attribute mark_debug of full : signal is "true";
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+         attribute mark_debug of wr_en        : signal is "true";
+         attribute mark_debug of almost_empty : signal is "true";
+         attribute mark_debug of full         : signal is "true";
+    '''
+
+    def __init__(self):
+        Rule.__init__(self, 'package', '402', lAlign, oStart, oEnd, lUnless)
+        self.solution = 'Align colon.'

--- a/vsg/rules/package_body/__init__.py
+++ b/vsg/rules/package_body/__init__.py
@@ -16,6 +16,7 @@ from .rule_301 import rule_301
 
 from .rule_400 import rule_400
 from .rule_401 import rule_401
+from .rule_402 import rule_402
 
 from .rule_500 import rule_500
 from .rule_501 import rule_501

--- a/vsg/rules/package_body/rule_402.py
+++ b/vsg/rules/package_body/rule_402.py
@@ -1,0 +1,38 @@
+
+from vsg.rules import align_tokens_in_region_between_tokens_unless_between_tokens as Rule
+
+from vsg import token
+
+lAlign = []
+lAlign.append(token.entity_specification.colon)
+
+lUnless = []
+lUnless.append([token.subprogram_body.is_keyword,token.subprogram_body.begin_keyword])
+
+
+class rule_402(Rule):
+    '''
+    This rule checks the colons are in the same column for all attribute specifications.
+
+    |configuring_keyword_alignment_rules_link|
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+         attribute mark_debug of wr_en : signal is "true";
+         attribute mark_debug of almost_empty : signal is "true";
+         attribute mark_debug of full : signal is "true";
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+         attribute mark_debug of wr_en        : signal is "true";
+         attribute mark_debug of almost_empty : signal is "true";
+         attribute mark_debug of full         : signal is "true";
+    '''
+
+    def __init__(self):
+        Rule.__init__(self, 'package_body', '402', lAlign, token.package_body.is_keyword, token.package_body.end_keyword, lUnless)
+        self.solution = 'Align colon.'

--- a/vsg/rules/package_body/rule_402.py
+++ b/vsg/rules/package_body/rule_402.py
@@ -7,7 +7,7 @@ lAlign = []
 lAlign.append(token.entity_specification.colon)
 
 lUnless = []
-lUnless.append([token.subprogram_body.is_keyword,token.subprogram_body.begin_keyword])
+lUnless.append([token.subprogram_body.is_keyword, token.subprogram_body.begin_keyword])
 
 
 class rule_402(Rule):

--- a/vsg/rules/process/__init__.py
+++ b/vsg/rules/process/__init__.py
@@ -37,5 +37,6 @@ from .rule_035 import rule_035
 from .rule_036 import rule_036
 
 from .rule_400 import rule_400
+from .rule_401 import rule_401
 
 from .rule_600 import rule_600

--- a/vsg/rules/process/rule_401.py
+++ b/vsg/rules/process/rule_401.py
@@ -1,0 +1,41 @@
+
+from vsg.rules import align_tokens_in_region_between_tokens_unless_between_tokens as Rule
+
+from vsg import token
+
+lAlign = []
+lAlign.append(token.entity_specification.colon)
+
+oStart = token.process_statement.process_keyword
+oEnd = token.process_statement.begin_keyword
+
+lUnless = []
+lUnless.append([token.subprogram_body.is_keyword,token.subprogram_body.begin_keyword])
+
+
+class rule_401(Rule):
+    '''
+    This rule checks the colons are in the same column for all attribute specifications.
+
+    |configuring_keyword_alignment_rules_link|
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+         attribute mark_debug of wr_en : signal is "true";
+         attribute mark_debug of almost_empty : signal is "true";
+         attribute mark_debug of full : signal is "true";
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+         attribute mark_debug of wr_en        : signal is "true";
+         attribute mark_debug of almost_empty : signal is "true";
+         attribute mark_debug of full         : signal is "true";
+    '''
+
+    def __init__(self):
+        Rule.__init__(self, 'process', '401', lAlign, oStart, oEnd, lUnless)
+        self.solution = 'align colon.'

--- a/vsg/rules/process/rule_401.py
+++ b/vsg/rules/process/rule_401.py
@@ -10,7 +10,7 @@ oStart = token.process_statement.process_keyword
 oEnd = token.process_statement.begin_keyword
 
 lUnless = []
-lUnless.append([token.subprogram_body.is_keyword,token.subprogram_body.begin_keyword])
+lUnless.append([token.subprogram_body.is_keyword, token.subprogram_body.begin_keyword])
 
 
 class rule_401(Rule):

--- a/vsg/rules/subprogram_body/__init__.py
+++ b/vsg/rules/subprogram_body/__init__.py
@@ -6,3 +6,4 @@ from .rule_204 import rule_204
 from .rule_205 import rule_205
 
 from .rule_400 import rule_400
+from .rule_401 import rule_401

--- a/vsg/rules/subprogram_body/rule_401.py
+++ b/vsg/rules/subprogram_body/rule_401.py
@@ -1,0 +1,40 @@
+
+from vsg.rules import align_tokens_in_region_between_tokens_unless_between_tokens as Rule
+
+from vsg import token
+
+lAlign = []
+lAlign.append(token.entity_specification.colon)
+
+oStart = token.subprogram_body.is_keyword
+oEnd = token.subprogram_body.begin_keyword
+
+lUnless = []
+
+
+class rule_401(Rule):
+    '''
+    This rule checks the colons are in the same column for all attribute specifications.
+
+    |configuring_keyword_alignment_rules_link|
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+         attribute mark_debug of wr_en : signal is "true";
+         attribute mark_debug of almost_empty : signal is "true";
+         attribute mark_debug of full : signal is "true";
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+         attribute mark_debug of wr_en        : signal is "true";
+         attribute mark_debug of almost_empty : signal is "true";
+         attribute mark_debug of full         : signal is "true";
+    '''
+
+    def __init__(self):
+        Rule.__init__(self, 'subprogram_body', '401', lAlign, oStart, oEnd, lUnless)
+        self.solution = 'Align colon.'

--- a/vsg/tests/architecture/rule_400_test_input.fixed.vhd
+++ b/vsg/tests/architecture/rule_400_test_input.fixed.vhd
@@ -1,0 +1,11 @@
+
+architecture RTL of FIFO is
+
+  attribute mark_debug of wr_en        : signal is "true";
+  attribute mark_debug of almost_empty : signal is "true";
+  attribute mark_debug of full         : signal is "true";
+
+begin
+
+end architecture RTL;
+

--- a/vsg/tests/architecture/rule_400_test_input.vhd
+++ b/vsg/tests/architecture/rule_400_test_input.vhd
@@ -1,0 +1,11 @@
+
+architecture RTL of FIFO is
+
+  attribute mark_debug of wr_en : signal is "true";
+  attribute mark_debug of almost_empty : signal is "true";
+  attribute mark_debug of full : signal is "true";
+
+begin
+
+end architecture RTL;
+

--- a/vsg/tests/architecture/test_rule_400.py
+++ b/vsg/tests/architecture/test_rule_400.py
@@ -1,0 +1,48 @@
+
+import os
+import unittest
+
+from vsg.rules import architecture
+from vsg import vhdlFile
+from vsg.tests import utils
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError =vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir,'rule_400_test_input.vhd'))
+
+dIndentMap = utils.read_indent_file()
+
+lExpected = []
+lExpected.append('')
+utils.read_file(os.path.join(sTestDir, 'rule_400_test_input.fixed.vhd'), lExpected)
+
+
+class test_architecture_rule(unittest.TestCase):
+
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+        self.oFile.set_indent_map(dIndentMap)
+
+    def test_rule_400(self):
+        oRule = architecture.rule_400()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, 'architecture')
+        self.assertEqual(oRule.identifier, '400')
+
+        lExpected = [4, 6]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_400(self):
+        oRule = architecture.rule_400()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/vsg/tests/block/rule_402_test_input.fixed.vhd
+++ b/vsg/tests/block/rule_402_test_input.fixed.vhd
@@ -1,0 +1,15 @@
+
+architecture RTL of FIFO is
+
+begin
+
+  BLOCK_LABEL : block is
+
+    attribute mark_debug of wr_en        : signal is "true";
+    attribute mark_debug of almost_empty : signal is "true";
+    attribute mark_debug of full         : signal is "true";
+
+  begin
+  end block BLOCK_LABEL;
+
+end architecture RTL;

--- a/vsg/tests/block/rule_402_test_input.vhd
+++ b/vsg/tests/block/rule_402_test_input.vhd
@@ -1,0 +1,15 @@
+
+architecture RTL of FIFO is
+
+begin
+
+  BLOCK_LABEL : block is
+
+    attribute mark_debug of wr_en : signal is "true";
+    attribute mark_debug of almost_empty : signal is "true";
+    attribute mark_debug of full : signal is "true";
+
+  begin
+  end block BLOCK_LABEL;
+
+end architecture RTL;

--- a/vsg/tests/block/test_rule_402.py
+++ b/vsg/tests/block/test_rule_402.py
@@ -1,0 +1,45 @@
+
+import os
+import unittest
+
+from vsg.rules import block
+from vsg import vhdlFile
+from vsg.tests import utils
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError =vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir,'rule_402_test_input.vhd'))
+
+lExpected = []
+lExpected.append('')
+utils.read_file(os.path.join(sTestDir, 'rule_402_test_input.fixed.vhd'), lExpected, False)
+
+
+class test_block_rule(unittest.TestCase):
+
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_402(self):
+        oRule = block.rule_402()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, 'block')
+        self.assertEqual(oRule.identifier, '402')
+
+        lExpected = [8, 10]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_402(self):
+        oRule = block.rule_402()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/vsg/tests/package/rule_402_test_input.fixed.vhd
+++ b/vsg/tests/package/rule_402_test_input.fixed.vhd
@@ -1,0 +1,9 @@
+
+package fifo_pkg is
+
+  attribute mark_debug of wr_en        : signal is "true";
+  attribute mark_debug of almost_empty : signal is "true";
+  attribute mark_debug of full         : signal is "true";
+
+end package;
+

--- a/vsg/tests/package/rule_402_test_input.vhd
+++ b/vsg/tests/package/rule_402_test_input.vhd
@@ -1,0 +1,9 @@
+
+package fifo_pkg is
+
+  attribute mark_debug of wr_en : signal is "true";
+  attribute mark_debug of almost_empty : signal is "true";
+  attribute mark_debug of full : signal is "true";
+
+end package;
+

--- a/vsg/tests/package/test_rule_402.py
+++ b/vsg/tests/package/test_rule_402.py
@@ -1,0 +1,48 @@
+
+import os
+import unittest
+
+from vsg.rules import package
+from vsg import vhdlFile
+from vsg.tests import utils
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError =vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir,'rule_402_test_input.vhd'))
+
+dIndentMap = utils.read_indent_file()
+
+lExpected = []
+lExpected.append('')
+utils.read_file(os.path.join(sTestDir, 'rule_402_test_input.fixed.vhd'), lExpected, bStrip=False)
+
+
+class test_package_rule(unittest.TestCase):
+
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+        self.oFile.set_indent_map(dIndentMap)
+
+    def test_rule_402(self):
+        oRule = package.rule_402()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, 'package')
+        self.assertEqual(oRule.identifier, '402')
+
+        lExpected = [4, 6]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_402(self):
+        oRule = package.rule_402()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/vsg/tests/package_body/rule_402_test_input.fixed.vhd
+++ b/vsg/tests/package_body/rule_402_test_input.fixed.vhd
@@ -1,0 +1,18 @@
+
+package body RTL is
+
+  attribute mark_debug of wr_en        : signal is "true";
+  attribute mark_debug of almost_empty : signal is "true";
+  attribute mark_debug of full         : signal is "true";
+
+  procedure rst_procedure is
+
+    attribute mark_debug of wr_en : signal is "true";
+    attribute mark_debug of almost_empty : signal is "true";
+    attribute mark_debug of full : signal is "true";
+
+  begin
+  end procedure;
+
+end package body RTL;
+

--- a/vsg/tests/package_body/rule_402_test_input.vhd
+++ b/vsg/tests/package_body/rule_402_test_input.vhd
@@ -1,0 +1,18 @@
+
+package body RTL is
+
+  attribute mark_debug of wr_en : signal is "true";
+  attribute mark_debug of almost_empty : signal is "true";
+  attribute mark_debug of full : signal is "true";
+
+  procedure rst_procedure is
+
+    attribute mark_debug of wr_en : signal is "true";
+    attribute mark_debug of almost_empty : signal is "true";
+    attribute mark_debug of full : signal is "true";
+
+  begin
+  end procedure;
+
+end package body RTL;
+

--- a/vsg/tests/package_body/test_rule_402.py
+++ b/vsg/tests/package_body/test_rule_402.py
@@ -1,0 +1,45 @@
+
+import os
+import unittest
+
+from vsg.rules import package_body
+from vsg import vhdlFile
+from vsg.tests import utils
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError =vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir,'rule_402_test_input.vhd'))
+
+lExpected = []
+lExpected.append('')
+utils.read_file(os.path.join(sTestDir, 'rule_402_test_input.fixed.vhd'), lExpected)
+
+
+class test_package_body_rule(unittest.TestCase):
+
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_402(self):
+        oRule = package_body.rule_402()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, 'package_body')
+        self.assertEqual(oRule.identifier, '402')
+
+        lExpected = [4, 6]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_402(self):
+        oRule = package_body.rule_402()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/vsg/tests/process/rule_401_test_input.fixed.vhd
+++ b/vsg/tests/process/rule_401_test_input.fixed.vhd
@@ -1,0 +1,34 @@
+
+architecture RTL of FIFO is
+
+  procedure rst_procedure is
+
+    attribute mark_debug of wr_en : signal is "true";
+    attribute mark_debug of almost_empty : signal is "true";
+    attribute mark_debug of full : signal is "true";
+
+  begin
+  end procedure;
+
+begin
+
+  PROC_1 : process
+
+    attribute mark_debug of wr_en        : signal is "true";
+    attribute mark_debug of almost_empty : signal is "true";
+    attribute mark_debug of full         : signal is "true";
+
+    procedure rst_procedure is
+
+      attribute mark_debug of wr_en : signal is "true";
+      attribute mark_debug of almost_empty : signal is "true";
+      attribute mark_debug of full : signal is "true";
+
+    begin
+    end procedure;
+
+  begin
+
+  end process;
+
+end architecture RTL;

--- a/vsg/tests/process/rule_401_test_input.vhd
+++ b/vsg/tests/process/rule_401_test_input.vhd
@@ -1,0 +1,34 @@
+
+architecture RTL of FIFO is
+
+  procedure rst_procedure is
+
+    attribute mark_debug of wr_en : signal is "true";
+    attribute mark_debug of almost_empty : signal is "true";
+    attribute mark_debug of full : signal is "true";
+
+  begin
+  end procedure;
+
+begin
+
+  PROC_1 : process
+
+    attribute mark_debug of wr_en : signal is "true";
+    attribute mark_debug of almost_empty : signal is "true";
+    attribute mark_debug of full : signal is "true";
+
+    procedure rst_procedure is
+
+      attribute mark_debug of wr_en : signal is "true";
+      attribute mark_debug of almost_empty : signal is "true";
+      attribute mark_debug of full : signal is "true";
+
+    begin
+    end procedure;
+
+  begin
+
+  end process;
+
+end architecture RTL;

--- a/vsg/tests/process/test_rule_401.py
+++ b/vsg/tests/process/test_rule_401.py
@@ -1,0 +1,45 @@
+
+import os
+import unittest
+
+from vsg.rules import process
+from vsg import vhdlFile
+from vsg.tests import utils
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError =vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir,'rule_401_test_input.vhd'))
+
+lExpected_all = []
+lExpected_all.append('')
+utils.read_file(os.path.join(sTestDir, 'rule_401_test_input.fixed.vhd'), lExpected_all)
+
+
+class test_rule(unittest.TestCase):
+
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_401(self):
+        oRule = process.rule_401()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, 'process')
+        self.assertEqual(oRule.identifier, '401')
+
+        lExpected = [17, 19]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_401(self):
+        oRule = process.rule_401()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_all, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/vsg/tests/subprogram_body/rule_401_test_input.fixed.vhd
+++ b/vsg/tests/subprogram_body/rule_401_test_input.fixed.vhd
@@ -1,0 +1,70 @@
+architecture arc of ent is
+
+    signal a : std_logic_vector(7 downto 0);
+    signal b : std_logic_vector(7 downto 0);
+
+    procedure rst_procedure is
+
+      attribute mark_debug of wr_en        : signal is "true";
+      attribute mark_debug of almost_empty : signal is "true";
+      attribute mark_debug of full         : signal is "true";
+
+    begin
+    end procedure;
+
+begin
+
+    proc_p : process (clk_i, rst_n_i)
+        procedure rst_procedure is
+
+          attribute mark_debug of wr_en        : signal is "true";
+          attribute mark_debug of almost_empty : signal is "true";
+          attribute mark_debug of full         : signal is "true";
+
+        begin
+        end procedure;
+
+        procedure rst_procedure is
+
+          attribute mark_debug of wr_en        : signal is "true";
+          attribute mark_debug of almost_empty : signal is "true";
+          attribute mark_debug of full         : signal is "true";
+
+        begin
+        end procedure;
+
+        procedure rst_procedure is
+
+          attribute mark_debug of wr_en        : signal is "true";
+          attribute mark_debug of almost_empty : signal is "true";
+          attribute mark_debug of full         : signal is "true";
+
+        begin
+        end procedure;
+
+    begin
+    end process proc_p;
+
+end architecture arc;
+
+package body my_package is
+
+  procedure rst_procedure is
+
+    attribute mark_debug of wr_en        : signal is "true";
+    attribute mark_debug of almost_empty : signal is "true";
+    attribute mark_debug of full         : signal is "true";
+
+  begin
+  end procedure;
+
+  procedure rst_procedure is
+
+    attribute mark_debug of wr_en        : signal is "true";
+    attribute mark_debug of almost_empty : signal is "true";
+    attribute mark_debug of full         : signal is "true";
+
+  begin
+  end procedure;
+
+end package body;

--- a/vsg/tests/subprogram_body/rule_401_test_input.vhd
+++ b/vsg/tests/subprogram_body/rule_401_test_input.vhd
@@ -1,0 +1,70 @@
+architecture arc of ent is
+
+    signal a : std_logic_vector(7 downto 0);
+    signal b : std_logic_vector(7 downto 0);
+
+    procedure rst_procedure is
+
+      attribute mark_debug of wr_en : signal is "true";
+      attribute mark_debug of almost_empty : signal is "true";
+      attribute mark_debug of full : signal is "true";
+
+    begin
+    end procedure;
+
+begin
+
+    proc_p : process (clk_i, rst_n_i)
+        procedure rst_procedure is
+
+          attribute mark_debug of wr_en : signal is "true";
+          attribute mark_debug of almost_empty : signal is "true";
+          attribute mark_debug of full : signal is "true";
+
+        begin
+        end procedure;
+
+        procedure rst_procedure is
+
+          attribute mark_debug of wr_en : signal is "true";
+          attribute mark_debug of almost_empty : signal is "true";
+          attribute mark_debug of full : signal is "true";
+
+        begin
+        end procedure;
+
+        procedure rst_procedure is
+
+          attribute mark_debug of wr_en : signal is "true";
+          attribute mark_debug of almost_empty : signal is "true";
+          attribute mark_debug of full : signal is "true";
+
+        begin
+        end procedure;
+
+    begin
+    end process proc_p;
+
+end architecture arc;
+
+package body my_package is
+
+  procedure rst_procedure is
+
+    attribute mark_debug of wr_en : signal is "true";
+    attribute mark_debug of almost_empty : signal is "true";
+    attribute mark_debug of full : signal is "true";
+
+  begin
+  end procedure;
+
+  procedure rst_procedure is
+
+    attribute mark_debug of wr_en : signal is "true";
+    attribute mark_debug of almost_empty : signal is "true";
+    attribute mark_debug of full : signal is "true";
+
+  begin
+  end procedure;
+
+end package body;

--- a/vsg/tests/subprogram_body/test_rule_401.py
+++ b/vsg/tests/subprogram_body/test_rule_401.py
@@ -1,0 +1,45 @@
+
+import os
+import unittest
+
+from vsg.rules import subprogram_body
+from vsg import vhdlFile
+from vsg.tests import utils
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError =vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir,'rule_401_test_input.vhd'))
+
+lExpected_all = []
+lExpected_all.append('')
+utils.read_file(os.path.join(sTestDir, 'rule_401_test_input.fixed.vhd'), lExpected_all)
+
+
+class test_rule(unittest.TestCase):
+
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_401(self):
+        oRule = subprogram_body.rule_401()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, 'subprogram_body')
+        self.assertEqual(oRule.identifier, '401')
+
+        lExpected = [8, 10, 20, 22, 29, 31, 38, 40, 54, 56, 63, 65]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_401(self):
+        oRule = subprogram_body.rule_401()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_all, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])


### PR DESCRIPTION
Adding rules to align colons in attribute specifications:

  1)  Added documentation
  2)  Added tests
  3)  Added the following rules

      architecture_400
      block_402
      package_402
      process_401
      subprogram_body_401

Resolves #784
