### PR TITLE
Issue#1086: Corrected VHDL examples in "Configuring Multiline Indent Rules"

### DIFF
--- a/docs/configuring_multiline_indent_rules.rst
+++ b/docs/configuring_multiline_indent_rules.rst
@@ -33,7 +33,7 @@ There are several options to these rules:
    :code:`yes`
 
 .. |default_no| replace::
-   :code:`no`   
+   :code:`no`
 
 +---------------+----------+---------------+----------------------+
 | Option        | Values   | Default       | Description          |

--- a/docs/configuring_multiline_indent_rules.rst
+++ b/docs/configuring_multiline_indent_rules.rst
@@ -50,7 +50,7 @@ This is an example of how to configure the option.
 .. code-block:: yaml
 
    rule :
-     constant_012:
+     concurrent_003:
         align_left : "no"
         align_paren : "yes"
 

--- a/docs/configuring_multiline_indent_rules.rst
+++ b/docs/configuring_multiline_indent_rules.rst
@@ -83,23 +83,22 @@ Example: |align_left| set to |default_no| and |align_paren| set to |default_no|
 .. code-block:: vhdl
 
   wr_en <= resize(unsigned(I_FOO) +
-                  unsigned(I_BAR), q_foo'length);
+             unsigned(I_BAR), q_foo'length);
 
   wr_en <=
            resize(unsigned(I_FOO) +
-                  unsigned(I_BAR), q_foo'length);
+             unsigned(I_BAR), q_foo'length);
 
 Example: |align_left| set to |default_yes| and |align_paren| set to |default_yes|
 #################################################################################
 
 .. code-block:: vhdl
-
   wr_en <= resize(unsigned(I_FOO) +
-      unsigned(I_BAR), q_foo'length);
+                  unsigned(I_BAR), q_foo'length);
 
   wr_en <=
     resize(unsigned(I_FOO) +
-    unsigned(I_BAR), q_foo'length);
+           unsigned(I_BAR), q_foo'length);
 
 Example: |align_left| set to |default_no| and |align_paren| set to |default_yes|
 ################################################################################
@@ -111,7 +110,7 @@ Example: |align_left| set to |default_no| and |align_paren| set to |default_yes|
 
   wr_en <=
            resize(unsigned(I_FOO) +
-                   unsigned(I_BAR), q_foo'length);
+                  unsigned(I_BAR), q_foo'length);
 
 Rules Enforcing Multiline Indent Rules
 ######################################


### PR DESCRIPTION
Resolves #1086