### PR TITLE
vsg: print file name when ClassifyError

### DIFF
--- a/tests/vsg/test_main.py
+++ b/tests/vsg/test_main.py
@@ -167,13 +167,14 @@ class testMain(unittest.TestCase):
     @mock.patch("sys.stderr")
     def test_junit_with_file_that_fails_to_parse(self, mock_stderr):
         lStdErr = []
+        lStdErr.append("Error while processing tests/vsg/junit/parse_error.vhd: ")
         lStdErr.append("Error: Unexpected token detected while parsing architecture_body @ Line 4, Column 1 in file tests/vsg/junit/parse_error.vhd")
         lStdErr.append("       Expecting : begin")
         lStdErr.append("       Found     : end")
 
         junit_file = os.path.join(self._tmpdir.name, "config_error.actual.xml")
         lExpected = []
-        lExpected.append(mock.call("\n" + "\n".join(lStdErr) + "\n"))
+        lExpected.append(mock.call("\n".join(lStdErr) + "\n"))
         lExpected.append(mock.call("\n"))
 
         sys.argv = ["vsg"]

--- a/vsg/apply_rules.py
+++ b/vsg/apply_rules.py
@@ -87,7 +87,7 @@ def apply_rules(commandLineArguments, oConfig, tIndexFileName):
         dJsonEntry["file_path"] = sFileName
         dJsonEntry["violations"] = []
         sOutputStd = ""
-        sOutputErr = e.message
+        sOutputErr = f"Error while processing {sFileName}: {e.message}"
         return fExitStatus, testCase, dJsonEntry, sOutputStd, sOutputErr, bKeepProcessingFiles
 
     oVhdlFile.set_indent_map(dIndent)
@@ -106,7 +106,7 @@ def apply_rules(commandLineArguments, oConfig, tIndexFileName):
         dJsonEntry["file_path"] = sFileName
         dJsonEntry["violations"] = []
         sOutputStd = ""
-        sOutputErr = e.message
+        sOutputErr = f"Error while processing {sFileName}: {e.message}"
         return fExitStatus, testCase, dJsonEntry, sOutputStd, sOutputErr, bStopProcessingFiles
 
     if commandLineArguments.fix:


### PR DESCRIPTION
In current implementation the user see something like the following when `ClassifyError` is raised:

```
    Error: Unexpected token detected while parsing procedure_call_statement @ Line 49, Column 22 in file None
           Expecting : ;
           Found     : )
```

In a project that contains multiple files, the user is clueless as he does not know which of the files caused the error.

This change adds the name of the file to the message.

```
    Error while processing xxx:
    Error: Unexpected token detected while parsing procedure_call_statement @ Line 49, Column 22 in file None
           Expecting : ;
           Found     : )
````
