### PR TITLE
Issue#1084: Updated docstring for `iteration_scheme_501`.

### DIFF
--- a/docs/iteration_scheme_rules.rst
+++ b/docs/iteration_scheme_rules.rst
@@ -1,7 +1,7 @@
 .. include:: includes.rst
 
 Iteration Scheme Rules
------------------------
+----------------------
 
 iteration_scheme_100
 ####################

--- a/vsg/rules/iteration_scheme/rule_501.py
+++ b/vsg/rules/iteration_scheme/rule_501.py
@@ -9,7 +9,7 @@ lTokens.append(token.iteration_scheme.for_keyword)
 
 class rule_501(Rule):
     '''
-    This rule checks the **while** keyword has proper case.
+    This rule checks the **for** keyword has proper case.
 
     |configuring_uppercase_and_lowercase_rules_link|
 

--- a/vsg/tests/rule_doc/test_rule_doc.py
+++ b/vsg/tests/rule_doc/test_rule_doc.py
@@ -338,6 +338,12 @@ class testDocGen(unittest.TestCase):
 
         self.assertEqual(lExpected, lActual)
 
+    def test_iteration_scheme_doc(self):
+
+        lExpected, lActual = compare_files('iteration_scheme')
+
+        self.assertEqual(lExpected, lActual)
+
     def test_length_rules_doc(self):
 
         lExpected, lActual = compare_files('length')


### PR DESCRIPTION
Resolves #1084.
I also updated the iteration_scheme_rules.rst page with a `-` that was present in the autogenerated page but missing from the page in source control.