### PR TITLE
Support file configuration without scanning the file

### DIFF
--- a/docs/configuring_overview.rst
+++ b/docs/configuring_overview.rst
@@ -18,6 +18,13 @@ This is the basic form of a configuration file in JSON:
        "$PATH_TO_FILE/spi_master.vhd",
        "$OTHER_PATH/src/*.vhd"
      ],
+     "file_rules": [
+       "source/i2c.vhd": {
+         "rule": {
+           "ruleId_ruleNumber": "blah"
+         }
+       }
+     ],
      "local_rules":"$DIRECTORY_PATH",
      "rule": {
        "global": {
@@ -46,6 +53,11 @@ This is the basic form of a configuration file in YAML:
              attributeName: AttributeValue
      - $PATH_TO_FILE/spi_master.vhd
      - $OTHER_PATH/src/*.vhd
+   file_rules:
+     - source/i2c.vhd:
+         rule:
+           ruleId_ruleNumber:
+             attributeName: AttributeValue
    local_rules: $DIRECTORY_PATH
    rule:
      global:
@@ -74,6 +86,11 @@ This option can be useful when running VSG over multiple files.
 The file name will be converted to POSIX style using '/' as a separator for all platforms.
 
 Rule configurations can be specified for each file by following the format of the **rule** configuration.
+
+file_rules
+----------
+
+The file_rules is exactly the same as file_list except that it will not add the file to the scan list.
 
 local_rules
 -----------

--- a/docs/configuring_overview.rst
+++ b/docs/configuring_overview.rst
@@ -87,10 +87,15 @@ The file name will be converted to POSIX style using '/' as a separator for all 
 
 Rule configurations can be specified for each file by following the format of the **rule** configuration.
 
+.. NOTE:: Defining rule configurations under the file_list will be deprecated at some point.
+          Use the file_rules option instead.
+
 file_rules
 ----------
 
-The file_rules is exactly the same as file_list except that it will not add the file to the scan list.
+The file_rules option allows for configuration of individual rules per file.
+Any file listed under this option will have the configuration applied if it is being analyzed.
+.. The file_rules is exactly the same as file_list except that it will not add the file to the scan list.
 
 local_rules
 -----------

--- a/vsg/apply_rules.py
+++ b/vsg/apply_rules.py
@@ -21,18 +21,19 @@ def configure_rules(oConfig, oRules, configuration, iIndex, sFileName):
 
     sFileName = sFileName.replace(os.sep, "/")
 
-    oRules.configure(oConfig)
-    if is_filename_in_file_list(configuration, sFileName):
-        iMyIndex = get_index_of_filename_in_file_list(configuration, sFileName)
-        oRuleConfig = config.config()
-        if does_file_have_rule_configuration(configuration, iMyIndex, sFileName):
-            oRuleConfig.dConfig = configuration["file_list"][iMyIndex][sFileName]
-            oRules.configure(oRuleConfig)
+    for section in ("file_rules", "file_list"):
+        oRules.configure(oConfig)
+        if is_filename_in_file_list(configuration, section, sFileName):
+            iMyIndex = get_index_of_filename_in_file_list(configuration, section, sFileName)
+            oRuleConfig = config.config()
+            if does_file_have_rule_configuration(configuration, section, iMyIndex, sFileName):
+                oRuleConfig.dConfig = configuration[section][iMyIndex][sFileName]
+                oRules.configure(oRuleConfig)
 
 
-def is_filename_in_file_list(configuration, sFileName):
+def is_filename_in_file_list(configuration, section, sFileName):
     try:
-        lFileNames = utils.extract_file_names_from_file_list(configuration["file_list"])
+        lFileNames = utils.extract_file_names_from_file_list(configuration[section])
         if sFileName in lFileNames:
             return True
         return False
@@ -40,14 +41,14 @@ def is_filename_in_file_list(configuration, sFileName):
         return False
 
 
-def get_index_of_filename_in_file_list(configuration, sFileName):
-    lFileNames = utils.extract_file_names_from_file_list(configuration["file_list"])
+def get_index_of_filename_in_file_list(configuration, section, sFileName):
+    lFileNames = utils.extract_file_names_from_file_list(configuration[section])
     return lFileNames.index(sFileName)
 
 
-def does_file_have_rule_configuration(configuration, iMyIndex, sFileName):
+def does_file_have_rule_configuration(configuration, section, iMyIndex, sFileName):
     try:
-        sTemp = configuration["file_list"][iMyIndex][sFileName]
+        sTemp = configuration[section][iMyIndex][sFileName]
         return True
     except:
         return False

--- a/vsg/apply_rules.py
+++ b/vsg/apply_rules.py
@@ -21,17 +21,33 @@ def configure_rules(oConfig, oRules, configuration, iIndex, sFileName):
 
     sFileName = sFileName.replace(os.sep, "/")
 
-    for section in ("file_rules", "file_list"):
-        oRules.configure(oConfig)
-        if is_filename_in_file_list(configuration, section, sFileName):
-            iMyIndex = get_index_of_filename_in_file_list(configuration, section, sFileName)
+    configure_rules_per_rule_option(oConfig, oRules)
+    configure_rules_per_file_list_option(oRules, configuration, iIndex, sFileName)
+    configure_rules_per_file_rules_option(oRules, configuration, iIndex, sFileName)
+
+
+def configure_rules_per_rule_option(oConfig, oRules):
+    oRules.configure(oConfig)
+
+
+def configure_rules_per_file_list_option(oRules, configuration, iIndex, sFileName):
+    configure_rules_per_option(oRules, configuration, iIndex, sFileName, 'file_list')
+
+
+def configure_rules_per_file_rules_option(oRules, configuration, iIndex, sFileName):
+    configure_rules_per_option(oRules, configuration, iIndex, sFileName, 'file_rules')
+
+
+def configure_rules_per_option(oRules, configuration, iIndex, sFileName, section):
+    if is_filename_in_option(configuration, section, sFileName):
+        iMyIndex = get_index_of_filename_in_file_list(configuration, section, sFileName)
+        if does_file_have_rule_configuration(configuration, section, iMyIndex, sFileName):
             oRuleConfig = config.config()
-            if does_file_have_rule_configuration(configuration, section, iMyIndex, sFileName):
-                oRuleConfig.dConfig = configuration[section][iMyIndex][sFileName]
-                oRules.configure(oRuleConfig)
+            oRuleConfig.dConfig = configuration[section][iMyIndex][sFileName]
+            oRules.configure(oRuleConfig)
 
 
-def is_filename_in_file_list(configuration, section, sFileName):
+def is_filename_in_option(configuration, section, sFileName):
     try:
         lFileNames = utils.extract_file_names_from_file_list(configuration[section])
         if sFileName in lFileNames:

--- a/vsg/tests/vsg/config_file_rules.yaml
+++ b/vsg/tests/vsg/config_file_rules.yaml
@@ -1,0 +1,20 @@
+---
+rule:
+  entity_008:
+    disable : True
+  entity_012:
+    disable : True
+  port_010:
+    disable : True
+  architecture_011:
+    disable : True
+  architecture_013:
+    disable : True
+  architecture_014:
+    disable : True
+file_rules:
+  - vsg/tests/vsg/entity1.vhd :
+      rule:
+         port_007:
+            disable : True
+...

--- a/vsg/tests/vsg/config_glob_with_file_rules.yaml
+++ b/vsg/tests/vsg/config_glob_with_file_rules.yaml
@@ -1,0 +1,22 @@
+---
+file_list:
+  - vsg/tests/vsg/*.vhd
+rule:
+  entity_008:
+    disable : True
+  entity_012:
+    disable : True
+  port_010:
+    disable : True
+  architecture_011:
+    disable : True
+  architecture_013:
+    disable : True
+  architecture_014:
+    disable : True
+file_rules:
+  - vsg/tests/vsg/entity1.vhd :
+      rule:
+         port_007:
+            disable : True
+...

--- a/vsg/tests/vsg/test_vsg.py
+++ b/vsg/tests/vsg/test_vsg.py
@@ -520,5 +520,3 @@ class testVsg(unittest.TestCase):
             iExitStatus = e.returncode
 
         self.assertEqual(lActual, lExpected)
-
-

--- a/vsg/tests/vsg/test_vsg.py
+++ b/vsg/tests/vsg/test_vsg.py
@@ -481,3 +481,44 @@ class testVsg(unittest.TestCase):
 
         self.assertEqual(utils.replace_total_count_summary(lActualStdErr), lExpectedStdErr)
         self.assertEqual(utils.replace_total_count_summary(lActualStdOut), lExpectedStdOut)
+
+    def test_globbing_filenames_in_configuration_with_file_rules(self):
+        lExpected = []
+        lExpected.append('ERROR: vsg/tests/vsg/entity2.vhd(8)port_008 -- Change number of spaces after *out* to 3.')
+        lExpected.append('')
+
+        try:
+            subprocess.check_output(['bin/vsg','--configuration','vsg/tests/vsg/config_glob_with_file_rules.yaml','--output_format','syntastic'])
+        except subprocess.CalledProcessError as e:
+            lActual = str(e.output.decode('utf-8')).split('\n')
+            iExitStatus = e.returncode
+
+        self.assertEqual(lActual, lExpected)
+
+    def test_configuration_with_file_rules_and_no_file_list_entity2(self):
+        lExpected = []
+        lExpected.append('ERROR: vsg/tests/vsg/entity2.vhd(8)port_008 -- Change number of spaces after *out* to 3.')
+        lExpected.append('')
+
+        try:
+            subprocess.check_output(['bin/vsg','--configuration','vsg/tests/vsg/config_file_rules.yaml', '-f', 'vsg/tests/vsg/entity2.vhd', '--output_format','syntastic'])
+        except subprocess.CalledProcessError as e:
+            lActual = str(e.output.decode('utf-8')).split('\n')
+            iExitStatus = e.returncode
+
+        self.assertEqual(lActual, lExpected)
+
+    def test_configuration_with_file_rules_and_no_file_list_entity1(self):
+        lExpected = []
+
+        lActual = []
+
+        try:
+            subprocess.check_output(['bin/vsg','--configuration','vsg/tests/vsg/config_file_rules.yaml', '-f', 'vsg/tests/vsg/entity1.vhd', '--output_format','syntastic'])
+        except subprocess.CalledProcessError as e:
+            lActual = str(e.output.decode('utf-8')).split('\n')
+            iExitStatus = e.returncode
+
+        self.assertEqual(lActual, lExpected)
+
+


### PR DESCRIPTION
**Description**

Currently per file configuration is specified under `file_list`, the `file_list` has side effect of scanning the file regardless of what files provided in command-line.

Configuration should be able to specify per file configuration without adding the file to the scan.

New implementation will look for the file under `file_rules` and merge it to the existing `file_list` configuration to keep backward compatibility.
