### PR TITLE
Issue#981 Corrected None to "" in block comment example configurations.

### DIFF
--- a/docs/configuring_block_comments.rst
+++ b/docs/configuring_block_comments.rst
@@ -122,19 +122,19 @@ To configure the following example...
    rule:
      block_comment_001:
        disable : False
-       header_left : ""
+       header_left : ''
        header_left_repeat : '-'
-       header_string : ""
-       header_right_repeat : ""
+       header_string : ''
+       header_right_repeat : ''
      block_comment_002:
        disable : False
-       comment_left : ""
+       comment_left : ''
      block_comment_003:
        disable : False
-       footer_left : ""
+       footer_left : ''
        footer_left_repeat : '-'
-       footer_string : ""
-       footer_right_repeat : ""
+       footer_string : ''
+       footer_right_repeat : ''
 
 Complex Block Comment
 ^^^^^^^^^^^^^^^^^^^^^
@@ -194,8 +194,8 @@ To configure a block comment for Doxygen...
        disable : False
        header_left : '-'
        header_left_repeat : '-'
-       header_string : ""
-       header_right_repeat : ""
+       header_string : ''
+       header_right_repeat : ''
      block_comment_002:
        disable : False
        comment_left : '!'
@@ -203,8 +203,8 @@ To configure a block comment for Doxygen...
        disable : False
        footer_left : '-'
        footer_left_repeat : '-'
-       footer_string : ""
-       footer_right_repeat : ""
+       footer_string : ''
+       footer_right_repeat : ''
 
 Rules Enforcing Block Comments
 ##############################

--- a/docs/configuring_block_comments.rst
+++ b/docs/configuring_block_comments.rst
@@ -122,19 +122,19 @@ To configure the following example...
    rule:
      block_comment_001:
        disable : False
-       header_left : None
+       header_left : ""
        header_left_repeat : '-'
-       header_string : None
-       header_right_repeat : None
+       header_string : ""
+       header_right_repeat : ""
      block_comment_002:
        disable : False
-       comment_left : None
+       comment_left : ""
      block_comment_003:
        disable : False
-       footer_left : None
+       footer_left : ""
        footer_left_repeat : '-'
-       footer_string : None
-       footer_right_repeat : None
+       footer_string : ""
+       footer_right_repeat : ""
 
 Complex Block Comment
 ^^^^^^^^^^^^^^^^^^^^^
@@ -194,8 +194,8 @@ To configure a block comment for Doxygen...
        disable : False
        header_left : '-'
        header_left_repeat : '-'
-       header_string : None
-       header_right_repeat : None
+       header_string : ""
+       header_right_repeat : ""
      block_comment_002:
        disable : False
        comment_left : '!'
@@ -203,8 +203,8 @@ To configure a block comment for Doxygen...
        disable : False
        footer_left : '-'
        footer_left_repeat : '-'
-       footer_string : None
-       footer_right_repeat : None
+       footer_string : ""
+       footer_right_repeat : ""
 
 Rules Enforcing Block Comments
 ##############################


### PR DESCRIPTION
**Description**
Correction to example configuration in the Configuring Block Comments page of the docs. See Issue #981 for details.

**Screenshots**
See Issue #981 

**Additional context**
None

Resolves #981