### PR TITLE
fix 'keyError: regexp' by dStyle having parse regexp and dConfig not

### DIFF
--- a/vsg/config.py
+++ b/vsg/config.py
@@ -223,8 +223,8 @@ def New(commandLineArguments):
     oReturn = config()
 
     dStyle = read_predefined_style(commandLineArguments.style)
-    add_pragma_regular_expressions(dStyle)
     dConfig = read_configuration_files(dStyle, commandLineArguments)
+    add_pragma_regular_expressions(dConfig)
 
     oReturn.severity_list = severity.create_list(dConfig)
 


### PR DESCRIPTION
**Description**
As noted on issue 1054, I get a Traceback running the branch with a 'pragma' key / 'patterns' sub-key in my configuration.yaml
```
  File ... /vsg/__main__.py, line 153, in main
    for tResult in pool.imap(f, enumerate(commandLineArguments.filename)):
  File "/usr/lib/python3.10/multiprocessing/pool.py", line 873, in next
    raise value
KeyError: 'regexp'
```

This patch resolves that, by running `add_pragma_regular_expressions` on dConfig, not on dStatus.
