### PR TITLE
Updates for issue #820:

### DIFF
--- a/vsg/rules/whitespace_between_tokens.py
+++ b/vsg/rules/whitespace_between_tokens.py
@@ -50,8 +50,9 @@ class Rule(whitespace.Rule):
                 self.analyze_no_whitespace_token(oToi)
 
     def analyze_no_whitespace_token(self, oToi):
-        iSpaces = self.extract_expected_number_of_spaces()
-        self.create_violation(oToi, iSpaces)
+        if self.number_of_spaces != 0:
+            iSpaces = self.extract_expected_number_of_spaces()
+            self.create_violation(oToi, iSpaces)
 
     def extract_expected_number_of_spaces(self):
         if self.number_of_spaces_is_an_integer():
@@ -125,10 +126,13 @@ class Rule(whitespace.Rule):
     def _fix_violation(self, oViolation):
         lTokens = oViolation.get_tokens()
         dAction = oViolation.get_action()
-        if isinstance(lTokens[1], parser.whitespace):
-            lTokens[1].set_value(' '*dAction['spaces'])
+        if self.number_of_spaces == 0:
+            lTokens = [lTokens[0], lTokens[2]]
         else:
-            rules_utils.insert_whitespace(lTokens, dAction['spaces'])
+            if isinstance(lTokens[1], parser.whitespace):
+                lTokens[1].set_value(' '*dAction['spaces'])
+            else:
+                rules_utils.insert_whitespace(lTokens, dAction['spaces'])
         oViolation.set_tokens(lTokens)
 
 

--- a/vsg/tests/generate/rule_002_test_input.fixed_w_0_spaces.vhd
+++ b/vsg/tests/generate/rule_002_test_input.fixed_w_0_spaces.vhd
@@ -1,0 +1,32 @@
+
+architecture RTL of FIFO is
+
+begin
+
+  FOR_LABEL: for i in 0 to 7 generate
+
+  end generate;
+
+  IF_LABEL: if a = '1' generate
+
+  end generate;
+
+  CASE_LABEL: case data generate
+
+  end generate;
+
+  -- Violations below
+
+  FOR_LABEL: for i in 0 to 7 generate
+
+  end generate;
+
+  IF_LABEL: if a = '1' generate
+
+  end generate;
+
+  CASE_LABEL: case data generate
+
+  end generate;
+
+end;

--- a/vsg/tests/generate/test_rule_002.py
+++ b/vsg/tests/generate/test_rule_002.py
@@ -14,6 +14,10 @@ lExpected = []
 lExpected.append('')
 utils.read_file(os.path.join(sTestDir, 'rule_002_test_input.fixed.vhd'), lExpected)
 
+lExpected_w_0_spaces = []
+lExpected_w_0_spaces.append('')
+utils.read_file(os.path.join(sTestDir, 'rule_002_test_input.fixed_w_0_spaces.vhd'), lExpected_w_0_spaces)
+
 
 class test_generate_rule(unittest.TestCase):
 
@@ -43,3 +47,26 @@ class test_generate_rule(unittest.TestCase):
 
         oRule.analyze(self.oFile)
         self.assertEqual(oRule.violations, [])
+
+    def test_rule_002_with_0_spaces(self):
+        oRule = generate.rule_002()
+        oRule.number_of_spaces = 0
+
+        lExpected = [6, 10, 14, 24, 28]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_002_with_0_spaces(self):
+        oRule = generate.rule_002()
+        oRule.number_of_spaces = 0
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_w_0_spaces, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])
+


### PR DESCRIPTION
Configuring whitespace to 0 would not enforce 0 whitespace.

  1)  Updated tests
  2)  Updated whitespace_between_tokens base rule

Resolves #820
