### PR TITLE
Use platform independent file name in configuration

### DIFF
--- a/docs/configuring_overview.rst
+++ b/docs/configuring_overview.rst
@@ -71,6 +71,8 @@ File globbing is also supported.
 The Environment variables will be expanded before globbing occurs.
 This option can be useful when running VSG over multiple files.
 
+The file name will be converted to POSIX style using '/' as a separator for all platforms.
+
 Rule configurations can be specified for each file by following the format of the **rule** configuration.
 
 local_rules

--- a/vsg/apply_rules.py
+++ b/vsg/apply_rules.py
@@ -1,4 +1,5 @@
 
+import os
 import shutil
 
 from . import config
@@ -17,6 +18,8 @@ def create_backup_file(sFileName):
 
 
 def configure_rules(oConfig, oRules, configuration, iIndex, sFileName):
+
+    sFileName = sFileName.replace(os.sep, "/")
 
     oRules.configure(oConfig)
     if is_filename_in_file_list(configuration, sFileName):


### PR DESCRIPTION
**Description**

Current implementation searches the file as provided by user or glob, this name may be platform specific.

New implementation will always use '/' as separator, enabling the same configuration to be used in any platform.
