### PR TITLE
Fix bug in whitespace between tokens and add test for it

### DIFF
--- a/tests/element_association/rule_100_test_input.fixed_spaces_gte2.vhd
+++ b/tests/element_association/rule_100_test_input.fixed_spaces_gte2.vhd
@@ -1,0 +1,29 @@
+
+architecture rtl of fifo is
+
+begin
+
+  a <= (others  => (others  => '0'));
+
+  process begin
+
+    a <= (others  => (others  => '0'));
+
+  end process;
+
+end architecture;
+
+
+architecture rtl of fifo is
+
+begin
+
+  a <= (others  => (others          => '0'));
+
+  process begin
+
+    a <= (others        => (others  => '0'));
+
+  end process;
+
+end architecture;

--- a/tests/element_association/test_rule_100.py
+++ b/tests/element_association/test_rule_100.py
@@ -15,6 +15,10 @@ lExpected = []
 lExpected.append("")
 utils.read_file(os.path.join(sTestDir, "rule_100_test_input.fixed.vhd"), lExpected)
 
+lExpected_spaces_gte2 = []
+lExpected_spaces_gte2.append("")
+utils.read_file(os.path.join(sTestDir, "rule_100_test_input.fixed_spaces_gte2.vhd"), lExpected_spaces_gte2)
+
 
 class test_element_association_rule(unittest.TestCase):
     def setUp(self):
@@ -40,6 +44,28 @@ class test_element_association_rule(unittest.TestCase):
         lActual = self.oFile.get_lines()
 
         self.assertEqual(lExpected, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])
+
+    def test_rule_100_spaces_2_plus(self):
+        oRule = element_association.rule_100()
+        oRule.number_of_spaces = "2+"
+
+        lExpected = [6, 6, 10, 10, 21, 25]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_100_spaces_2_plus(self):
+        oRule = element_association.rule_100()
+        oRule.number_of_spaces = "2+"
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_spaces_gte2, lActual)
 
         oRule.analyze(self.oFile)
         self.assertEqual(oRule.violations, [])

--- a/vsg/rules/whitespace_between_tokens.py
+++ b/vsg/rules/whitespace_between_tokens.py
@@ -59,6 +59,8 @@ class Rule(whitespace.Rule):
             return int(self.number_of_spaces[2:])
         elif self.number_of_spaces_is_gt():
             return int(self.number_of_spaces[1:])
+        elif self.number_of_spaces_is_plus():
+            return int(self.number_of_spaces[:-1])
 
     def analyze_whitespace_token(self, oToi):
         if self.number_of_spaces_is_an_integer():
@@ -130,7 +132,7 @@ class Rule(whitespace.Rule):
             if isinstance(lTokens[1], parser.whitespace):
                 lTokens[1].set_value(" " * dAction["spaces"])
             else:
-                rules_utils.insert_whitespace(lTokens, dAction["spaces"])
+                rules_utils.insert_whitespace(lTokens, 1, num=dAction["spaces"])
         oViolation.set_tokens(lTokens)
 
 


### PR DESCRIPTION
**Description**
Fixes two bugs in `whitespace_between_tokens.py`. The first bug is passing the number of spaces as index into `lTokens` instead of the `num` parameter. This fails when `number_of_spaces` is more than 1,  and is silently catched by an `except IndexError`.

The second bug is fixed by adding extraction of `number_of_spaces` if the number ends with a  `+`.  There already is a function for analyzing if it exists, but the functionality of extracting it is missing. 

Also add a test in `element_association` that checks that you can set `number_of_spaces: '2+'`, covering both these bugs.
