### PR TITLE
Issue#990:  Rule constant_016 ignored if subtype_indication included parenthesis.

### DIFF
--- a/vsg/rules/utils.py
+++ b/vsg/rules/utils.py
@@ -114,6 +114,13 @@ def get_index_of_token_in_list(oToken, lTokens):
     return None
 
 
+def get_index_of_token_in_list_after_index(oToken, lTokens, iIndex):
+    for iToken, token in enumerate(lTokens):
+        if iToken > iIndex and isinstance(token, oToken):
+            return iToken
+    return None
+
+
 def get_indexes_of_token_in_list(oToken, lTokens):
     lReturn = []
     for iToken, token in enumerate(lTokens):
@@ -425,7 +432,7 @@ def open_paren_after_assignment_operator(assignment_operator, lTokens):
 def open_paren_after_assignment_operator_is_aggregate(assignment_operator, lTokens):
     iToken = get_index_of_token_in_list(assignment_operator, lTokens)
     if is_next_token_ignoring_whitespace(parser.open_parenthesis, iToken, lTokens):
-        iIndex = get_index_of_token_in_list(parser.open_parenthesis, lTokens)
+        iIndex = get_index_of_token_in_list_after_index(parser.open_parenthesis, lTokens, iToken)
         return isinstance(lTokens[iIndex], token.aggregate.open_parenthesis)
     return False
 

--- a/vsg/tests/constant/rule_016_test_input.fixed_all_false.vhd
+++ b/vsg/tests/constant/rule_016_test_input.fixed_all_false.vhd
@@ -23,6 +23,8 @@ architecture rtl of fifo is
 
   constant c_stimulus : t_stimulus_array := (name => "Not enabled", clk_in => "01", rst_in => "00", cnt_en_in => "00", cnt_out => "00"); -- Comment
 
+  constant c_stimulus : signed(t_stimulus_array) := (name => "Not enabled", clk_in => "01", rst_in => "00", cnt_en_in => "00", cnt_out => "00"); -- Comment
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/rule_016_test_input.fixed_all_true.vhd
+++ b/vsg/tests/constant/rule_016_test_input.fixed_all_true.vhd
@@ -142,6 +142,15 @@ architecture rtl of fifo is
    cnt_out => "00" -- Comment
  );
 
+  constant c_stimulus : signed(t_stimulus_array) :=
+  (
+   name => "Not enabled",
+   clk_in => "01",
+   rst_in => "00",
+   cnt_en_in => "00",
+   cnt_out => "00" -- Comment
+ );
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/rule_016_test_input.fixed_close_paren_new_line_false.vhd
+++ b/vsg/tests/constant/rule_016_test_input.fixed_close_paren_new_line_false.vhd
@@ -77,6 +77,14 @@ architecture rtl of fifo is
    cnt_en_in => "00",
    cnt_out => "00"); -- Comment
 
+  constant c_stimulus : signed(t_stimulus_array) :=
+  (
+   name => "Not enabled",
+   clk_in => "01",
+   rst_in => "00",
+   cnt_en_in => "00",
+   cnt_out => "00"); -- Comment
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/rule_016_test_input.fixed_close_paren_new_line_true.vhd
+++ b/vsg/tests/constant/rule_016_test_input.fixed_close_paren_new_line_true.vhd
@@ -91,6 +91,14 @@ architecture rtl of fifo is
    cnt_en_in => "00",
    cnt_out => "00"); -- Comment
 
+  constant c_stimulus : signed(t_stimulus_array) :=
+  (
+   name => "Not enabled",
+   clk_in => "01",
+   rst_in => "00",
+   cnt_en_in => "00",
+   cnt_out => "00"); -- Comment
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/rule_016_test_input.fixed_first_paren_new_line_false.vhd
+++ b/vsg/tests/constant/rule_016_test_input.fixed_first_paren_new_line_false.vhd
@@ -72,6 +72,13 @@ architecture rtl of fifo is
    cnt_en_in => "00",
    cnt_out => "00"); -- Comment
 
+  constant c_stimulus : signed(t_stimulus_array) := (
+   name => "Not enabled",
+   clk_in => "01",
+   rst_in => "00",
+   cnt_en_in => "00",
+   cnt_out => "00"); -- Comment
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/rule_016_test_input.fixed_first_paren_new_line_true.vhd
+++ b/vsg/tests/constant/rule_016_test_input.fixed_first_paren_new_line_true.vhd
@@ -80,6 +80,14 @@ architecture rtl of fifo is
    cnt_en_in => "00",
    cnt_out => "00"); -- Comment
 
+  constant c_stimulus : signed(t_stimulus_array) :=
+  (
+   name => "Not enabled",
+   clk_in => "01",
+   rst_in => "00",
+   cnt_en_in => "00",
+   cnt_out => "00"); -- Comment
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/rule_016_test_input.fixed_last_paren_new_line_false.vhd
+++ b/vsg/tests/constant/rule_016_test_input.fixed_last_paren_new_line_false.vhd
@@ -74,6 +74,14 @@ architecture rtl of fifo is
    cnt_en_in => "00",
    cnt_out => "00"); -- Comment
 
+  constant c_stimulus : signed(t_stimulus_array) :=
+  (
+   name => "Not enabled",
+   clk_in => "01",
+   rst_in => "00",
+   cnt_en_in => "00",
+   cnt_out => "00"); -- Comment
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/rule_016_test_input.fixed_last_paren_new_line_true.vhd
+++ b/vsg/tests/constant/rule_016_test_input.fixed_last_paren_new_line_true.vhd
@@ -82,6 +82,15 @@ architecture rtl of fifo is
    cnt_out => "00"
  ); -- Comment
 
+  constant c_stimulus : signed(t_stimulus_array) :=
+  (
+   name => "Not enabled",
+   clk_in => "01",
+   rst_in => "00",
+   cnt_en_in => "00",
+   cnt_out => "00"
+ ); -- Comment
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/rule_016_test_input.fixed_last_paren_new_line_true_move_last_comment_true.vhd
+++ b/vsg/tests/constant/rule_016_test_input.fixed_last_paren_new_line_true_move_last_comment_true.vhd
@@ -82,6 +82,15 @@ architecture rtl of fifo is
    cnt_out => "00" -- Comment
  );
 
+  constant c_stimulus : signed(t_stimulus_array) :=
+  (
+   name => "Not enabled",
+   clk_in => "01",
+   rst_in => "00",
+   cnt_en_in => "00",
+   cnt_out => "00" -- Comment
+ );
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/rule_016_test_input.fixed_new_line_after_comma_false.vhd
+++ b/vsg/tests/constant/rule_016_test_input.fixed_new_line_after_comma_false.vhd
@@ -47,6 +47,10 @@ architecture rtl of fifo is
   (
    name => "Not enabled", clk_in => "01", rst_in => "00", cnt_en_in => "00", cnt_out => "00"); -- Comment
 
+  constant c_stimulus : signed(t_stimulus_array) :=
+  (
+   name => "Not enabled", clk_in => "01", rst_in => "00", cnt_en_in => "00", cnt_out => "00"); -- Comment
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/rule_016_test_input.fixed_new_line_after_comma_true.vhd
+++ b/vsg/tests/constant/rule_016_test_input.fixed_new_line_after_comma_true.vhd
@@ -114,6 +114,14 @@ architecture rtl of fifo is
    cnt_en_in => "00",
    cnt_out => "00"); -- Comment
 
+  constant c_stimulus : signed(t_stimulus_array) :=
+  (
+   name => "Not enabled",
+   clk_in => "01",
+   rst_in => "00",
+   cnt_en_in => "00",
+   cnt_out => "00"); -- Comment
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/rule_016_test_input.fixed_open_paren_new_line_false.vhd
+++ b/vsg/tests/constant/rule_016_test_input.fixed_open_paren_new_line_false.vhd
@@ -69,6 +69,13 @@ architecture rtl of fifo is
    cnt_en_in => "00",
    cnt_out => "00"); -- Comment
 
+  constant c_stimulus : signed(t_stimulus_array) :=
+  (name => "Not enabled",
+   clk_in => "01",
+   rst_in => "00",
+   cnt_en_in => "00",
+   cnt_out => "00"); -- Comment
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/rule_016_test_input.fixed_open_paren_new_line_true.vhd
+++ b/vsg/tests/constant/rule_016_test_input.fixed_open_paren_new_line_true.vhd
@@ -91,6 +91,14 @@ architecture rtl of fifo is
    cnt_en_in => "00",
    cnt_out => "00"); -- Comment
 
+  constant c_stimulus : signed(t_stimulus_array) :=
+  (
+   name => "Not enabled",
+   clk_in => "01",
+   rst_in => "00",
+   cnt_en_in => "00",
+   cnt_out => "00"); -- Comment
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/rule_016_test_input.vhd
+++ b/vsg/tests/constant/rule_016_test_input.vhd
@@ -79,6 +79,14 @@ architecture rtl of fifo is
    cnt_en_in => "00",
    cnt_out => "00"); -- Comment
 
+  constant c_stimulus : signed(t_stimulus_array) :=
+  (
+   name => "Not enabled",
+   clk_in => "01",
+   rst_in => "00",
+   cnt_en_in => "00",
+   cnt_out => "00"); -- Comment
+
 begin
 
 end architecture rtl;

--- a/vsg/tests/constant/test_rule_016.py
+++ b/vsg/tests/constant/test_rule_016.py
@@ -117,7 +117,7 @@ class test_constant_rule(unittest.TestCase):
         oRule.new_line_after_comma = 'ignore'
         oRule.assign_on_single_line = 'ignore'
 
-        lExpected = [14, 17, 21, 27, 41, 57, 75]
+        lExpected = [14, 17, 21, 27, 41, 57, 75, 83]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
@@ -131,7 +131,7 @@ class test_constant_rule(unittest.TestCase):
         oRule.new_line_after_comma = 'ignore'
         oRule.assign_on_single_line = 'ignore'
 
-        lExpected = [11, 14, 80]
+        lExpected = [11, 14, 80, 88]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
@@ -173,7 +173,7 @@ class test_constant_rule(unittest.TestCase):
         oRule.new_line_after_comma = 'ignore'
         oRule.assign_on_single_line = 'ignore'
 
-        lExpected = [10, 21, 27, 41, 42, 48, 57, 58, 65, 75]
+        lExpected = [10, 21, 27, 41, 42, 48, 57, 58, 65, 75, 83]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
@@ -242,6 +242,7 @@ class test_constant_rule(unittest.TestCase):
         lExpected.append(64)
         lExpected.extend(range(66, 70))
         lExpected.extend(range(76, 80))
+        lExpected.extend(range(84, 88))
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
@@ -271,7 +272,7 @@ class test_constant_rule(unittest.TestCase):
         oRule.assign_on_single_line = 'ignore'
         oRule.move_last_comment = 'yes'
 
-        lExpected = [11, 14, 80]
+        lExpected = [11, 14, 80, 88]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
@@ -286,7 +287,7 @@ class test_constant_rule(unittest.TestCase):
         oRule.assign_on_single_line = 'ignore'
         oRule.move_last_comment = 'no'
 
-        lExpected = [11, 14, 80]
+        lExpected = [11, 14, 80, 88]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))

--- a/vsg/tests/constant/test_rule_016_boolean.py
+++ b/vsg/tests/constant/test_rule_016_boolean.py
@@ -117,7 +117,7 @@ class test_constant_rule(unittest.TestCase):
         oRule.new_line_after_comma = 'ignore'
         oRule.assign_on_single_line = 'ignore'
 
-        lExpected = [14, 17, 21, 27, 41, 57, 75]
+        lExpected = [14, 17, 21, 27, 41, 57, 75, 83]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
@@ -131,7 +131,7 @@ class test_constant_rule(unittest.TestCase):
         oRule.new_line_after_comma = 'ignore'
         oRule.assign_on_single_line = 'ignore'
 
-        lExpected = [11, 14, 80]
+        lExpected = [11, 14, 80, 88]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
@@ -173,7 +173,7 @@ class test_constant_rule(unittest.TestCase):
         oRule.new_line_after_comma = 'ignore'
         oRule.assign_on_single_line = 'ignore'
 
-        lExpected = [10, 21, 27, 41, 42, 48, 57, 58, 65, 75]
+        lExpected = [10, 21, 27, 41, 42, 48, 57, 58, 65, 75, 83]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
@@ -242,6 +242,7 @@ class test_constant_rule(unittest.TestCase):
         lExpected.append(64)
         lExpected.extend(range(66, 70))
         lExpected.extend(range(76, 80))
+        lExpected.extend(range(84, 88))
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
@@ -271,7 +272,7 @@ class test_constant_rule(unittest.TestCase):
         oRule.assign_on_single_line = 'ignore'
         oRule.move_last_comment = True
 
-        lExpected = [11, 14, 80]
+        lExpected = [11, 14, 80, 88]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
@@ -286,7 +287,7 @@ class test_constant_rule(unittest.TestCase):
         oRule.assign_on_single_line = 'ignore'
         oRule.move_last_comment = False
 
-        lExpected = [11, 14, 80]
+        lExpected = [11, 14, 80, 88]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))


### PR DESCRIPTION
Resolves #990 
