### PR TITLE
Issue#1006: Minor documentation fixes

### DIFF
--- a/docs/configuring_simple_multiline_structure_rules.rst
+++ b/docs/configuring_simple_multiline_structure_rules.rst
@@ -1,5 +1,8 @@
 .. _configuring-simple-multiline-structure-rules:
 
+Configuring Simple Multiline Structure Rules
+--------------------------------------------
+
 .. |new_line_after_assign| replace::
    :code:`new_line_after_assign`
 
@@ -16,7 +19,7 @@
    :code:`yes`, :code:`no`, :code:`ignore`
 
 .. |values2| replace::
-   :code:`yes`, :code:`no` 
+   :code:`yes`, :code:`no`
 
 .. |ignore_single_line| replace::
    :code:`ignore_single_line`
@@ -32,9 +35,6 @@
 
 .. |default_no| replace::
    :code:`no`
-
-Configuring Simple Multiline Structure Rules
---------------------------------------------
 
 There are rules which will check the structure of simple multiline expressions and conditions.
 

--- a/docs/editor_integration/vim.rst
+++ b/docs/editor_integration/vim.rst
@@ -23,15 +23,16 @@ Linting/Diagnostics with ALE
 
 A custom linter can be defined for 'ALE <https://github.com/dense-analysis/ale>'_ if you use this. You can place the following contents into a file somewhere in your runtime path under `ale_linters/vhdl/`, this will generate a Linter that can give you diagnostics in Vim
 
-.. code_block:: viml
+.. code-block:: viml
+
     function! ale_linters#vhdl#vsg_ale#GetCommand(buffer)
         return "vsg --config ./vsg_config.yaml -of syntastic -f " . expand('%p')
     endfunction
-    
+
     function! ale_linters#vhdl#vsg_ale#Handle(buffer, lines)
         let l:pattern = '^\(\w\{-}\):\s\+\(.*\)(\(\d\+\))\(\w\+\)\s\+--\s\+\(.*\)$'
         let l:output = []
-    
+
         for l:match in ale#util#GetMatches(a:lines, l:pattern)
             call add(l:output, {
             \   'lnum': l:match[3],
@@ -69,7 +70,8 @@ One option to interact with the LSP client with VSG is to use 'null-ls <https://
 
 This works by taking the current buffer's contents and passing it into the standard input for VSG, then using a regex, parses the syntastic style output from standard output to generate the diagnostics. For the formatting it puts the current buffer's contents into a temporary file, has VSG "fix" that file and then writes that temporary file back to the buffer (without saving).
 
-.. code_block:: lua
+.. code-block:: lua
+
     local null_ls = require('null-ls')
     local helpers = require('null-ls.helpers')
     local vsg_lint = {
@@ -113,7 +115,7 @@ This works by taking the current buffer's contents and passing it into the stand
             }),
         })
     }
-    
+
     local vsg_format = {
         name = "VSG Formatting",
         method = null_ls.methods.FORMATTING,
@@ -130,7 +132,7 @@ This works by taking the current buffer's contents and passing it into the stand
             multiple_files = false,
         })
     }
-    
+
     null_ls.setup({
         diagnostics_format = "[#{c}] #{m} (#{s})",
         sources = { vsg_lint, vsg_format }

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -8,9 +8,6 @@
 .. |configuring_conditional_multiline_indent_rules_link| replace::
    Refer to :ref:`configuring-conditional-multiline-indent-rules` for more information.
 
-.. |configuring_conditional_expressions_structure_rules_link| replace::
-   Refer to :ref:`configuring-conditional-expressions-structure-rules` for more information.
-
 .. |configuring_consecutive_blank_line_rules| replace::
    Refer to :ref:`configuring-consecutive-blank-line-rules` for more information.
 

--- a/docs/rule_groups/structure_optional_rule_group.rst
+++ b/docs/rule_groups/structure_optional_rule_group.rst
@@ -17,11 +17,11 @@ Rules Enforcing Structure::Optional Rule Group
 * `function_018 <../function_rules.html#function-018>`_
 * `generate_011 <../generate_rules.html#generate-011>`_
 * `instantiation_033 <../instantiation_rules.html#instantiation-033>`_
-* `loop_statement_007 <../loop_statement_rules.html#loop-statement-007>`_ 
-* `package_007 <../package_rules.html#package-007>`_ 
-* `package_014 <../package_rules.html#package-014>`_ 
-* `package_body_002 <../package_body_rules.html#package-body-002>`_ 
-* `package_body_003 <../package_body_rules.html#package-body-003>`_ 
+* `loop_statement_007 <../loop_statement_rules.html#loop-statement-007>`_
+* `package_007 <../package_rules.html#package-007>`_
+* `package_014 <../package_rules.html#package-014>`_
+* `package_body_002 <../package_body_rules.html#package-body-002>`_
+* `package_body_003 <../package_body_rules.html#package-body-003>`_
 * `procedure_012 <../procedure_rules.html#procedure-012>`_
 * `process_012 <../process_rules.html#process-012>`_
 * `process_018 <../process_rules.html#process-018>`_

--- a/docs/rule_groups/whitespace_rule_group.rst
+++ b/docs/rule_groups/whitespace_rule_group.rst
@@ -1,9 +1,9 @@
 
 Whitespace Rule Group
---------------------
+---------------------
 
 Rules Enforcing Whitespace Rule Group
-####################################
+#####################################
 
 * `alias_declaration_100 <../alias_declaration_rules.html#alias-declaration-100>`_
 * `alias_declaration_101 <../alias_declaration_rules.html#alias-declaration-101>`_


### PR DESCRIPTION
**Description**
Resolves #1006.
Warnings that I've corrected:
- Trailing whitespace in docs/rule_groups/structure_optional_rule_group.rst. (This isn't a warning raised by Sphinx, but I introduced it without realising and would like to correct it).
- `code-block` directive called in docs/editor_integration/vim.rst, rather than the actual directive `code_block`. This leads to the code blocks on this page not being rendered.
- Underline lengths in docs/rule_groups/whitespace_rule_group.rst
- Undefined label `configuring-conditional-expressions-structure-rules`. This link is not used anywhere, so I've deleted it.
- No title or caption to be referenced for `configuring-simple-multiline-structure-rules`. Moved title to the top for the reference anchor on to more easily.

Warnings that I've ignored:
- `configuring_selected_assignment_structure_rules.rst` missing from docs/configuring.rst. (It looks like this page looks incomplete and claims to describe selected_assignment_001, but describes a rule that is much more complex than selected_assignment's current functionality.
- `notepad_pp.rst` missing from docs/editor_integration.rst. (This page looks incomplete).
- Several duplicate label warnings. (They're not a problem as long as we don't reference the labels, I think).
- api.rst, release_process.rst, and rule_selection.rst missing not included in any toctrees. (I'm not sure where they would go. It looks like they might be not be "customer facing" and therefore are deliberately not linked).
- No pygments lexer for viml. (Nothing we can do about that).

**Screenshots**
None

**Additional context**
None
