### PR TITLE
Issue#1076: procedure_call_003 modified to accept ignore_single_line option.

### DIFF
--- a/docs/configuring_procedure_call_statement_rules.rst
+++ b/docs/configuring_procedure_call_statement_rules.rst
@@ -35,6 +35,12 @@ There are several options to the structure rules:
 .. |values2| replace::
    :code:`remove_new_line`, :code:`ignore`
 
+.. |values3| replace::
+   :code:`yes`, :code:`no`
+
+.. |no| replace::
+   :code:`no`
+
 .. |green_diamond| image:: img/green_diamond.png
 
 .. |red_penta_star| image:: img/red_penta_star.png
@@ -57,17 +63,29 @@ There are several options to the structure rules:
 .. |default_remove_new_line| replace::
    :code:`remove_new_line`
 
-+---------------------------------------+--------------------+-----------+------------------------+----------------------------+----------------------------+
-| Option                                | Symbol             | Values    | Structural Element     | Default Value              | Description                |
-+=======================================+====================+===========+========================+============================+============================+
-| :code:`first_open_paren`              | |green_diamond|    | |values|  | opening parenthesis    | |default_remove_new_line|  | * |add_new_line|           |
-+---------------------------------------+--------------------+-----------+------------------------+----------------------------+ * |remove_new_line|        |
-| :code:`last_close_paren`              | |red_penta_star|   | |values|  | closing parenthesis    | |default_remove_new_line|  | * |ignore|                 |
-+---------------------------------------+--------------------+-----------+------------------------+----------------------------+                            |
-| :code:`association_element`           | |orange_triangle|  | |values|  | association element    | |default_remove_new_line|  |                            |
-+---------------------------------------+--------------------+-----------+------------------------+----------------------------+                            |
-| :code:`association_list_comma`        | |purple_hexa_star| | |values2| | comma                  | |default_remove_new_line|  |                            |
-+---------------------------------------+--------------------+-----------+------------------------+----------------------------+----------------------------+
+.. |ignore_single_line| replace::
+   :code:`ignore_single_line`
+
+.. |ignore_single_line__yes| replace::
+   :code:`yes` = Ignore single line expressions.
+
+.. |ignore_single_line__no| replace::
+   :code:`no` =  Apply rules to single line expressions.
+
++---------------------------------------+--------------------+-----------+------------------------+----------------------------+-----------------------------+
+| Option                                | Symbol             | Values    | Structural Element     | Default Value              | Description                 |
++=======================================+====================+===========+========================+============================+=============================+
+| :code:`first_open_paren`              | |green_diamond|    | |values|  | opening parenthesis    | |default_remove_new_line|  | * |add_new_line|            |
++---------------------------------------+--------------------+-----------+------------------------+----------------------------+ * |remove_new_line|         |
+| :code:`last_close_paren`              | |red_penta_star|   | |values|  | closing parenthesis    | |default_remove_new_line|  | * |ignore|                  |
++---------------------------------------+--------------------+-----------+------------------------+----------------------------+                             |
+| :code:`association_element`           | |orange_triangle|  | |values|  | association element    | |default_remove_new_line|  |                             |
++---------------------------------------+--------------------+-----------+------------------------+----------------------------+                             |
+| :code:`association_list_comma`        | |purple_hexa_star| | |values2| | comma                  | |default_remove_new_line|  |                             |
++---------------------------------------+--------------------+-----------+------------------------+----------------------------+-----------------------------+
+| :code:`ignore_single_line`            | N/A                | |values3| | N/A                    | |no|                       | * |ignore_single_line__yes| |
+|                                       |                    |           |                        |                            | * |ignore_single_line__no|  |
++---------------------------------------+--------------------+-----------+------------------------+----------------------------+-----------------------------+
 
 The following figure illustrates where the options will be applied in an procedure call.
 
@@ -83,6 +101,7 @@ The following configuration replicates the above code snippet.
         last_close_paren : 'add_new_line'
         association_list_comma : 'remove_new_line'
         association_element: 'add_new_line'
+        ignore_single_line : 'no'
 
 .. NOTE:: All examples use the above configuration.
 

--- a/vsg/rules/multiline_procedure_call_structure.py
+++ b/vsg/rules/multiline_procedure_call_structure.py
@@ -4,6 +4,7 @@ from vsg import token
 from vsg.rules import check
 from vsg.rules import fix
 from vsg.rules import tokens_of_interest as toi
+from vsg.rules import utils as rules_utils
 
 from vsg.rule_group import structure
 
@@ -29,12 +30,16 @@ class multiline_procedure_call_structure(structure.Rule):
         self.configuration.append('association_list_comma')
         self.association_element = 'ignore'
         self.configuration.append('association_element')
+        self.ignore_single_line = 'no'
+        self.configuration.append('ignore_single_line')
 
     def _get_tokens_of_interest(self, oFile):
         return toi.get_tokens_bounded_by(self.lTokenPairs, oFile)
 
     def _analyze(self, lToi):
         for oToi in lToi:
+            if rules_utils.is_single_line(oToi) and utils.convert_yes_no_option_to_boolean(self.ignore_single_line):
+                continue
 
             _check_first_open_paren(self, oToi)
             _check_last_close_paren(self, oToi)

--- a/vsg/tests/procedure_call/rule_003_test_input.fixed_ignore_single_line__yes.vhd
+++ b/vsg/tests/procedure_call/rule_003_test_input.fixed_ignore_single_line__yes.vhd
@@ -1,0 +1,64 @@
+
+architecture rtl of fifo is
+
+begin
+
+  connect_ports(port_1 => data, port_2 => enable, port_3 => overflow, port_4 => underflow);
+
+  connect_ports
+ (
+ port_1 => data,
+ port_2 => enable,
+ port_3 => overflow,
+ port_4 => underflow
+ );
+
+  connect_ports
+ (
+ port_1 => data,
+ port_2 => enable,
+ port_3 => overflow,
+ port_4 => underflow
+ );
+
+  connect_ports
+ (
+ port_1 => data,
+ port_2 => enable,
+ port_3 => overflow,
+ port_4 => underflow
+ );
+
+  connect_ports
+ (
+    port_1 => data,
+    port_2 => enable,
+    port_3 => overflow,
+    port_4 => underflow
+  );
+
+  connect_ports
+  (
+    port_1 => data
+    ,
+    port_2 => enable,
+    port_3 => overflow
+,
+    port_4 => underflow
+  );
+
+
+  process
+  begin
+
+    connect_ports
+ (
+      port_1   => data,
+      port_2=> enable,
+      port_3 => overflow,
+      port_4       => underflow
+    );
+
+  end process;
+
+end architecture;

--- a/vsg/tests/procedure_call/test_rule_003.py
+++ b/vsg/tests/procedure_call/test_rule_003.py
@@ -38,6 +38,9 @@ lExpected_association_element__remove_new_line = []
 lExpected_association_element__remove_new_line.append('')
 utils.read_file(os.path.join(sTestDir, 'rule_003_test_input.fixed_association_element__remove_new_line.vhd'), lExpected_association_element__remove_new_line)
 
+lExpected_ignore_single_line__yes = []
+lExpected_ignore_single_line__yes.append('')
+utils.read_file(os.path.join(sTestDir, 'rule_003_test_input.fixed_ignore_single_line__yes.vhd'), lExpected_ignore_single_line__yes)
 
 class test_rule(unittest.TestCase):
 
@@ -51,6 +54,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'ignore'
         oRule.association_list_comma = 'ignore'
         oRule.association_element = 'ignore'
+        oRule.ignore_single_line = 'no'
 
         self.assertEqual(oRule.groups, ['structure'])
 
@@ -69,6 +73,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'ignore'
         oRule.association_list_comma = 'ignore'
         oRule.association_element = 'ignore'
+        oRule.ignore_single_line = 'no'
 
         oRule.fix(self.oFile)
 
@@ -85,6 +90,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'ignore'
         oRule.association_list_comma = 'ignore'
         oRule.association_element = 'ignore'
+        oRule.ignore_single_line = 'no'
 
         self.assertTrue(oRule)
         self.assertEqual(oRule.name, 'procedure_call')
@@ -101,6 +107,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'ignore'
         oRule.association_list_comma = 'ignore'
         oRule.association_element = 'ignore'
+        oRule.ignore_single_line = 'no'
 
         oRule.fix(self.oFile)
 
@@ -117,6 +124,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'add_new_line'
         oRule.association_list_comma = 'ignore'
         oRule.association_element = 'ignore'
+        oRule.ignore_single_line = 'no'
 
         self.assertTrue(oRule)
         self.assertEqual(oRule.name, 'procedure_call')
@@ -133,6 +141,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'add_new_line'
         oRule.association_list_comma = 'ignore'
         oRule.association_element = 'ignore'
+        oRule.ignore_single_line = 'no'
 
         oRule.fix(self.oFile)
 
@@ -149,6 +158,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'remove_new_line'
         oRule.association_list_comma = 'ignore'
         oRule.association_element = 'ignore'
+        oRule.ignore_single_line = 'no'
 
         self.assertTrue(oRule)
         self.assertEqual(oRule.name, 'procedure_call')
@@ -165,6 +175,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'remove_new_line'
         oRule.association_list_comma = 'ignore'
         oRule.association_element = 'ignore'
+        oRule.ignore_single_line = 'no'
 
         oRule.fix(self.oFile)
 
@@ -181,6 +192,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'ignore'
         oRule.association_list_comma = 'remove_new_line'
         oRule.association_element = 'ignore'
+        oRule.ignore_single_line = 'no'
 
         self.assertTrue(oRule)
         self.assertEqual(oRule.name, 'procedure_call')
@@ -197,6 +209,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'ignore'
         oRule.association_list_comma = 'remove_new_line'
         oRule.association_element = 'ignore'
+        oRule.ignore_single_line = 'no'
 
         oRule.fix(self.oFile)
 
@@ -213,6 +226,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'ignore'
         oRule.association_list_comma = 'ignore'
         oRule.association_element = 'add_new_line'
+        oRule.ignore_single_line = 'no'
 
         self.assertTrue(oRule)
         self.assertEqual(oRule.name, 'procedure_call')
@@ -229,6 +243,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'ignore'
         oRule.association_list_comma = 'ignore'
         oRule.association_element = 'add_new_line'
+        oRule.ignore_single_line = 'no'
 
         oRule.fix(self.oFile)
 
@@ -245,6 +260,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'ignore'
         oRule.association_list_comma = 'ignore'
         oRule.association_element = 'remove_new_line'
+        oRule.ignore_single_line = 'no'
 
         self.assertTrue(oRule)
         self.assertEqual(oRule.name, 'procedure_call')
@@ -261,6 +277,7 @@ class test_rule(unittest.TestCase):
         oRule.last_close_paren = 'ignore'
         oRule.association_list_comma = 'ignore'
         oRule.association_element = 'remove_new_line'
+        oRule.ignore_single_line = 'no'
 
         oRule.fix(self.oFile)
 
@@ -271,3 +288,36 @@ class test_rule(unittest.TestCase):
         oRule.analyze(self.oFile)
         self.assertEqual(oRule.violations, [])
 
+    def test_rule_003_ignore_single_line__yes(self):
+        oRule = procedure_call.rule_003()
+        oRule.first_open_paren = 'add_new_line'
+        oRule.last_close_paren = 'add_new_line'
+        oRule.association_list_comma = 'ignore'
+        oRule.association_element = 'add_new_line'
+        oRule.ignore_single_line = 'yes'
+
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, 'procedure_call')
+        self.assertEqual(oRule.identifier, '003')
+
+        lExpected = [8, 9, 9, 9, 9, 11, 11, 14, 16, 16, 16, 16, 16, 19, 40]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_003_ignore_single_line__yes(self):
+        oRule = procedure_call.rule_003()
+        oRule.first_open_paren = 'add_new_line'
+        oRule.last_close_paren = 'add_new_line'
+        oRule.association_list_comma = 'ignore'
+        oRule.association_element = 'add_new_line'
+        oRule.ignore_single_line = 'yes'
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_ignore_single_line__yes , lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])


### PR DESCRIPTION
Resolves #1076.

I have set the default value of the new option to `no` to avoid modifying the tool's default behaviour from what exists currently.