### PR TITLE
workaround: create junit result file even if some vhdl files can not parsed

### DIFF
--- a/vsg/__main__.py
+++ b/vsg/__main__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from cgi import test
 import sys
 import os
 import json
@@ -150,7 +151,11 @@ def main():
         fExitStatus = fExitStatus or fStatus
 
         if commandLineArguments.junit:
-            oJunitTestsuite.add_testcase(testCase)
+            # a file which can not be parsed ('Error: Unexpected token detected...') creates a None-value for testcase,
+            # which would lead to an error when generating junit results ('AttributeError: 'NoneType' object has no attribute 'failures')
+            # workaround: do not add None, so junit result file can still be created
+            if testCase is not None:
+                oJunitTestsuite.add_testcase(testCase)
 
         if commandLineArguments.json or commandLineArguments.quality_report:
             dJson['files'].append(dJsonEntry)

--- a/vsg/__main__.py
+++ b/vsg/__main__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from cgi import test
 import sys
 import os
 import json
@@ -150,12 +149,11 @@ def main():
         fStatus, testCase, dJsonEntry = tValue
         fExitStatus = fExitStatus or fStatus
 
-        if commandLineArguments.junit:
+        if commandLineArguments.junit and testCase is not None:
             # a file which can not be parsed ('Error: Unexpected token detected...') creates a None-value for testcase,
             # which would lead to an error when generating junit results ('AttributeError: 'NoneType' object has no attribute 'failures')
             # workaround: do not add None, so junit result file can still be created
-            if testCase is not None:
-                oJunitTestsuite.add_testcase(testCase)
+            oJunitTestsuite.add_testcase(testCase)
 
         if commandLineArguments.json or commandLineArguments.quality_report:
             dJson['files'].append(dJsonEntry)


### PR DESCRIPTION
**Description**
I want to run vsg on multiple files (file_list) and create a junit result file, but one of them is not parsable and no junit file is created.
I would like to skip unparsable files in the junit result file.

State a clear description of the problem and your solution:
a vhdl file which can not be parsed ('Error: Unexpected token detected...') creates a None-value for testcase, which would lead to an error when generating junit results ('AttributeError: 'NoneType' object has no attribute 'failures'); workaround: do not add None, so junit result file can still be created.