### PR TITLE
Updates for issue #831

### DIFF
--- a/vsg/apply_rules.py
+++ b/vsg/apply_rules.py
@@ -2,6 +2,7 @@
 import shutil
 
 from . import config
+from . import junit
 from . import rule_list
 from . import utils
 from . import vhdlFile
@@ -64,7 +65,7 @@ def apply_rules(commandLineArguments, oConfig, tIndexFileName):
         oVhdlFile = vhdlFile.vhdlFile(lFileContent, sFileName, eError)
     except ClassifyError as e:
         fExitStatus = True
-        testCase = None
+        testCase = create_junit_testcase(sFileName, e)
         dJsonEntry["file_path"] = sFileName
         dJsonEntry["violations"] = []
         sOutputStd = ''
@@ -135,3 +136,19 @@ def write_vhdl_file(oVhdlFile):
         print (err, "Could not write fixes back to file.")
 
 
+def create_junit_testcase(sVhdlFileName, oException):
+    '''
+    Creates JUnit XML file listing all violations found.
+
+    Parameters:
+
+      sVhdlFileName (string)
+
+    Returns: (junit testcase object)
+    '''
+    oTestcase = junit.testcase(sVhdlFileName, str(0), 'failure')
+    oFailure = junit.failure('Failure')
+    oFailure.add_text(oException.message)
+    oTestcase.add_failure(oFailure)
+
+    return oTestcase

--- a/vsg/tests/vsg/junit/parse_error.expected.xml
+++ b/vsg/tests/vsg/junit/parse_error.expected.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<testsuite errors="0" hostname="Rimmer" failures="1" timestamp="2018-12-07T03:10:28" tests="1" time="0" name="vhdl-style-guide">
+  <properties>
+  </properties>
+  <testcase name="vsg/tests/vsg/junit/parse_error.vhd" time="0" classname="failure">
+    <failure type="Failure">
+
+Error: Unexpected token detected while parsing architecture_body @ Line 4, Column 1 in file vsg/tests/vsg/junit/parse_error.vhd
+       Expecting : begin
+       Found     : end
+
+    </failure>
+  </testcase>
+  <system-out>
+  </system-out>
+  <system-err>
+  </system-err>
+</testsuite>

--- a/vsg/tests/vsg/junit/parse_error.vhd
+++ b/vsg/tests/vsg/junit/parse_error.vhd
@@ -1,0 +1,5 @@
+
+architecture rtl of fifo is
+
+end architecture;
+

--- a/vsg/tests/vsg/test_main.py
+++ b/vsg/tests/vsg/test_main.py
@@ -162,6 +162,44 @@ class testMain(unittest.TestCase):
         # Clean up
         utils.remove_file('vsg/tests/vsg/config_error.actual.xml')
 
+    @mock.patch('sys.stderr')
+    def test_junit_with_file_that_fails_to_parse(self, mock_stderr):
+#    def test_invalid_configuration(self):
+        utils.remove_file('vsg/tests/vsg/junit/parse_error.actual.xml')
+        lStdErr = []
+        lStdErr.append('Error: Unexpected token detected while parsing architecture_body @ Line 4, Column 1 in file vsg/tests/vsg/junit/parse_error.vhd')
+        lStdErr.append('       Expecting : begin')
+        lStdErr.append('       Found     : end')
+
+        lExpected = []
+        lExpected.append(mock.call('\n' + '\n'.join(lStdErr) + '\n'))
+        lExpected.append(mock.call('\n'))
+
+        sys.argv = ['vsg']
+        sys.argv.extend(['-f', 'vsg/tests/vsg/junit/parse_error.vhd'])
+        sys.argv.extend(['--junit', 'vsg/tests/vsg/junit/parse_error.actual.xml'])
+        sys.argv.extend(['-p 1'])
+
+        try:
+            __main__.main()
+        except SystemExit:
+            pass
+
+        mock_stderr.write.assert_has_calls(lExpected)
+
+        # Read in the expected JUnit XML file for comparison
+        lExpected = []
+        utils.read_file(os.path.join(os.path.dirname(__file__),'junit','parse_error.expected.xml'), lExpected)
+        # Read in the actual JUnit XML file for comparison
+        lActual = []
+        utils.read_file(os.path.join(os.path.dirname(__file__),'junit','parse_error.actual.xml'), lActual)
+        # Compare the two files, but skip the line with the timestamp (as it will never match)
+        for iLineNumber, sLine in enumerate(lExpected):
+            if iLineNumber != 1:
+                self.assertEqual(sLine, lActual[iLineNumber])
+        # Clean up
+        utils.remove_file('vsg/tests/vsg/junit/parse_error.actual.xml')
+
     @mock.patch('sys.stdout')
     def test_local_rules(self,mock_stdout):
         lExpected = []


### PR DESCRIPTION
Files which fail to parse will will be included in JUnit output.

  1)  Added test
  2)  Output parse failures to JUnit files

Resolves #831 
