### PR TITLE
Support vsg as pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: vsg
+  name: fix VHDL style
+  description: VHDL Style Guide
+  entry: vsg --fix --jobs=1
+  language: python
+  types:
+    - file
+  files: \.(vhd|vhdl)$

--- a/README.rst
+++ b/README.rst
@@ -160,8 +160,12 @@ The command line tool can be invoked with:
                                  [-fp FIX_PHASE] [-j JUNIT] [-js JSON] [-of {vsg,syntastic,summary}] [-b] [-oc OUTPUT_CONFIGURATION]
                                  [-rc RULE_CONFIGURATION] [--style {indent_only,jcl}] [-v] [-ap] [--fix_only FIX_ONLY] [--stdin]
                                  [--quality_report QUALITY_REPORT] [-p JOBS] [--debug]
+                                 [FILENAME ...]
 
    Analyzes VHDL files for style guide violations. Reference documentation is located at: http://vhdl-style-guide.readthedocs.io/en/latest/index.html
+
+   positional arguments:
+     FILENAME              File to analyze
 
    options:
      -h, --help            show this help message and exit

--- a/README.rst
+++ b/README.rst
@@ -204,6 +204,19 @@ Here is an example output running against a test file:
 
 .. image:: https://github.com/jeremiah-c-leary/vhdl-style-guide/blob/master/docs/img/fixing_single_file.gif
 
+pre-commit Integration
+----------------------
+
+Here is an example of ``.pre-commit-config.yaml`` file:
+
+.. code-block:: yaml
+
+  repos:
+    - repo: https://github.com/jeremiah-c-leary/vhdl-style-guide
+      rev: v3.18.0
+      hooks:
+        - id: vsg
+
 Documentation
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -158,12 +158,12 @@ The command line tool can be invoked with:
    $ vsg
    usage: VHDL Style Guide (VSG) [-h] [-f FILENAME [FILENAME ...]] [-lr LOCAL_RULES] [-c CONFIGURATION [CONFIGURATION ...]] [--fix]
                                  [-fp FIX_PHASE] [-j JUNIT] [-js JSON] [-of {vsg,syntastic,summary}] [-b] [-oc OUTPUT_CONFIGURATION]
-                                 [-rc RULE_CONFIGURATION] [--style {indent_only,jcl}] [-v] [-ap] [--fix_only FIX_ONLY] [-p JOBS]
-                                 [--debug]
-   
+                                 [-rc RULE_CONFIGURATION] [--style {indent_only,jcl}] [-v] [-ap] [--fix_only FIX_ONLY] [--stdin]
+                                 [--quality_report QUALITY_REPORT] [-p JOBS] [--debug]
+
    Analyzes VHDL files for style guide violations. Reference documentation is located at: http://vhdl-style-guide.readthedocs.io/en/latest/index.html
-   
-   optional arguments:
+
+   options:
      -h, --help            show this help message and exit
      -f FILENAME [FILENAME ...], --filename FILENAME [FILENAME ...]
                            File to analyze
@@ -190,6 +190,9 @@ The command line tool can be invoked with:
      -v, --version         Displays version information
      -ap, --all_phases     Do not stop when a violation is detected.
      --fix_only FIX_ONLY   Restrict fixing via JSON file.
+     --stdin               Read VHDL input from stdin, disables all other file selections, disables multiprocessing
+     --quality_report QUALITY_REPORT
+                           Create code quality report for GitLab
      -p JOBS, --jobs JOBS  number of parallel jobs to use, default is the number of cpu cores
      --debug               Displays verbose debug information
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Welcome to vhdl-style-guide's documentation!
    code_tags
    continuous_integration_servers
    editor_integration/editor_integration
-   tool_integration
+   tool_integration/tool_integration
    pragmas
    localizing
    phases

--- a/docs/tool_integration/generic.rst
+++ b/docs/tool_integration/generic.rst
@@ -1,5 +1,5 @@
-Tool Integration
-----------------
+Generic Tool Integration
+------------------------
 
 VSG supports integration with other tools via several command line options.
 

--- a/docs/tool_integration/pre-commit.rst
+++ b/docs/tool_integration/pre-commit.rst
@@ -1,0 +1,25 @@
+pre-commit Integration
+----------------------
+
+VSG supports integration with pre-commit using the following ``.pre-commit-config.yaml`` file:
+
+.. code-block:: yaml
+
+  repos:
+    - repo: https://github.com/jeremiah-c-leary/vhdl-style-guide
+      rev: v3.18.0
+      hooks:
+        - id: vsg
+
+You may customize VSG by using the ``arg`` node, for example:
+
+.. code-block:: yaml
+
+  repos:
+    - repo: https://github.com/alonbl/vhdl-style-guide
+      rev: v3.18.0
+      hooks:
+        - id: vsg
+          args:
+            - --configuration=.vsg.yaml
+            - --output_format=syntastic

--- a/docs/tool_integration/tool_integration.rst
+++ b/docs/tool_integration/tool_integration.rst
@@ -1,0 +1,8 @@
+Tool Integration
+------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   generic.rst
+   pre-commit.rst

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -18,9 +18,13 @@ The command line tool can be invoked with:
                                  [--fix_only FIX_ONLY] [--stdin]
                                  [--quality_report QUALITY_REPORT] [-p JOBS]
                                  [--debug]
+                                 [FILENAME ...]
 
    Analyzes VHDL files for style guide violations. Reference documentation is
    located at: http://vhdl-style-guide.readthedocs.io/en/latest/index.html
+
+   positional arguments:
+     FILENAME              File to analyze
 
    options:
      -h, --help            show this help message and exit

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -14,14 +14,14 @@ The command line tool can be invoked with:
                                  [-of {vsg,syntastic,summary}] [-b]
                                  [-oc OUTPUT_CONFIGURATION]
                                  [-rc RULE_CONFIGURATION]
-                                 [--style {jcl,indent_only}] [-v] [-ap]
+                                 [--style {indent_only,jcl}] [-v] [-ap]
                                  [--fix_only FIX_ONLY] [--stdin]
                                  [--quality_report QUALITY_REPORT] [-p JOBS]
                                  [--debug]
-   
+
    Analyzes VHDL files for style guide violations. Reference documentation is
    located at: http://vhdl-style-guide.readthedocs.io/en/latest/index.html
-   
+
    options:
      -h, --help            show this help message and exit
      -f FILENAME [FILENAME ...], --filename FILENAME [FILENAME ...]
@@ -45,7 +45,7 @@ The command line tool can be invoked with:
                            Write configuration to file name.
      -rc RULE_CONFIGURATION, --rule_configuration RULE_CONFIGURATION
                            Display configuration of a rule
-     --style {jcl,indent_only}
+     --style {indent_only,jcl}
                            Use predefined style
      -v, --version         Displays version information
      -ap, --all_phases     Do not stop when a violation is detected.

--- a/vsg/cmd_line_args.py
+++ b/vsg/cmd_line_args.py
@@ -117,7 +117,7 @@ def get_predefined_styles():
             with open(os.path.join(sStylePath, sStyle)) as yaml_file:
                 tempConfiguration = yaml.safe_load(yaml_file)
             lReturn.append(tempConfiguration['name'])
-    return lReturn
+    return sorted(lReturn)
 
 
 def validate_backup_argument(args_):

--- a/vsg/cmd_line_args.py
+++ b/vsg/cmd_line_args.py
@@ -48,7 +48,7 @@ def parse_command_line_arguments():
                    Reference documentation is located at:
                    http://vhdl-style-guide.readthedocs.io/en/latest/index.html''')
 
-    parser.add_argument('-f', '--filename', type=__is_valid_file, nargs='+', help='File to analyze')
+    parser.add_argument('-f', '--filename', type=__is_valid_file, nargs='+', default=[], help='File to analyze')
     parser.add_argument('-lr', '--local_rules', help='Path to local rules')
     parser.add_argument('-c', '--configuration', type=__is_valid_file, nargs='+', help='JSON or YAML configuration file(s)')
     parser.add_argument('--fix', default=False, action='store_true', help='Fix issues found')
@@ -82,6 +82,8 @@ def parse_command_line_arguments():
         help="number of parallel jobs to use, default is the number of cpu cores",
     )
     parser.add_argument('--debug', default=False, action='store_true', help='Displays verbose debug information')
+    parser.add_argument('filename_args', metavar='FILENAME', type=__is_valid_file, nargs='*', default=[],
+                        help='File to analyze')
 
     args_ = parser.parse_args()
 
@@ -147,12 +149,12 @@ def add_quality_report_argument(parser):
 
 
 def fix_filename_argument(args_):
-    if args_.filename is None:
-        return None
     lUpdate = []
     for lFilenames in args_.filename:
         lUpdate.extend(lFilenames)
-    args_.filename = lUpdate
+    for lFilenames in args_.filename_args:
+        lUpdate.extend(lFilenames)
+    args_.filename = lUpdate or None
 
 
 def fix_configuration_argument(args_):

--- a/vsg/tests/cmd_line_args/test_cmd_line_args.py
+++ b/vsg/tests/cmd_line_args/test_cmd_line_args.py
@@ -48,6 +48,32 @@ class test(unittest.TestCase):
 
         self.assertEqual(lActual, lExpected)
 
+    def test_filename_w_two_files_positional(self):
+        sys.argv = ['vsg']
+        sys.argv.extend([sAFile, sBFile])
+
+        lExpected = [sAFile, sBFile]
+        lExpected.sort()
+
+        oActual = cmd_line_args.parse_command_line_arguments()
+        lActual = oActual.filename
+        lActual.sort()
+
+        self.assertEqual(lActual, lExpected)
+
+    def test_filename_w_two_files_positional_merge(self):
+        sys.argv = ['vsg']
+        sys.argv.extend(['-f', sAFile, sBFile])
+
+        lExpected = [sAFile, sBFile]
+        lExpected.sort()
+
+        oActual = cmd_line_args.parse_command_line_arguments()
+        lActual = oActual.filename
+        lActual.sort()
+
+        self.assertEqual(lActual, lExpected)
+
     def test_valid_glob(self):
         sys.argv = ['vsg']
         sys.argv.extend(['-f', sGlobFile])

--- a/vsg/version.py
+++ b/vsg/version.py
@@ -33,13 +33,14 @@ def get_version_info():
         sReturnPath = os.getcwd()
         sPath = os.path.dirname(__file__)
         os.chdir(sPath)
-        lActual = subprocess.check_output(['git', 'describe', '--tags'])
-        lActual = str(lActual.decode('utf-8')).split('\n')
-        lVersion = lActual[0].split('-')
+        lVersion = "0"  # version if no tags (shallow checkout)
         try:
+            lActual = subprocess.check_output(['git', 'describe', '--tags'])
+            lActual = str(lActual.decode('utf-8')).split('\n')
+            lVersion = lActual[0].split('-')
             sVersion = str(lVersion[0]) + '.dev' + str(lVersion[1])
             sShaNum = str(lVersion[-1][1:])
-        except IndexError:
+        except (IndexError, subprocess.CalledProcessError):
             sVersion = str(lVersion[0])
             lActual = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])
             lActual = str(lActual.decode('utf-8')).split('\n')


### PR DESCRIPTION
**Description**

[pre-commit](https://pre-commit.com) is a tool for running various of format and validation tools. It would be nice if it will be possible to use vsg as pre-commit hook.

**Additional context**

Trivial changes provided as a patch set:
* Support of providing files as positional arguments, most tools assumes that the input files may be used as positional arguments, so let's support both notations.
* Support build from shallow git clone without tags, assign a temporary version 0 to this mode.
* Add pre-commit-hook metadata.

Tested and working for me, please let me know what you think.