### PR TITLE
Issue#1001: Mistake in the documentation example for type_500

### DIFF
--- a/docs/type_rules.rst
+++ b/docs/type_rules.rst
@@ -466,7 +466,7 @@ This rule checks enumerate types have proper case.
 
 .. code-block:: vhdl
 
-   TYPE state_machine is (IDLE, WRITE, READ, DONE);
+   type state_machine is (IDLE, WRITE, READ, DONE);
 
 **Fix**
 

--- a/vsg/rules/type_definition/rule_500.py
+++ b/vsg/rules/type_definition/rule_500.py
@@ -17,7 +17,7 @@ class rule_500(token_case):
 
     .. code-block:: vhdl
 
-       TYPE state_machine is (IDLE, WRITE, READ, DONE);
+       type state_machine is (IDLE, WRITE, READ, DONE);
 
     **Fix**
 


### PR DESCRIPTION
**Description**
Resolves #1001.

**Screenshots**
See #1001. 

**Additional context**
None
