### PR TITLE
Prevent Python from replacing the existing newline characters.

### DIFF
--- a/vsg/apply_rules.py
+++ b/vsg/apply_rules.py
@@ -131,7 +131,7 @@ def apply_rules(commandLineArguments, oConfig, tIndexFileName):
 
 def write_vhdl_file(oVhdlFile):
     try:
-        with open(oVhdlFile.filename, 'w', encoding='utf-8') as oFile:
+        with open(oVhdlFile.filename, 'w', encoding='utf-8', newline='') as oFile:
             for sLine in oVhdlFile.get_lines()[1:]:
                 oFile.write(sLine + '\n')
     except PermissionError as err:


### PR DESCRIPTION
Prevent Python from replacing the existing newline characters.
From the [documentation](https://docs.python.org/3/library/functions.html#open): "... If newline is '' or '\n', no translation takes place ..."

**Description**
My code base is based on unix line endings '\n'. When running VSG on Windows every file is rewritten with windows line endings '\r\n'. This is due to pythons implementation of 'open'. The added newline argument prevents python from replacing the existing line endings.
