### PR TITLE
Issue#973: Correcting typo in code example on Configuring Rule Groups…

### DIFF
--- a/docs/configuring_rule_groups.rst
+++ b/docs/configuring_rule_groups.rst
@@ -27,5 +27,5 @@ The following example configures the rules to:
         length:
           disable: True
         naming:
-          disable: Tue
+          disable: True
 


### PR DESCRIPTION
… page.

**Description**
The code example on docs\configuring_rule_groups.rst has "Tue" where it should say "True". Sorry if this is annoying! 😅 

**Screenshots**
See issue #973 

**Additional context**
None

Resolves #973