### PR TITLE
Issue-1225 vsg_rule_doc_gen script does not run.

### DIFF
--- a/docs/ieee_rules.rst
+++ b/docs/ieee_rules.rst
@@ -1,4 +1,3 @@
-
 .. include:: includes.rst
 
 IEEE Rules

--- a/docs/reserved_rules.rst
+++ b/docs/reserved_rules.rst
@@ -6,7 +6,7 @@ Reserved Rules
 reserved_001
 ############
 
-|phase_1| |error| |structure|
+|phase_1| |error| |unfixable| |structure|
 
 This rule checks for VHDL reserved words being used as identifiers and names.
 

--- a/tests/rule_doc/test_rule_doc_gen_main.py
+++ b/tests/rule_doc/test_rule_doc_gen_main.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+import unittest
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from vsg import __rule_doc_gen__
+
+
+class testMain(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = TemporaryDirectory()
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    @mock.patch("sys.stdout")
+    def test_w_user_provided_path(self, mock_stdout):
+        lExpected = []
+
+        sys.argv = ["vsg_rule_doc_gen"]
+        sys.argv.extend(["-p", self._tmpdir.name])
+
+        try:
+            __rule_doc_gen__.main()
+        except SystemExit:
+            pass
+
+        # Check that the temporary directory is not empty after document
+        # generation. Detailed checking is left to test_rule_doc.
+        self.assertNotEqual([], os.listdir(self._tmpdir.name))
+
+        mock_stdout.write.assert_has_calls(lExpected)

--- a/vsg/__rule_doc_gen__.py
+++ b/vsg/__rule_doc_gen__.py
@@ -26,7 +26,7 @@ def main():
 
     commandLineArguments = parse_command_line_arguments()
 
-    create_rule_documentation()
+    create_rule_documentation(commandLineArguments.path)
 
     sys.exit(fExitStatus)
 

--- a/vsg/__rule_doc_gen__.py
+++ b/vsg/__rule_doc_gen__.py
@@ -9,10 +9,7 @@ from . import config, rule_list, vhdlFile
 def parse_command_line_arguments():
     """Parses the command line arguments and returns them."""
 
-    parser = argparse.ArgumentParser(
-        prog="VHDL Style Guide (VSG) Rule Documentation Generator",
-        description="""Outputs formatted rule documentation."""
-    )
+    parser = argparse.ArgumentParser(prog="VHDL Style Guide (VSG) Rule Documentation Generator", description="""Outputs formatted rule documentation.""")
 
     sDocsPath = os.path.join(os.path.dirname(__file__), "../docs")
 

--- a/vsg/__rule_doc_gen__.py
+++ b/vsg/__rule_doc_gen__.py
@@ -9,12 +9,14 @@ from . import config, rule_list, vhdlFile
 def parse_command_line_arguments():
     """Parses the command line arguments and returns them."""
 
-    parser = argparse.ArgumentParser(prog="VHDL Style Guide (VSG) Rule Documentation Generator", description="""Outputs formatted rule documentation.""")
+    parser = argparse.ArgumentParser(
+        prog="VHDL Style Guide (VSG) Rule Documentation Generator",
+        description="""Outputs formatted rule documentation."""
+    )
 
     sDocsPath = os.path.join(os.path.dirname(__file__), "../docs")
 
     parser.add_argument("-p", "--path", default=sDocsPath, help="Path in which to generate the rule documentation")
-
 
     return parser.parse_args()
 

--- a/vsg/__rule_doc_gen__.py
+++ b/vsg/__rule_doc_gen__.py
@@ -11,6 +11,11 @@ def parse_command_line_arguments():
 
     parser = argparse.ArgumentParser(prog="VHDL Style Guide (VSG) Rule Documentation Generator", description="""Outputs formatted rule documentation.""")
 
+    sDocsPath = os.path.join(os.path.dirname(__file__), "../docs")
+
+    parser.add_argument("-p", "--path", default=sDocsPath, help="Path in which to generate the rule documentation")
+
+
     return parser.parse_args()
 
 

--- a/vsg/__rule_doc_gen__.py
+++ b/vsg/__rule_doc_gen__.py
@@ -9,7 +9,7 @@ from . import config, rule_list, vhdlFile
 def parse_command_line_arguments():
     """Parses the command line arguments and returns them."""
 
-    parser = argparse.ArgumentParser(prog="VHDL Style Guide (VSG) Parser", description="""Outputs formatted rule documentation.""")
+    parser = argparse.ArgumentParser(prog="VHDL Style Guide (VSG) Rule Documentation Generator", description="""Outputs formatted rule documentation.""")
 
     return parser.parse_args()
 


### PR DESCRIPTION
Resolves #1225.

I've added a very rudimentary test for the vsg_rule_doc_gen script. It basically just checks that:
- The script runs without crashing.
- The script produces output files to the user-specified directory.
- The script doesn't print anything to stdout.

I haven't done any further in-depth testing since the functionality is very thoroughly tested in test_rule_doc. If you'd like the testing to be more thorough, I'd be happy to work on it a bit more, but, considering that the top-level script wasn't tested at all before, hopefully it's good enough.