### PR TITLE
Issue#1120: Uncommented lines of code

### DIFF
--- a/vsg/tests/tool_integration/quality_report/test_main.py
+++ b/vsg/tests/tool_integration/quality_report/test_main.py
@@ -26,8 +26,8 @@ class testMain(unittest.TestCase):
         if os.path.isfile('deleteme.json'):
             os.remove('deleteme.json')
 
-#        if os.path.isfile('actual.json'):
-#            os.remove('actual.json')
+        if os.path.isfile('actual.json'):
+            os.remove('actual.json')
 
 
     @mock.patch('sys.stdout')


### PR DESCRIPTION
Resolves #1120.
Lines of code to remove `actual.sjon` in the teardown of `testMain` were commented out, leaving the test file behind after the test. Uncommenting the lines corrects the issue.