### PR TITLE
Fix broken links to Subprogram Body Rules

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -55,7 +55,7 @@ Pull requests are always welcome.
 
 VSG was developed using a Test Driven Development (TDD) process.
 There are over 1000 tests which cover individual rules and other features of VSG.
-For each pull request, an accompaning test to validate the pull request would be appreciated.
+For each pull request, an accompanying test to validate the pull request would be appreciated.
 
 Refer to `Setting up a Development Environment <setting_up_a_development_environment.html#running-unit-tests>`_ for more information on how to get started.
 
@@ -68,5 +68,5 @@ This project uses the following open source tools to help with code quality:
 * *Codacy* and *Code Climate* to check for code style issues.
 * *Codcov* to check the code coverage of the tests.
 
-The results will be available on the pull request Github page.
+The results will be available on the pull request GitHub page.
 

--- a/docs/function_rules.rst
+++ b/docs/function_rules.rst
@@ -117,7 +117,7 @@ This rule checks for blank lines or comments above the **function** keyword.
 function_007
 ############
 
-This rule has been moved to rule `subprogram_body_205 <subprogram_rules.html#subprogram-body-205>`_.
+This rule has been moved to rule `subprogram_body_205 <subprogram_body_rules.html#subprogram-body-205>`_.
 
 function_008
 ############
@@ -425,22 +425,22 @@ This rule checks for a single space between the **end** and **function** keyword
 function_201
 ############
 
-This rule has been moved to rule `subprogram_body_201 <subprogram_rules.html#subprogram-body-201>`_.
+This rule has been moved to rule `subprogram_body_201 <subprogram_body_rules.html#subprogram-body-201>`_.
 
 function_202
 ############
 
-This rule has been moved to rule `subprogram_body_202 <subprogram_rules.html#subprogram-body-202>`_.
+This rule has been moved to rule `subprogram_body_202 <subprogram_body_rules.html#subprogram-body-202>`_.
 
 function_203
 ############
 
-This rule has been moved to rule `subprogram_body_203 <subprogram_rules.html#subprogram-body-203>`_.
+This rule has been moved to rule `subprogram_body_203 <subprogram_body_rules.html#subprogram-body-203>`_.
 
 function_204
 ############
 
-This rule has been moved to rule `subprogram_body_204 <subprogram_rules.html#subprogram-body-204>`_.
+This rule has been moved to rule `subprogram_body_204 <subprogram_body_rules.html#subprogram-body-204>`_.
 
 function_300
 ############

--- a/docs/procedure_rules.rst
+++ b/docs/procedure_rules.rst
@@ -452,27 +452,27 @@ This rule checks for blank lines or comments above the **procedure** keyword.
 procedure_201
 #############
 
-This rule has been moved to rule `subprogram_body_201 <subprogram_rules.html#subprogram-body-201>`_.
+This rule has been moved to rule `subprogram_body_201 <subprogram_body_rules.html#subprogram-body-201>`_.
 
 procedure_202
 #############
 
-This rule has been moved to rule `subprogram_body_202 <subprogram_rules.html#subprogram-body-202>`_.
+This rule has been moved to rule `subprogram_body_202 <subprogram_body_rules.html#subprogram-body-202>`_.
 
 procedure_203
 #############
 
-This rule has been moved to rule `subprogram_body_203 <subprogram_rules.html#subprogram-body-203>`_.
+This rule has been moved to rule `subprogram_body_203 <subprogram_body_rules.html#subprogram-body-203>`_.
 
 procedure_204
 #############
 
-This rule has been moved to rule `subprogram_body_204 <subprogram_rules.html#subprogram-body-204>`_.
+This rule has been moved to rule `subprogram_body_204 <subprogram_body_rules.html#subprogram-body-204>`_.
 
 procedure_205
 #############
 
-This rule has been moved to rule `subprogram_body_205 <subprogram_rules.html#subprogram-body-205>`_.
+This rule has been moved to rule `subprogram_body_205 <subprogram_body_rules.html#subprogram-body-205>`_.
 
 procedure_401
 #############

--- a/vsg/rules/function/rule_007.py
+++ b/vsg/rules/function/rule_007.py
@@ -4,7 +4,7 @@ from vsg.deprecated_rule import Rule
 
 class rule_007(Rule):
     '''
-    This rule has been moved to rule `subprogram_body_205 <subprogram_rules.html#subprogram-body-205>`_.
+    This rule has been moved to rule `subprogram_body_205 <subprogram_body_rules.html#subprogram-body-205>`_.
     '''
 
     def __init__(self):

--- a/vsg/rules/function/rule_201.py
+++ b/vsg/rules/function/rule_201.py
@@ -4,7 +4,7 @@ from vsg.deprecated_rule import Rule
 
 class rule_201(Rule):
     '''
-    This rule has been moved to rule `subprogram_body_201 <subprogram_rules.html#subprogram-body-201>`_.
+    This rule has been moved to rule `subprogram_body_201 <subprogram_body_rules.html#subprogram-body-201>`_.
     '''
 
     def __init__(self):

--- a/vsg/rules/function/rule_202.py
+++ b/vsg/rules/function/rule_202.py
@@ -4,7 +4,7 @@ from vsg.deprecated_rule import Rule
 
 class rule_202(Rule):
     '''
-    This rule has been moved to rule `subprogram_body_202 <subprogram_rules.html#subprogram-body-202>`_.
+    This rule has been moved to rule `subprogram_body_202 <subprogram_body_rules.html#subprogram-body-202>`_.
     '''
 
     def __init__(self):

--- a/vsg/rules/function/rule_203.py
+++ b/vsg/rules/function/rule_203.py
@@ -4,7 +4,7 @@ from vsg.deprecated_rule import Rule
 
 class rule_203(Rule):
     '''
-    This rule has been moved to rule `subprogram_body_203 <subprogram_rules.html#subprogram-body-203>`_.
+    This rule has been moved to rule `subprogram_body_203 <subprogram_body_rules.html#subprogram-body-203>`_.
     '''
 
     def __init__(self):

--- a/vsg/rules/function/rule_204.py
+++ b/vsg/rules/function/rule_204.py
@@ -4,7 +4,7 @@ from vsg.deprecated_rule import Rule
 
 class rule_204(Rule):
     '''
-    This rule has been moved to rule `subprogram_body_204 <subprogram_rules.html#subprogram-body-204>`_.
+    This rule has been moved to rule `subprogram_body_204 <subprogram_body_rules.html#subprogram-body-204>`_.
     '''
 
     def __init__(self):

--- a/vsg/rules/procedure/rule_201.py
+++ b/vsg/rules/procedure/rule_201.py
@@ -4,7 +4,7 @@ from vsg.deprecated_rule import Rule
 
 class rule_201(Rule):
     '''
-    This rule has been moved to rule `subprogram_body_201 <subprogram_rules.html#subprogram-body-201>`_.
+    This rule has been moved to rule `subprogram_body_201 <subprogram_body_rules.html#subprogram-body-201>`_.
     '''
 
     def __init__(self):

--- a/vsg/rules/procedure/rule_202.py
+++ b/vsg/rules/procedure/rule_202.py
@@ -4,7 +4,7 @@ from vsg.deprecated_rule import Rule
 
 class rule_202(Rule):
     '''
-    This rule has been moved to rule `subprogram_body_202 <subprogram_rules.html#subprogram-body-202>`_.
+    This rule has been moved to rule `subprogram_body_202 <subprogram_body_rules.html#subprogram-body-202>`_.
     '''
 
     def __init__(self):

--- a/vsg/rules/procedure/rule_203.py
+++ b/vsg/rules/procedure/rule_203.py
@@ -4,7 +4,7 @@ from vsg.deprecated_rule import Rule
 
 class rule_203(Rule):
     '''
-    This rule has been moved to rule `subprogram_body_203 <subprogram_rules.html#subprogram-body-203>`_.
+    This rule has been moved to rule `subprogram_body_203 <subprogram_body_rules.html#subprogram-body-203>`_.
     '''
 
     def __init__(self):

--- a/vsg/rules/procedure/rule_204.py
+++ b/vsg/rules/procedure/rule_204.py
@@ -4,7 +4,7 @@ from vsg.deprecated_rule import Rule
 
 class rule_204(Rule):
     '''
-    This rule has been moved to rule `subprogram_body_204 <subprogram_rules.html#subprogram-body-204>`_.
+    This rule has been moved to rule `subprogram_body_204 <subprogram_body_rules.html#subprogram-body-204>`_.
     '''
 
     def __init__(self):

--- a/vsg/rules/procedure/rule_205.py
+++ b/vsg/rules/procedure/rule_205.py
@@ -4,7 +4,7 @@ from vsg.deprecated_rule import Rule
 
 class rule_205(Rule):
     '''
-    This rule has been moved to rule `subprogram_body_205 <subprogram_rules.html#subprogram-body-205>`_.
+    This rule has been moved to rule `subprogram_body_205 <subprogram_body_rules.html#subprogram-body-205>`_.
     '''
 
     def __init__(self):


### PR DESCRIPTION
Fix broken links to Subprogram Body Rules.

Some rules were moved into the Subprogram Body Rules but the references from the old location to the new location were broken &mdash;this PR fixes that.

**PS: I just noticed an error in the contributing page I will also quickly fix that**
