### PR TITLE
Issue#1127: Corrected formatting for code block in "Configuring Multiline Indent Rules" page.

### DIFF
--- a/docs/configuring_multiline_indent_rules.rst
+++ b/docs/configuring_multiline_indent_rules.rst
@@ -93,6 +93,7 @@ Example: |align_left| set to |default_yes| and |align_paren| set to |default_yes
 #################################################################################
 
 .. code-block:: vhdl
+
   wr_en <= resize(unsigned(I_FOO) +
                   unsigned(I_BAR), q_foo'length);
 


### PR DESCRIPTION
Resolves #1127.