### PR TITLE
Updates for issue #867

### DIFF
--- a/docs/configuring_concurrent_procedure_call_statement_rules.rst
+++ b/docs/configuring_concurrent_procedure_call_statement_rules.rst
@@ -59,7 +59,7 @@ There are several options to the structure rules:
 +=======================================+====================+===========+========================+============================+============================+
 | :code:`first_open_paren`              | |green_diamond|    | |values|  | opening parenthesis    | |default_remove_new_line|  | * |add_new_line|           |
 +---------------------------------------+--------------------+-----------+------------------------+----------------------------+ * |remove_new_line|        |
-| :code:`last_open_paren`               | |red_penta_star|   | |values|  | closing parenthesis    | |default_remove_new_line|  | * |ignore|                 |
+| :code:`last_close_paren`              | |red_penta_star|   | |values|  | closing parenthesis    | |default_remove_new_line|  | * |ignore|                 |
 +---------------------------------------+--------------------+-----------+------------------------+----------------------------+                            |
 | :code:`association_element`           | |orange_triangle|  | |values|  | association element    | |default_remove_new_line|  |                            |
 +---------------------------------------+--------------------+-----------+------------------------+----------------------------+                            |


### PR DESCRIPTION
Correction in concurrent procedue call configuration documentation.

**Description**
Correcting a typo in the "Configuring Concurrent Procedure Call Statement Rules" page.

**Screenshots**
![Screenshot 2022-11-12 145318](https://user-images.githubusercontent.com/22753502/201486418-4d430abb-e514-4641-bd04-7320bb314bff.png)

**Additional context**
Resolves https://github.com/jeremiah-c-leary/vhdl-style-guide/issues/867
