### PR TITLE
Issue#970: Correcting title on Whitespace Rule Group page.

### DIFF
--- a/docs/rule_groups/whitespace_rule_group.rst
+++ b/docs/rule_groups/whitespace_rule_group.rst
@@ -1,8 +1,8 @@
 
-Alignment Rule Group
+Whitespace Rule Group
 --------------------
 
-Rules Enforcing Alignment Rule Group
+Rules Enforcing Whitespace Rule Group
 ####################################
 
 * `alias_declaration_100 <alias_declaration_rules.html#alias-declaration-100>`_


### PR DESCRIPTION
**Description**
Made a correction to the title of the Whitespace Rule Group page. Prior to this change, the page is erroneously titled "Alignment Rule Group"

**Screenshots**
See  issue #970 

**Additional context**
none

Resolves #970