### PR TITLE
Issue#1236: Rule for case in hexadecimal constants and base specifier

### DIFF
--- a/docs/bit_string_literal_rules.rst
+++ b/docs/bit_string_literal_rules.rst
@@ -34,6 +34,8 @@ This rule checks the bit value has proper case.
 
 |configuring_uppercase_and_lowercase_rules_link|
 
+The default style is :code:`upper`.
+
 **Violation**
 
 .. code-block:: vhdl

--- a/docs/bit_string_literal_rules.rst
+++ b/docs/bit_string_literal_rules.rst
@@ -1,0 +1,48 @@
+.. include:: includes.rst
+
+Bit String Literal Rules
+------------------------
+
+bit_string_literal_500
+######################
+
+|phase_6| |error| |case|
+
+This rule checks the base specifier has proper case.
+
+|configuring_uppercase_and_lowercase_rules_link|
+
+**Violation**
+
+.. code-block:: vhdl
+
+    signal test : my_vector := X"FFF";
+
+
+**Fix**
+
+.. code-block:: vhdl
+
+   signal test : my_vector := x"FFF";
+
+bit_string_literal_501
+######################
+
+|phase_6| |error| |case|
+
+This rule checks the bit value has proper case.
+
+|configuring_uppercase_and_lowercase_rules_link|
+
+**Violation**
+
+.. code-block:: vhdl
+
+    signal test : my_vector := x"FFF";
+
+
+**Fix**
+
+.. code-block:: vhdl
+
+   signal test : my_vector := x"fff";

--- a/docs/configuring_uppercase_and_lowercase_rules.rst
+++ b/docs/configuring_uppercase_and_lowercase_rules.rst
@@ -251,6 +251,9 @@ Rules Enforcing Case
 * `attribute_specification_502 <attribute_specification_rules.html#attribute-specification-502>`_
 * `attribute_specification_503 <attribute_specification_rules.html#attribute-specification-503>`_
 
+* `bit_string_literal_500 <bit_string_literal_rules.html#bit-string-literal-500>`_
+* `bit_string_literal_501 <bit_string_literal_rules.html#bit-string-literal-501>`_
+
 * `block_500 <block_rules.html#block-500>`_
 * `block_501 <block_rules.html#block-501>`_
 * `block_502 <block_rules.html#block-502>`_

--- a/docs/rule_groups/case_rule_group.rst
+++ b/docs/rule_groups/case_rule_group.rst
@@ -31,6 +31,8 @@ Rules Enforcing Case Rule Group
 * `attribute_specification_501 <../attribute_specification_rules.html#attribute-specification-501>`_
 * `attribute_specification_502 <../attribute_specification_rules.html#attribute-specification-502>`_
 * `attribute_specification_503 <../attribute_specification_rules.html#attribute-specification-503>`_
+* `bit_string_literal_500 <bit_string_literal_rules.html#bit-string-literal-500>`_
+* `bit_string_literal_501 <bit_string_literal_rules.html#bit-string-literal-501>`_
 * `block_500 <../block_rules.html#block-500>`_
 * `block_501 <../block_rules.html#block-501>`_
 * `block_502 <../block_rules.html#block-502>`_

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -13,6 +13,7 @@ The rules are divided into categories depending on the part of the VHDL code bei
    attribute_rules.rst
    attribute_declaration_rules.rst
    attribute_specification_rules.rst
+   bit_string_literal_rules.rst
    block_rules.rst
    block_comment_rules.rst
    case_rules.rst

--- a/tests/bit_string_literal/rule_500_test_input.fixed_lower.vhd
+++ b/tests/bit_string_literal/rule_500_test_input.fixed_lower.vhd
@@ -1,0 +1,130 @@
+
+architecture RTL of FIFO is
+
+  -- Examples adapted from those given in the LRM.
+
+  -- Lower
+
+  constant c_test : std_logic_vector := b"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+  constant c_test : std_logic_vector := x"FFF";            -- Equivalent to B"1111_1111_1111".
+  constant c_test : std_logic_vector := o"777";            -- Equivalent to B"111_111_111".
+  constant c_test : std_logic_vector := x"777";            -- Equivalent to B"0111_0111_0111".
+  constant c_test : std_logic_vector := b"XXXX_01LH";      -- Equivalent to the string literal "XXXX01LH"
+  constant c_test : unsigned         := uo"27";            -- Equivalent to B"010_111"
+  constant c_test : unsigned         := uo"2C";            -- Equivalent to B"011_CCC"
+  constant c_test : signed           := sx"3W";            -- Equivalent to B"0011_WWWW"
+  constant c_test : std_logic_vector := d"35";             -- Equivalent to B"100011"
+  constant c_test : std_logic_vector := 12ub"X1";          -- Equivalent to B"0000_0000_00X1"
+  constant c_test : std_logic_vector := 12sb"X1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+  constant c_test : unsigned         := 12ux"F-";          -- Equivalent to B"0000_1111_----"
+  constant c_test : signed           := 12sx"F-";          -- Equivalent to B"1111_1111_----"
+  constant c_test : std_logic_vector := 12d"13";           -- Equivalent to B"0000_0000_1101"
+  constant c_test : unsigned         := 12ux"000WWW";      -- Equivalent to B"WWWW_WWWW_WWWW"
+  constant c_test : signed           := 12sx"FFFC00";      -- Equivalent to B"1100_0000_0000"
+  constant c_test : signed           := 12sx"XXXX00";      -- Equivalent to B"XXXX_0000_0000"
+  constant c_test : std_logic_vector := 8d"511";           -- Error
+  constant c_test : unsigned         := 8uo"477";          -- Error
+  constant c_test : signed           := 8sx"0FF";          -- Error
+  constant c_test : signed           := 8sx"FXX";          -- Error
+  constant c1: STRING := b"1111_1111_1111";
+  constant c2: BIT_VECTOR := x"FFF";
+
+  type MVL is ('X', '0', '1', 'Z');
+  type MVL_VECTOR is array (NATURAL range <>) of MVL;
+  constant c3: MVL_VECTOR := o"777";
+
+  -- Upper
+
+  constant c_test : std_logic_vector := b"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+  constant c_test : std_logic_vector := x"FFF";            -- Equivalent to B"1111_1111_1111".
+  constant c_test : std_logic_vector := o"777";            -- Equivalent to B"111_111_111".
+  constant c_test : std_logic_vector := x"777";            -- Equivalent to B"0111_0111_0111".
+  constant c_test : std_logic_vector := b"XXXX_01LH";      -- Equivalent to the string literal "XXXX01LH"
+  constant c_test : unsigned         := uo"27";            -- Equivalent to B"010_111"
+  constant c_test : unsigned         := uo"2C";            -- Equivalent to B"011_CCC"
+  constant c_test : signed           := sx"3W";            -- Equivalent to B"0011_WWWW"
+  constant c_test : std_logic_vector := d"35";             -- Equivalent to B"100011"
+  constant c_test : std_logic_vector := 12ub"X1";          -- Equivalent to B"0000_0000_00X1"
+  constant c_test : std_logic_vector := 12sb"X1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+  constant c_test : unsigned         := 12ux"F-";          -- Equivalent to B"0000_1111_----"
+  constant c_test : signed           := 12sx"F-";          -- Equivalent to B"1111_1111_----"
+  constant c_test : std_logic_vector := 12d"13";           -- Equivalent to B"0000_0000_1101"
+  constant c_test : unsigned         := 12ux"000WWW";      -- Equivalent to B"WWWW_WWWW_WWWW"
+  constant c_test : signed           := 12sx"FFFC00";      -- Equivalent to B"1100_0000_0000"
+  constant c_test : signed           := 12sx"XXXX00";      -- Equivalent to B"XXXX_0000_0000"
+  constant c_test : std_logic_vector := 8d"511";           -- Error
+  constant c_test : unsigned         := 8uo"477";          -- Error
+  constant c_test : signed           := 8sx"0FF";          -- Error
+  constant c_test : signed           := 8sx"FXX";          -- Error
+  constant c1: STRING := b"1111_1111_1111";
+  constant c2: BIT_VECTOR := x"FFF";
+
+  type MVL is ('X', '0', '1', 'Z');
+  type MVL_VECTOR is array (NATURAL range <>) of MVL;
+  constant c3: MVL_VECTOR := o"777";
+
+begin
+
+  -- Lower
+
+  assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+
+  signal_b  <= b"01uxzwlh-";
+  signal_sb <= sb"01uxzwlh-";
+  signal_ub <= ub"01uxzwlh-";
+  signal_o  <= o"01234567uxzwlh-";
+  signal_so <= so"01234567uxzwlh-";
+  signal_uo <= uo"01234567uxzwlh-";
+  signal_x  <= x"0123456789abcdefuxzwlh-";
+  signal_sx <= sx"0123456789abcdefuxzwlh-";
+  signal_ux <= ux"0123456789abcdefuxzwlh-";
+  signal_d  <= d"0123456789";
+
+  process (all) is
+  begin
+
+    variable_b  := b"01uxzwlh-";
+    variable_sb := sb"01uxzwlh-";
+    variable_ub := ub"01uxzwlh-";
+    variable_o  := o"01234567uxzwlh-";
+    variable_so := so"01234567uxzwlh-";
+    variable_uo := uo"01234567uxzwlh-";
+    variable_x  := x"0123456789abcdefuxzwlh-";
+    variable_sx := sx"0123456789abcdefuxzwlh-";
+    variable_ux := ux"0123456789abcdefuxzwlh-";
+    variable_d  := d"0123456789";
+
+  end process;
+
+  -- Upper
+
+  assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+
+  signal_b  <= b"01uxzwlh-";
+  signal_sb <= sb"01uxzwlh-";
+  signal_ub <= ub"01uxzwlh-";
+  signal_o  <= o"01234567uxzwlh-";
+  signal_so <= so"01234567uxzwlh-";
+  signal_uo <= uo"01234567uxzwlh-";
+  signal_x  <= x"0123456789abcdefuxzwlh-";
+  signal_sx <= sx"0123456789abcdefuxzwlh-";
+  signal_ux <= ux"0123456789abcdefuxzwlh-";
+  signal_d  <= d"0123456789";
+
+  process (all) is
+  begin
+
+    variable_b  := b"01uxzwlh-";
+    variable_sb := sb"01uxzwlh-";
+    variable_ub := ub"01uxzwlh-";
+    variable_o  := o"01234567uxzwlh-";
+    variable_so := so"01234567uxzwlh-";
+    variable_uo := uo"01234567uxzwlh-";
+    variable_x  := x"0123456789abcdefuxzwlh-";
+    variable_sx := sx"0123456789abcdefuxzwlh-";
+    variable_ux := ux"0123456789abcdefuxzwlh-";
+    variable_d  := d"0123456789";
+
+  end process;
+
+end architecture RTL;

--- a/tests/bit_string_literal/rule_500_test_input.fixed_upper.vhd
+++ b/tests/bit_string_literal/rule_500_test_input.fixed_upper.vhd
@@ -1,0 +1,130 @@
+
+architecture RTL of FIFO is
+
+  -- Examples adapted from those given in the LRM.
+
+  -- Lower
+
+  constant c_test : std_logic_vector := B"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+  constant c_test : std_logic_vector := X"FFF";            -- Equivalent to B"1111_1111_1111".
+  constant c_test : std_logic_vector := O"777";            -- Equivalent to B"111_111_111".
+  constant c_test : std_logic_vector := X"777";            -- Equivalent to B"0111_0111_0111".
+  constant c_test : std_logic_vector := B"XXXX_01LH";      -- Equivalent to the string literal "XXXX01LH"
+  constant c_test : unsigned         := UO"27";            -- Equivalent to B"010_111"
+  constant c_test : unsigned         := UO"2C";            -- Equivalent to B"011_CCC"
+  constant c_test : signed           := SX"3W";            -- Equivalent to B"0011_WWWW"
+  constant c_test : std_logic_vector := D"35";             -- Equivalent to B"100011"
+  constant c_test : std_logic_vector := 12UB"X1";          -- Equivalent to B"0000_0000_00X1"
+  constant c_test : std_logic_vector := 12SB"X1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+  constant c_test : unsigned         := 12UX"F-";          -- Equivalent to B"0000_1111_----"
+  constant c_test : signed           := 12SX"F-";          -- Equivalent to B"1111_1111_----"
+  constant c_test : std_logic_vector := 12D"13";           -- Equivalent to B"0000_0000_1101"
+  constant c_test : unsigned         := 12UX"000WWW";      -- Equivalent to B"WWWW_WWWW_WWWW"
+  constant c_test : signed           := 12SX"FFFC00";      -- Equivalent to B"1100_0000_0000"
+  constant c_test : signed           := 12SX"XXXX00";      -- Equivalent to B"XXXX_0000_0000"
+  constant c_test : std_logic_vector := 8D"511";           -- Error
+  constant c_test : unsigned         := 8UO"477";          -- Error
+  constant c_test : signed           := 8SX"0FF";          -- Error
+  constant c_test : signed           := 8SX"FXX";          -- Error
+  constant c1: STRING := B"1111_1111_1111";
+  constant c2: BIT_VECTOR := X"FFF";
+
+  type MVL is ('X', '0', '1', 'Z');
+  type MVL_VECTOR is array (NATURAL range <>) of MVL;
+  constant c3: MVL_VECTOR := O"777";
+
+  -- Upper
+
+  constant c_test : std_logic_vector := B"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+  constant c_test : std_logic_vector := X"FFF";            -- Equivalent to B"1111_1111_1111".
+  constant c_test : std_logic_vector := O"777";            -- Equivalent to B"111_111_111".
+  constant c_test : std_logic_vector := X"777";            -- Equivalent to B"0111_0111_0111".
+  constant c_test : std_logic_vector := B"XXXX_01LH";      -- Equivalent to the string literal "XXXX01LH"
+  constant c_test : unsigned         := UO"27";            -- Equivalent to B"010_111"
+  constant c_test : unsigned         := UO"2C";            -- Equivalent to B"011_CCC"
+  constant c_test : signed           := SX"3W";            -- Equivalent to B"0011_WWWW"
+  constant c_test : std_logic_vector := D"35";             -- Equivalent to B"100011"
+  constant c_test : std_logic_vector := 12UB"X1";          -- Equivalent to B"0000_0000_00X1"
+  constant c_test : std_logic_vector := 12SB"X1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+  constant c_test : unsigned         := 12UX"F-";          -- Equivalent to B"0000_1111_----"
+  constant c_test : signed           := 12SX"F-";          -- Equivalent to B"1111_1111_----"
+  constant c_test : std_logic_vector := 12D"13";           -- Equivalent to B"0000_0000_1101"
+  constant c_test : unsigned         := 12UX"000WWW";      -- Equivalent to B"WWWW_WWWW_WWWW"
+  constant c_test : signed           := 12SX"FFFC00";      -- Equivalent to B"1100_0000_0000"
+  constant c_test : signed           := 12SX"XXXX00";      -- Equivalent to B"XXXX_0000_0000"
+  constant c_test : std_logic_vector := 8D"511";           -- Error
+  constant c_test : unsigned         := 8UO"477";          -- Error
+  constant c_test : signed           := 8SX"0FF";          -- Error
+  constant c_test : signed           := 8SX"FXX";          -- Error
+  constant c1: STRING := B"1111_1111_1111";
+  constant c2: BIT_VECTOR := X"FFF";
+
+  type MVL is ('X', '0', '1', 'Z');
+  type MVL_VECTOR is array (NATURAL range <>) of MVL;
+  constant c3: MVL_VECTOR := O"777";
+
+begin
+
+  -- Lower
+
+  assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+
+  signal_b  <= B"01uxzwlh-";
+  signal_sb <= SB"01uxzwlh-";
+  signal_ub <= UB"01uxzwlh-";
+  signal_o  <= O"01234567uxzwlh-";
+  signal_so <= SO"01234567uxzwlh-";
+  signal_uo <= UO"01234567uxzwlh-";
+  signal_x  <= X"0123456789abcdefuxzwlh-";
+  signal_sx <= SX"0123456789abcdefuxzwlh-";
+  signal_ux <= UX"0123456789abcdefuxzwlh-";
+  signal_d  <= D"0123456789";
+
+  process (all) is
+  begin
+
+    variable_b  := B"01uxzwlh-";
+    variable_sb := SB"01uxzwlh-";
+    variable_ub := UB"01uxzwlh-";
+    variable_o  := O"01234567uxzwlh-";
+    variable_so := SO"01234567uxzwlh-";
+    variable_uo := UO"01234567uxzwlh-";
+    variable_x  := X"0123456789abcdefuxzwlh-";
+    variable_sx := SX"0123456789abcdefuxzwlh-";
+    variable_ux := UX"0123456789abcdefuxzwlh-";
+    variable_d  := D"0123456789";
+
+  end process;
+
+  -- Upper
+
+  assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+
+  signal_b  <= B"01uxzwlh-";
+  signal_sb <= SB"01uxzwlh-";
+  signal_ub <= UB"01uxzwlh-";
+  signal_o  <= O"01234567uxzwlh-";
+  signal_so <= SO"01234567uxzwlh-";
+  signal_uo <= UO"01234567uxzwlh-";
+  signal_x  <= X"0123456789abcdefuxzwlh-";
+  signal_sx <= SX"0123456789abcdefuxzwlh-";
+  signal_ux <= UX"0123456789abcdefuxzwlh-";
+  signal_d  <= D"0123456789";
+
+  process (all) is
+  begin
+
+    variable_b  := B"01uxzwlh-";
+    variable_sb := SB"01uxzwlh-";
+    variable_ub := UB"01uxzwlh-";
+    variable_o  := O"01234567uxzwlh-";
+    variable_so := SO"01234567uxzwlh-";
+    variable_uo := UO"01234567uxzwlh-";
+    variable_x  := X"0123456789abcdefuxzwlh-";
+    variable_sx := SX"0123456789abcdefuxzwlh-";
+    variable_ux := UX"0123456789abcdefuxzwlh-";
+    variable_d  := D"0123456789";
+
+  end process;
+
+end architecture RTL;

--- a/tests/bit_string_literal/rule_500_test_input.vhd
+++ b/tests/bit_string_literal/rule_500_test_input.vhd
@@ -1,0 +1,130 @@
+
+architecture RTL of FIFO is
+
+  -- Examples adapted from those given in the LRM.
+
+  -- Lower
+
+  constant c_test : std_logic_vector := b"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+  constant c_test : std_logic_vector := x"FFF";            -- Equivalent to B"1111_1111_1111".
+  constant c_test : std_logic_vector := o"777";            -- Equivalent to B"111_111_111".
+  constant c_test : std_logic_vector := x"777";            -- Equivalent to B"0111_0111_0111".
+  constant c_test : std_logic_vector := b"XXXX_01LH";      -- Equivalent to the string literal "XXXX01LH"
+  constant c_test : unsigned         := uo"27";            -- Equivalent to B"010_111"
+  constant c_test : unsigned         := uo"2C";            -- Equivalent to B"011_CCC"
+  constant c_test : signed           := sx"3W";            -- Equivalent to B"0011_WWWW"
+  constant c_test : std_logic_vector := d"35";             -- Equivalent to B"100011"
+  constant c_test : std_logic_vector := 12ub"X1";          -- Equivalent to B"0000_0000_00X1"
+  constant c_test : std_logic_vector := 12sb"X1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+  constant c_test : unsigned         := 12ux"F-";          -- Equivalent to B"0000_1111_----"
+  constant c_test : signed           := 12sx"F-";          -- Equivalent to B"1111_1111_----"
+  constant c_test : std_logic_vector := 12d"13";           -- Equivalent to B"0000_0000_1101"
+  constant c_test : unsigned         := 12ux"000WWW";      -- Equivalent to B"WWWW_WWWW_WWWW"
+  constant c_test : signed           := 12sx"FFFC00";      -- Equivalent to B"1100_0000_0000"
+  constant c_test : signed           := 12sx"XXXX00";      -- Equivalent to B"XXXX_0000_0000"
+  constant c_test : std_logic_vector := 8d"511";           -- Error
+  constant c_test : unsigned         := 8uo"477";          -- Error
+  constant c_test : signed           := 8sx"0FF";          -- Error
+  constant c_test : signed           := 8sx"FXX";          -- Error
+  constant c1: STRING := b"1111_1111_1111";
+  constant c2: BIT_VECTOR := x"FFF";
+
+  type MVL is ('X', '0', '1', 'Z');
+  type MVL_VECTOR is array (NATURAL range <>) of MVL;
+  constant c3: MVL_VECTOR := o"777";
+
+  -- Upper
+
+  constant c_test : std_logic_vector := B"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+  constant c_test : std_logic_vector := X"FFF";            -- Equivalent to B"1111_1111_1111".
+  constant c_test : std_logic_vector := O"777";            -- Equivalent to B"111_111_111".
+  constant c_test : std_logic_vector := X"777";            -- Equivalent to B"0111_0111_0111".
+  constant c_test : std_logic_vector := B"XXXX_01LH";      -- Equivalent to the string literal "XXXX01LH"
+  constant c_test : unsigned         := UO"27";            -- Equivalent to B"010_111"
+  constant c_test : unsigned         := UO"2C";            -- Equivalent to B"011_CCC"
+  constant c_test : signed           := SX"3W";            -- Equivalent to B"0011_WWWW"
+  constant c_test : std_logic_vector := D"35";             -- Equivalent to B"100011"
+  constant c_test : std_logic_vector := 12UB"X1";          -- Equivalent to B"0000_0000_00X1"
+  constant c_test : std_logic_vector := 12SB"X1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+  constant c_test : unsigned         := 12UX"F-";          -- Equivalent to B"0000_1111_----"
+  constant c_test : signed           := 12SX"F-";          -- Equivalent to B"1111_1111_----"
+  constant c_test : std_logic_vector := 12D"13";           -- Equivalent to B"0000_0000_1101"
+  constant c_test : unsigned         := 12UX"000WWW";      -- Equivalent to B"WWWW_WWWW_WWWW"
+  constant c_test : signed           := 12SX"FFFC00";      -- Equivalent to B"1100_0000_0000"
+  constant c_test : signed           := 12SX"XXXX00";      -- Equivalent to B"XXXX_0000_0000"
+  constant c_test : std_logic_vector := 8D"511";           -- Error
+  constant c_test : unsigned         := 8UO"477";          -- Error
+  constant c_test : signed           := 8SX"0FF";          -- Error
+  constant c_test : signed           := 8SX"FXX";          -- Error
+  constant c1: STRING := B"1111_1111_1111";
+  constant c2: BIT_VECTOR := X"FFF";
+
+  type MVL is ('X', '0', '1', 'Z');
+  type MVL_VECTOR is array (NATURAL range <>) of MVL;
+  constant c3: MVL_VECTOR := O"777";
+
+begin
+
+  -- Lower
+
+  assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+
+  signal_b  <= b"01uxzwlh-";
+  signal_sb <= sb"01uxzwlh-";
+  signal_ub <= ub"01uxzwlh-";
+  signal_o  <= o"01234567uxzwlh-";
+  signal_so <= so"01234567uxzwlh-";
+  signal_uo <= uo"01234567uxzwlh-";
+  signal_x  <= x"0123456789abcdefuxzwlh-";
+  signal_sx <= sx"0123456789abcdefuxzwlh-";
+  signal_ux <= ux"0123456789abcdefuxzwlh-";
+  signal_d  <= d"0123456789";
+
+  process (all) is
+  begin
+
+    variable_b  := b"01uxzwlh-";
+    variable_sb := sb"01uxzwlh-";
+    variable_ub := ub"01uxzwlh-";
+    variable_o  := o"01234567uxzwlh-";
+    variable_so := so"01234567uxzwlh-";
+    variable_uo := uo"01234567uxzwlh-";
+    variable_x  := x"0123456789abcdefuxzwlh-";
+    variable_sx := sx"0123456789abcdefuxzwlh-";
+    variable_ux := ux"0123456789abcdefuxzwlh-";
+    variable_d  := d"0123456789";
+
+  end process;
+
+  -- Upper
+
+  assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+
+  signal_b  <= B"01uxzwlh-";
+  signal_sb <= SB"01uxzwlh-";
+  signal_ub <= UB"01uxzwlh-";
+  signal_o  <= O"01234567uxzwlh-";
+  signal_so <= SO"01234567uxzwlh-";
+  signal_uo <= UO"01234567uxzwlh-";
+  signal_x  <= X"0123456789abcdefuxzwlh-";
+  signal_sx <= SX"0123456789abcdefuxzwlh-";
+  signal_ux <= UX"0123456789abcdefuxzwlh-";
+  signal_d  <= D"0123456789";
+
+  process (all) is
+  begin
+
+    variable_b  := B"01uxzwlh-";
+    variable_sb := SB"01uxzwlh-";
+    variable_ub := UB"01uxzwlh-";
+    variable_o  := O"01234567uxzwlh-";
+    variable_so := SO"01234567uxzwlh-";
+    variable_uo := UO"01234567uxzwlh-";
+    variable_x  := X"0123456789abcdefuxzwlh-";
+    variable_sx := SX"0123456789abcdefuxzwlh-";
+    variable_ux := UX"0123456789abcdefuxzwlh-";
+    variable_d  := D"0123456789";
+
+  end process;
+
+end architecture RTL;

--- a/tests/bit_string_literal/rule_501_test_input.fixed_lower.vhd
+++ b/tests/bit_string_literal/rule_501_test_input.fixed_lower.vhd
@@ -1,0 +1,130 @@
+
+architecture RTL of FIFO is
+
+  -- Examples adapted from those given in the LRM.
+
+  -- Lower
+
+  constant c_test : std_logic_vector := b"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+  constant c_test : std_logic_vector := x"fff";            -- Equivalent to B"1111_1111_1111".
+  constant c_test : std_logic_vector := o"777";            -- Equivalent to B"111_111_111".
+  constant c_test : std_logic_vector := x"777";            -- Equivalent to B"0111_0111_0111".
+  constant c_test : std_logic_vector := b"xxxx_01lh";      -- Equivalent to the string literal "XXXX01LH"
+  constant c_test : unsigned         := uo"27";            -- Equivalent to B"010_111"
+  constant c_test : unsigned         := uo"2c";            -- Equivalent to B"011_CCC"
+  constant c_test : signed           := sx"3w";            -- Equivalent to B"0011_WWWW"
+  constant c_test : std_logic_vector := d"35";             -- Equivalent to B"100011"
+  constant c_test : std_logic_vector := 12ub"x1";          -- Equivalent to B"0000_0000_00X1"
+  constant c_test : std_logic_vector := 12sb"x1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+  constant c_test : unsigned         := 12ux"f-";          -- Equivalent to B"0000_1111_----"
+  constant c_test : signed           := 12sx"f-";          -- Equivalent to B"1111_1111_----"
+  constant c_test : std_logic_vector := 12d"13";           -- Equivalent to B"0000_0000_1101"
+  constant c_test : unsigned         := 12ux"000www";      -- Equivalent to B"WWWW_WWWW_WWWW"
+  constant c_test : signed           := 12sx"fffc00";      -- Equivalent to B"1100_0000_0000"
+  constant c_test : signed           := 12sx"xxxx00";      -- Equivalent to B"XXXX_0000_0000"
+  constant c_test : std_logic_vector := 8d"511";           -- Error
+  constant c_test : unsigned         := 8uo"477";          -- Error
+  constant c_test : signed           := 8sx"0ff";          -- Error
+  constant c_test : signed           := 8sx"fxx";          -- Error
+  constant c1: STRING := b"1111_1111_1111";
+  constant c2: BIT_VECTOR := x"fff";
+
+  type MVL is ('X', '0', '1', 'Z');
+  type MVL_VECTOR is array (NATURAL range <>) of MVL;
+  constant c3: MVL_VECTOR := o"777";
+
+  -- Upper
+
+  constant c_test : std_logic_vector := B"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+  constant c_test : std_logic_vector := X"fff";            -- Equivalent to B"1111_1111_1111".
+  constant c_test : std_logic_vector := O"777";            -- Equivalent to B"111_111_111".
+  constant c_test : std_logic_vector := X"777";            -- Equivalent to B"0111_0111_0111".
+  constant c_test : std_logic_vector := B"xxxx_01lh";      -- Equivalent to the string literal "XXXX01LH"
+  constant c_test : unsigned         := UO"27";            -- Equivalent to B"010_111"
+  constant c_test : unsigned         := UO"2c";            -- Equivalent to B"011_CCC"
+  constant c_test : signed           := SX"3w";            -- Equivalent to B"0011_WWWW"
+  constant c_test : std_logic_vector := D"35";             -- Equivalent to B"100011"
+  constant c_test : std_logic_vector := 12UB"x1";          -- Equivalent to B"0000_0000_00X1"
+  constant c_test : std_logic_vector := 12SB"x1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+  constant c_test : unsigned         := 12UX"f-";          -- Equivalent to B"0000_1111_----"
+  constant c_test : signed           := 12SX"f-";          -- Equivalent to B"1111_1111_----"
+  constant c_test : std_logic_vector := 12D"13";           -- Equivalent to B"0000_0000_1101"
+  constant c_test : unsigned         := 12UX"000www";      -- Equivalent to B"WWWW_WWWW_WWWW"
+  constant c_test : signed           := 12SX"fffc00";      -- Equivalent to B"1100_0000_0000"
+  constant c_test : signed           := 12SX"xxxx00";      -- Equivalent to B"XXXX_0000_0000"
+  constant c_test : std_logic_vector := 8D"511";           -- Error
+  constant c_test : unsigned         := 8UO"477";          -- Error
+  constant c_test : signed           := 8SX"0ff";          -- Error
+  constant c_test : signed           := 8SX"fxx";          -- Error
+  constant c1: STRING := B"1111_1111_1111";
+  constant c2: BIT_VECTOR := X"fff";
+
+  type MVL is ('X', '0', '1', 'Z');
+  type MVL_VECTOR is array (NATURAL range <>) of MVL;
+  constant c3: MVL_VECTOR := O"777";
+
+begin
+
+  -- Lower
+
+  assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+
+  signal_b  <= b"01uxzwlh-";
+  signal_sb <= sb"01uxzwlh-";
+  signal_ub <= ub"01uxzwlh-";
+  signal_o  <= o"01234567uxzwlh-";
+  signal_so <= so"01234567uxzwlh-";
+  signal_uo <= uo"01234567uxzwlh-";
+  signal_x  <= x"0123456789abcdefuxzwlh-";
+  signal_sx <= sx"0123456789abcdefuxzwlh-";
+  signal_ux <= ux"0123456789abcdefuxzwlh-";
+  signal_d  <= d"0123456789";
+
+  process (all) is
+  begin
+
+    variable_b  := b"01uxzwlh-";
+    variable_sb := sb"01uxzwlh-";
+    variable_ub := ub"01uxzwlh-";
+    variable_o  := o"01234567uxzwlh-";
+    variable_so := so"01234567uxzwlh-";
+    variable_uo := uo"01234567uxzwlh-";
+    variable_x  := x"0123456789abcdefuxzwlh-";
+    variable_sx := sx"0123456789abcdefuxzwlh-";
+    variable_ux := ux"0123456789abcdefuxzwlh-";
+    variable_d  := d"0123456789";
+
+  end process;
+
+  -- Upper
+
+  assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+
+  signal_b  <= B"01uxzwlh-";
+  signal_sb <= SB"01uxzwlh-";
+  signal_ub <= UB"01uxzwlh-";
+  signal_o  <= O"01234567uxzwlh-";
+  signal_so <= SO"01234567uxzwlh-";
+  signal_uo <= UO"01234567uxzwlh-";
+  signal_x  <= X"0123456789abcdefuxzwlh-";
+  signal_sx <= SX"0123456789abcdefuxzwlh-";
+  signal_ux <= UX"0123456789abcdefuxzwlh-";
+  signal_d  <= D"0123456789";
+
+  process (all) is
+  begin
+
+    variable_b  := B"01uxzwlh-";
+    variable_sb := SB"01uxzwlh-";
+    variable_ub := UB"01uxzwlh-";
+    variable_o  := O"01234567uxzwlh-";
+    variable_so := SO"01234567uxzwlh-";
+    variable_uo := UO"01234567uxzwlh-";
+    variable_x  := X"0123456789abcdefuxzwlh-";
+    variable_sx := SX"0123456789abcdefuxzwlh-";
+    variable_ux := UX"0123456789abcdefuxzwlh-";
+    variable_d  := D"0123456789";
+
+  end process;
+
+end architecture RTL;

--- a/tests/bit_string_literal/rule_501_test_input.fixed_upper.vhd
+++ b/tests/bit_string_literal/rule_501_test_input.fixed_upper.vhd
@@ -1,0 +1,130 @@
+
+architecture RTL of FIFO is
+
+  -- Examples adapted from those given in the LRM.
+
+  -- Lower
+
+  constant c_test : std_logic_vector := b"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+  constant c_test : std_logic_vector := x"FFF";            -- Equivalent to B"1111_1111_1111".
+  constant c_test : std_logic_vector := o"777";            -- Equivalent to B"111_111_111".
+  constant c_test : std_logic_vector := x"777";            -- Equivalent to B"0111_0111_0111".
+  constant c_test : std_logic_vector := b"XXXX_01LH";      -- Equivalent to the string literal "XXXX01LH"
+  constant c_test : unsigned         := uo"27";            -- Equivalent to B"010_111"
+  constant c_test : unsigned         := uo"2C";            -- Equivalent to B"011_CCC"
+  constant c_test : signed           := sx"3W";            -- Equivalent to B"0011_WWWW"
+  constant c_test : std_logic_vector := d"35";             -- Equivalent to B"100011"
+  constant c_test : std_logic_vector := 12ub"X1";          -- Equivalent to B"0000_0000_00X1"
+  constant c_test : std_logic_vector := 12sb"X1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+  constant c_test : unsigned         := 12ux"F-";          -- Equivalent to B"0000_1111_----"
+  constant c_test : signed           := 12sx"F-";          -- Equivalent to B"1111_1111_----"
+  constant c_test : std_logic_vector := 12d"13";           -- Equivalent to B"0000_0000_1101"
+  constant c_test : unsigned         := 12ux"000WWW";      -- Equivalent to B"WWWW_WWWW_WWWW"
+  constant c_test : signed           := 12sx"FFFC00";      -- Equivalent to B"1100_0000_0000"
+  constant c_test : signed           := 12sx"XXXX00";      -- Equivalent to B"XXXX_0000_0000"
+  constant c_test : std_logic_vector := 8d"511";           -- Error
+  constant c_test : unsigned         := 8uo"477";          -- Error
+  constant c_test : signed           := 8sx"0FF";          -- Error
+  constant c_test : signed           := 8sx"FXX";          -- Error
+  constant c1: STRING := b"1111_1111_1111";
+  constant c2: BIT_VECTOR := x"FFF";
+
+  type MVL is ('X', '0', '1', 'Z');
+  type MVL_VECTOR is array (NATURAL range <>) of MVL;
+  constant c3: MVL_VECTOR := o"777";
+
+  -- Upper
+
+  constant c_test : std_logic_vector := B"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+  constant c_test : std_logic_vector := X"FFF";            -- Equivalent to B"1111_1111_1111".
+  constant c_test : std_logic_vector := O"777";            -- Equivalent to B"111_111_111".
+  constant c_test : std_logic_vector := X"777";            -- Equivalent to B"0111_0111_0111".
+  constant c_test : std_logic_vector := B"XXXX_01LH";      -- Equivalent to the string literal "XXXX01LH"
+  constant c_test : unsigned         := UO"27";            -- Equivalent to B"010_111"
+  constant c_test : unsigned         := UO"2C";            -- Equivalent to B"011_CCC"
+  constant c_test : signed           := SX"3W";            -- Equivalent to B"0011_WWWW"
+  constant c_test : std_logic_vector := D"35";             -- Equivalent to B"100011"
+  constant c_test : std_logic_vector := 12UB"X1";          -- Equivalent to B"0000_0000_00X1"
+  constant c_test : std_logic_vector := 12SB"X1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+  constant c_test : unsigned         := 12UX"F-";          -- Equivalent to B"0000_1111_----"
+  constant c_test : signed           := 12SX"F-";          -- Equivalent to B"1111_1111_----"
+  constant c_test : std_logic_vector := 12D"13";           -- Equivalent to B"0000_0000_1101"
+  constant c_test : unsigned         := 12UX"000WWW";      -- Equivalent to B"WWWW_WWWW_WWWW"
+  constant c_test : signed           := 12SX"FFFC00";      -- Equivalent to B"1100_0000_0000"
+  constant c_test : signed           := 12SX"XXXX00";      -- Equivalent to B"XXXX_0000_0000"
+  constant c_test : std_logic_vector := 8D"511";           -- Error
+  constant c_test : unsigned         := 8UO"477";          -- Error
+  constant c_test : signed           := 8SX"0FF";          -- Error
+  constant c_test : signed           := 8SX"FXX";          -- Error
+  constant c1: STRING := B"1111_1111_1111";
+  constant c2: BIT_VECTOR := X"FFF";
+
+  type MVL is ('X', '0', '1', 'Z');
+  type MVL_VECTOR is array (NATURAL range <>) of MVL;
+  constant c3: MVL_VECTOR := O"777";
+
+begin
+
+  -- Lower
+
+  assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+
+  signal_b  <= b"01UXZWLH-";
+  signal_sb <= sb"01UXZWLH-";
+  signal_ub <= ub"01UXZWLH-";
+  signal_o  <= o"01234567UXZWLH-";
+  signal_so <= so"01234567UXZWLH-";
+  signal_uo <= uo"01234567UXZWLH-";
+  signal_x  <= x"0123456789ABCDEFUXZWLH-";
+  signal_sx <= sx"0123456789ABCDEFUXZWLH-";
+  signal_ux <= ux"0123456789ABCDEFUXZWLH-";
+  signal_d  <= d"0123456789";
+
+  process (all) is
+  begin
+
+    variable_b  := b"01UXZWLH-";
+    variable_sb := sb"01UXZWLH-";
+    variable_ub := ub"01UXZWLH-";
+    variable_o  := o"01234567UXZWLH-";
+    variable_so := so"01234567UXZWLH-";
+    variable_uo := uo"01234567UXZWLH-";
+    variable_x  := x"0123456789ABCDEFUXZWLH-";
+    variable_sx := sx"0123456789ABCDEFUXZWLH-";
+    variable_ux := ux"0123456789ABCDEFUXZWLH-";
+    variable_d  := d"0123456789";
+
+  end process;
+
+  -- Upper
+
+  assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+
+  signal_b  <= B"01UXZWLH-";
+  signal_sb <= SB"01UXZWLH-";
+  signal_ub <= UB"01UXZWLH-";
+  signal_o  <= O"01234567UXZWLH-";
+  signal_so <= SO"01234567UXZWLH-";
+  signal_uo <= UO"01234567UXZWLH-";
+  signal_x  <= X"0123456789ABCDEFUXZWLH-";
+  signal_sx <= SX"0123456789ABCDEFUXZWLH-";
+  signal_ux <= UX"0123456789ABCDEFUXZWLH-";
+  signal_d  <= D"0123456789";
+
+  process (all) is
+  begin
+
+    variable_b  := B"01UXZWLH-";
+    variable_sb := SB"01UXZWLH-";
+    variable_ub := UB"01UXZWLH-";
+    variable_o  := O"01234567UXZWLH-";
+    variable_so := SO"01234567UXZWLH-";
+    variable_uo := UO"01234567UXZWLH-";
+    variable_x  := X"0123456789ABCDEFUXZWLH-";
+    variable_sx := SX"0123456789ABCDEFUXZWLH-";
+    variable_ux := UX"0123456789ABCDEFUXZWLH-";
+    variable_d  := D"0123456789";
+
+  end process;
+
+end architecture RTL;

--- a/tests/bit_string_literal/rule_501_test_input.vhd
+++ b/tests/bit_string_literal/rule_501_test_input.vhd
@@ -1,0 +1,130 @@
+
+architecture RTL of FIFO is
+
+  -- Examples adapted from those given in the LRM.
+
+  -- Lower
+
+  constant c_test : std_logic_vector := b"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+  constant c_test : std_logic_vector := x"FFF";            -- Equivalent to B"1111_1111_1111".
+  constant c_test : std_logic_vector := o"777";            -- Equivalent to B"111_111_111".
+  constant c_test : std_logic_vector := x"777";            -- Equivalent to B"0111_0111_0111".
+  constant c_test : std_logic_vector := b"XXXX_01LH";      -- Equivalent to the string literal "XXXX01LH"
+  constant c_test : unsigned         := uo"27";            -- Equivalent to B"010_111"
+  constant c_test : unsigned         := uo"2C";            -- Equivalent to B"011_CCC"
+  constant c_test : signed           := sx"3W";            -- Equivalent to B"0011_WWWW"
+  constant c_test : std_logic_vector := d"35";             -- Equivalent to B"100011"
+  constant c_test : std_logic_vector := 12ub"X1";          -- Equivalent to B"0000_0000_00X1"
+  constant c_test : std_logic_vector := 12sb"X1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+  constant c_test : unsigned         := 12ux"F-";          -- Equivalent to B"0000_1111_----"
+  constant c_test : signed           := 12sx"F-";          -- Equivalent to B"1111_1111_----"
+  constant c_test : std_logic_vector := 12d"13";           -- Equivalent to B"0000_0000_1101"
+  constant c_test : unsigned         := 12ux"000WWW";      -- Equivalent to B"WWWW_WWWW_WWWW"
+  constant c_test : signed           := 12sx"FFFC00";      -- Equivalent to B"1100_0000_0000"
+  constant c_test : signed           := 12sx"XXXX00";      -- Equivalent to B"XXXX_0000_0000"
+  constant c_test : std_logic_vector := 8d"511";           -- Error
+  constant c_test : unsigned         := 8uo"477";          -- Error
+  constant c_test : signed           := 8sx"0FF";          -- Error
+  constant c_test : signed           := 8sx"FXX";          -- Error
+  constant c1: STRING := b"1111_1111_1111";
+  constant c2: BIT_VECTOR := x"FFF";
+
+  type MVL is ('X', '0', '1', 'Z');
+  type MVL_VECTOR is array (NATURAL range <>) of MVL;
+  constant c3: MVL_VECTOR := o"777";
+
+  -- Upper
+
+  constant c_test : std_logic_vector := B"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+  constant c_test : std_logic_vector := X"FFF";            -- Equivalent to B"1111_1111_1111".
+  constant c_test : std_logic_vector := O"777";            -- Equivalent to B"111_111_111".
+  constant c_test : std_logic_vector := X"777";            -- Equivalent to B"0111_0111_0111".
+  constant c_test : std_logic_vector := B"XXXX_01LH";      -- Equivalent to the string literal "XXXX01LH"
+  constant c_test : unsigned         := UO"27";            -- Equivalent to B"010_111"
+  constant c_test : unsigned         := UO"2C";            -- Equivalent to B"011_CCC"
+  constant c_test : signed           := SX"3W";            -- Equivalent to B"0011_WWWW"
+  constant c_test : std_logic_vector := D"35";             -- Equivalent to B"100011"
+  constant c_test : std_logic_vector := 12UB"X1";          -- Equivalent to B"0000_0000_00X1"
+  constant c_test : std_logic_vector := 12SB"X1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+  constant c_test : unsigned         := 12UX"F-";          -- Equivalent to B"0000_1111_----"
+  constant c_test : signed           := 12SX"F-";          -- Equivalent to B"1111_1111_----"
+  constant c_test : std_logic_vector := 12D"13";           -- Equivalent to B"0000_0000_1101"
+  constant c_test : unsigned         := 12UX"000WWW";      -- Equivalent to B"WWWW_WWWW_WWWW"
+  constant c_test : signed           := 12SX"FFFC00";      -- Equivalent to B"1100_0000_0000"
+  constant c_test : signed           := 12SX"XXXX00";      -- Equivalent to B"XXXX_0000_0000"
+  constant c_test : std_logic_vector := 8D"511";           -- Error
+  constant c_test : unsigned         := 8UO"477";          -- Error
+  constant c_test : signed           := 8SX"0FF";          -- Error
+  constant c_test : signed           := 8SX"FXX";          -- Error
+  constant c1: STRING := B"1111_1111_1111";
+  constant c2: BIT_VECTOR := X"FFF";
+
+  type MVL is ('X', '0', '1', 'Z');
+  type MVL_VECTOR is array (NATURAL range <>) of MVL;
+  constant c3: MVL_VECTOR := O"777";
+
+begin
+
+  -- Lower
+
+  assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+
+  signal_b  <= b"01uxzwlh-";
+  signal_sb <= sb"01uxzwlh-";
+  signal_ub <= ub"01uxzwlh-";
+  signal_o  <= o"01234567uxzwlh-";
+  signal_so <= so"01234567uxzwlh-";
+  signal_uo <= uo"01234567uxzwlh-";
+  signal_x  <= x"0123456789abcdefuxzwlh-";
+  signal_sx <= sx"0123456789abcdefuxzwlh-";
+  signal_ux <= ux"0123456789abcdefuxzwlh-";
+  signal_d  <= d"0123456789";
+
+  process (all) is
+  begin
+
+    variable_b  := b"01uxzwlh-";
+    variable_sb := sb"01uxzwlh-";
+    variable_ub := ub"01uxzwlh-";
+    variable_o  := o"01234567uxzwlh-";
+    variable_so := so"01234567uxzwlh-";
+    variable_uo := uo"01234567uxzwlh-";
+    variable_x  := x"0123456789abcdefuxzwlh-";
+    variable_sx := sx"0123456789abcdefuxzwlh-";
+    variable_ux := ux"0123456789abcdefuxzwlh-";
+    variable_d  := d"0123456789";
+
+  end process;
+
+  -- Upper
+
+  assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+
+  signal_b  <= B"01uxzwlh-";
+  signal_sb <= SB"01uxzwlh-";
+  signal_ub <= UB"01uxzwlh-";
+  signal_o  <= O"01234567uxzwlh-";
+  signal_so <= SO"01234567uxzwlh-";
+  signal_uo <= UO"01234567uxzwlh-";
+  signal_x  <= X"0123456789abcdefuxzwlh-";
+  signal_sx <= SX"0123456789abcdefuxzwlh-";
+  signal_ux <= UX"0123456789abcdefuxzwlh-";
+  signal_d  <= D"0123456789";
+
+  process (all) is
+  begin
+
+    variable_b  := B"01uxzwlh-";
+    variable_sb := SB"01uxzwlh-";
+    variable_ub := UB"01uxzwlh-";
+    variable_o  := O"01234567uxzwlh-";
+    variable_so := SO"01234567uxzwlh-";
+    variable_uo := UO"01234567uxzwlh-";
+    variable_x  := X"0123456789abcdefuxzwlh-";
+    variable_sx := SX"0123456789abcdefuxzwlh-";
+    variable_ux := UX"0123456789abcdefuxzwlh-";
+    variable_d  := D"0123456789";
+
+  end process;
+
+end architecture RTL;

--- a/tests/bit_string_literal/test_rule_500.py
+++ b/tests/bit_string_literal/test_rule_500.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from tests import utils
+from vsg import vhdlFile
+from vsg.rules import bit_string_literal
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_500_test_input.vhd"))
+
+lExpected_lower = []
+lExpected_lower.append("")
+utils.read_file(os.path.join(sTestDir, "rule_500_test_input.fixed_lower.vhd"), lExpected_lower)
+
+lExpected_upper = []
+lExpected_upper.append("")
+utils.read_file(os.path.join(sTestDir, "rule_500_test_input.fixed_upper.vhd"), lExpected_upper)
+
+
+class test_assert_rule(unittest.TestCase):
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_500_lower(self):
+        oRule = bit_string_literal.rule_500()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "bit_string_literal")
+        self.assertEqual(oRule.identifier, "500")
+
+        lExpected = [
+            38,
+            39,
+            40,
+            41,
+            42,
+            43,
+            44,
+            45,
+            46,
+            47,
+            48,
+            49,
+            50,
+            51,
+            52,
+            53,
+            54,
+            55,
+            56,
+            57,
+            58,
+            59,
+            60,
+            64,
+            103,
+            104,
+            105,
+            106,
+            107,
+            108,
+            109,
+            110,
+            111,
+            112,
+            117,
+            118,
+            119,
+            120,
+            121,
+            122,
+            123,
+            124,
+            125,
+            126,
+        ]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(utils.extract_violation_lines_from_violation_object(oRule.violations), lExpected)
+
+    def test_rule_500_upper(self):
+        oRule = bit_string_literal.rule_500()
+        oRule.case = "upper"
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "bit_string_literal")
+        self.assertEqual(oRule.identifier, "500")
+
+        lExpected = [
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28,
+            29,
+            30,
+            34,
+            72,
+            73,
+            74,
+            75,
+            76,
+            77,
+            78,
+            79,
+            80,
+            81,
+            86,
+            87,
+            88,
+            89,
+            90,
+            91,
+            92,
+            93,
+            94,
+            95,
+        ]
+        oRule.analyze(self.oFile)
+        self.assertEqual(utils.extract_violation_lines_from_violation_object(oRule.violations), lExpected)
+
+    def test_fix_rule_500_lower(self):
+        oRule = bit_string_literal.rule_500()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_lower, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])
+
+    def test_fix_rule_500_upper(self):
+        oRule = bit_string_literal.rule_500()
+        oRule.case = "upper"
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_upper, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/tests/bit_string_literal/test_rule_501.py
+++ b/tests/bit_string_literal/test_rule_501.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from tests import utils
+from vsg import vhdlFile
+from vsg.rules import bit_string_literal
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_501_test_input.vhd"))
+
+lExpected_lower = []
+lExpected_lower.append("")
+utils.read_file(os.path.join(sTestDir, "rule_501_test_input.fixed_lower.vhd"), lExpected_lower)
+
+lExpected_upper = []
+lExpected_upper.append("")
+utils.read_file(os.path.join(sTestDir, "rule_501_test_input.fixed_upper.vhd"), lExpected_upper)
+
+
+class test_assert_rule(unittest.TestCase):
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_501_lower(self):
+        oRule = bit_string_literal.rule_501()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "bit_string_literal")
+        self.assertEqual(oRule.identifier, "501")
+
+        lExpected = [9, 12, 14, 15, 17, 18, 19, 20, 22, 23, 24, 27, 28, 30, 39, 42, 44, 45, 47, 48, 49, 50, 52, 53, 54, 57, 58, 60]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(utils.extract_violation_lines_from_violation_object(oRule.violations), lExpected)
+
+    def test_rule_501_upper(self):
+        oRule = bit_string_literal.rule_501()
+        oRule.case = "upper"
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "bit_string_literal")
+        self.assertEqual(oRule.identifier, "501")
+
+        lExpected = [
+            72,
+            73,
+            74,
+            75,
+            76,
+            77,
+            78,
+            79,
+            80,
+            86,
+            87,
+            88,
+            89,
+            90,
+            91,
+            92,
+            93,
+            94,
+            103,
+            104,
+            105,
+            106,
+            107,
+            108,
+            109,
+            110,
+            111,
+            117,
+            118,
+            119,
+            120,
+            121,
+            122,
+            123,
+            124,
+            125,
+        ]
+        oRule.analyze(self.oFile)
+        self.assertEqual(utils.extract_violation_lines_from_violation_object(oRule.violations), lExpected)
+
+    def test_fix_rule_501_lower(self):
+        oRule = bit_string_literal.rule_501()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_lower, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])
+
+    def test_fix_rule_501_upper(self):
+        oRule = bit_string_literal.rule_501()
+        oRule.case = "upper"
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_upper, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/tests/bit_string_literal/test_rule_501.py
+++ b/tests/bit_string_literal/test_rule_501.py
@@ -27,6 +27,7 @@ class test_assert_rule(unittest.TestCase):
 
     def test_rule_501_lower(self):
         oRule = bit_string_literal.rule_501()
+        oRule.case = "lower"
         self.assertTrue(oRule)
         self.assertEqual(oRule.name, "bit_string_literal")
         self.assertEqual(oRule.identifier, "501")
@@ -86,6 +87,7 @@ class test_assert_rule(unittest.TestCase):
 
     def test_fix_rule_501_lower(self):
         oRule = bit_string_literal.rule_501()
+        oRule.case = "lower"
 
         oRule.fix(self.oFile)
 

--- a/tests/rule_doc/test_rule_doc.py
+++ b/tests/rule_doc/test_rule_doc.py
@@ -214,6 +214,11 @@ class testDocGen(unittest.TestCase):
 
         self.assertEqual(lExpected, lActual)
 
+    def test_bit_string_literal_rules_doc(self):
+        lExpected, lActual = self.compare_files("bit_string_literal")
+
+        self.assertEqual(lExpected, lActual)
+
     def test_block_rules_doc(self):
         lExpected, lActual = self.compare_files("block")
 

--- a/tests/smart_tab/timestamp.fixed.vhd
+++ b/tests/smart_tab/timestamp.fixed.vhd
@@ -83,7 +83,7 @@ begin
 
 		if (RESET = '1') then
 			state        <= IDLE;
-			counter      <= X"00000000";
+			counter      <= x"00000000";
 			addr_counter <= "0000000000";
 		else
 			if (save_udi_code = '1') then

--- a/tests/styles/jcl/c16/data_core.fixed.vhd
+++ b/tests/styles/jcl/c16/data_core.fixed.vhd
@@ -162,7 +162,7 @@ begin
     case saz is
 
       when SA_21_0 =>
-        adr_z <= X"0000";
+        adr_z <= x"0000";
 
       when SA_21_LL =>
         adr_z <= ll;

--- a/tests/styles/jcl/c16/data_core.fixed.vhd
+++ b/tests/styles/jcl/c16/data_core.fixed.vhd
@@ -180,7 +180,7 @@ begin
   SEL_AYZ : process (SA(0), adr_z) is
   begin
 
-    adr_yz <= adr_z + (X"000" & "000" & SA(0));
+    adr_yz <= adr_z + (x"000" & "000" & SA(0));
 
   end process SEL_AYZ;
 
@@ -217,9 +217,9 @@ begin
 
     if (rising_edge(CLK_I)) then
       if (CLR = '1') then
-        rr <= X"0000";
-        ll <= X"0000";
-        sp <= X"0000";
+        rr <= x"0000";
+        ll <= x"0000";
+        sp <= x"0000";
       elsif (CE = '1' and T2 = '1') then
         if (WE_RR = '1') then
           rr <= zz;

--- a/tests/styles/jcl/timestamp.fixed.vhd
+++ b/tests/styles/jcl/timestamp.fixed.vhd
@@ -83,7 +83,7 @@ begin
 
     if (RESET = '1') then
       state        <= IDLE;
-      counter      <= X"00000000";
+      counter      <= x"00000000";
       addr_counter <= "0000000000";
     else
       if (save_udi_code = '1') then

--- a/tests/vhdlFile/bit_string_literal/classification_results.txt
+++ b/tests/vhdlFile/bit_string_literal/classification_results.txt
@@ -1,0 +1,530 @@
+--------------------------------------------------------------------------------
+0 |
+--------------------------------------------------------------------------------
+1 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+2 | architecture RTL of FIFO is
+<class 'vsg.token.architecture_body.architecture_keyword'>
+<class 'vsg.token.architecture_body.identifier'>
+<class 'vsg.token.architecture_body.of_keyword'>
+<class 'vsg.token.architecture_body.entity_name'>
+<class 'vsg.token.architecture_body.is_keyword'>
+--------------------------------------------------------------------------------
+3 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+4 |   -- Examples adapted from those given in the LRM.
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+5 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+6 |   constant c_test : std_logic_vector := B"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.std_logic_vector'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+7 |   constant c_test : std_logic_vector := X"FFF";            -- Equivalent to B"1111_1111_1111".
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.std_logic_vector'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+8 |   constant c_test : std_logic_vector := O"777";            -- Equivalent to B"111_111_111".
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.std_logic_vector'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+9 |   constant c_test : std_logic_vector := X"777";            -- Equivalent to B"0111_0111_0111".
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.std_logic_vector'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+10 |   constant c_test : std_logic_vector := B"XXXX_01LH";      -- Equivalent to the string literal "XXXX01LH"
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.std_logic_vector'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+11 |   constant c_test : unsigned         := UO"27";            -- Equivalent to B"010_111"
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.unsigned'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+12 |   constant c_test : unsigned         := UO"2C";            -- Equivalent to B"011_CCC"
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.unsigned'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+13 |   constant c_test : signed           := SX"3W";            -- Equivalent to B"0011_WWWW"
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.signed'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+14 |   constant c_test : std_logic_vector := D"35";             -- Equivalent to B"100011"
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.std_logic_vector'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+15 |   constant c_test : std_logic_vector := 12UB"X1";          -- Equivalent to B"0000_0000_00X1"
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.std_logic_vector'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.integer'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+16 |   constant c_test : std_logic_vector := 12SB"X1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.std_logic_vector'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.integer'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+17 |   constant c_test : unsigned         := 12UX"F-";          -- Equivalent to B"0000_1111_----"
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.unsigned'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.integer'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+18 |   constant c_test : signed           := 12SX"F-";          -- Equivalent to B"1111_1111_----"
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.signed'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.integer'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+19 |   constant c_test : std_logic_vector := 12D"13";           -- Equivalent to B"0000_0000_1101"
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.std_logic_vector'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.integer'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+20 |   constant c_test : unsigned         := 12UX"000WWW";      -- Equivalent to B"WWWW_WWWW_WWWW"
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.unsigned'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.integer'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+21 |   constant c_test : signed           := 12SX"FFFC00";      -- Equivalent to B"1100_0000_0000"
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.signed'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.integer'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+22 |   constant c_test : signed           := 12SX"XXXX00";      -- Equivalent to B"XXXX_0000_0000"
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.signed'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.integer'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+23 |   constant c_test : std_logic_vector := 8D"511";           -- Error
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.std_logic_vector'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.integer'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+24 |   constant c_test : unsigned         := 8UO"477";          -- Error
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.unsigned'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.integer'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+25 |   constant c_test : signed           := 8SX"0FF";          -- Error
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.signed'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.integer'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+26 |   constant c_test : signed           := 8SX"FXX";          -- Error
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.signed'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.integer'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+<class 'vsg.parser.comment'>
+--------------------------------------------------------------------------------
+27 |   constant c1: STRING := B"1111_1111_1111";
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+--------------------------------------------------------------------------------
+28 |   constant c2: BIT_VECTOR := X"FFF";
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+--------------------------------------------------------------------------------
+29 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+30 |   type MVL is ('X', '0', '1', 'Z');
+<class 'vsg.token.full_type_declaration.type_keyword'>
+<class 'vsg.token.full_type_declaration.identifier'>
+<class 'vsg.token.full_type_declaration.is_keyword'>
+<class 'vsg.token.enumeration_type_definition.open_parenthesis'>
+<class 'vsg.token.enumeration_type_definition.enumeration_literal'>
+<class 'vsg.token.enumeration_type_definition.comma'>
+<class 'vsg.token.enumeration_type_definition.enumeration_literal'>
+<class 'vsg.token.enumeration_type_definition.comma'>
+<class 'vsg.token.enumeration_type_definition.enumeration_literal'>
+<class 'vsg.token.enumeration_type_definition.comma'>
+<class 'vsg.token.enumeration_type_definition.enumeration_literal'>
+<class 'vsg.token.enumeration_type_definition.close_parenthesis'>
+<class 'vsg.token.full_type_declaration.semicolon'>
+--------------------------------------------------------------------------------
+31 |   type MVL_VECTOR is array (NATURAL range <>) of MVL;
+<class 'vsg.token.full_type_declaration.type_keyword'>
+<class 'vsg.token.full_type_declaration.identifier'>
+<class 'vsg.token.full_type_declaration.is_keyword'>
+<class 'vsg.token.unbounded_array_definition.array_keyword'>
+<class 'vsg.token.unbounded_array_definition.open_parenthesis'>
+<class 'vsg.token.ieee.std_logic_1164.types.natural'>
+<class 'vsg.token.index_subtype_definition.range_keyword'>
+<class 'vsg.token.index_subtype_definition.undefined_range'>
+<class 'vsg.token.unbounded_array_definition.close_parenthesis'>
+<class 'vsg.token.unbounded_array_definition.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.full_type_declaration.semicolon'>
+--------------------------------------------------------------------------------
+32 |   constant c3: MVL_VECTOR := O"777";
+<class 'vsg.token.constant_declaration.constant_keyword'>
+<class 'vsg.token.constant_declaration.identifier'>
+<class 'vsg.token.constant_declaration.colon'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.constant_declaration.assignment_operator'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.constant_declaration.semicolon'>
+--------------------------------------------------------------------------------
+33 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+34 | begin
+<class 'vsg.token.architecture_body.begin_keyword'>
+--------------------------------------------------------------------------------
+35 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+36 |   assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+<class 'vsg.token.assertion.keyword'>
+<class 'vsg.parser.todo'>
+<class 'vsg.parser.tic'>
+<class 'vsg.token.predefined_attribute.keyword'>
+<class 'vsg.token.relational_operator.equal'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.logical_operator.and_operator'>
+<class 'vsg.parser.todo'>
+<class 'vsg.parser.tic'>
+<class 'vsg.token.predefined_attribute.keyword'>
+<class 'vsg.token.relational_operator.equal'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.logical_operator.and_operator'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.relational_operator.equal'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.concurrent_assertion_statement.semicolon'>
+--------------------------------------------------------------------------------
+37 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+38 |   signal_b  <= B"01uxzwlh-";
+<class 'vsg.token.concurrent_simple_signal_assignment.target'>
+<class 'vsg.token.concurrent_simple_signal_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.concurrent_simple_signal_assignment.semicolon'>
+--------------------------------------------------------------------------------
+39 |   signal_sb <= sB"01uxzwlh-";
+<class 'vsg.token.concurrent_simple_signal_assignment.target'>
+<class 'vsg.token.concurrent_simple_signal_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.concurrent_simple_signal_assignment.semicolon'>
+--------------------------------------------------------------------------------
+40 |   signal_ub <= uB"01uxzwlh-";
+<class 'vsg.token.concurrent_simple_signal_assignment.target'>
+<class 'vsg.token.concurrent_simple_signal_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.concurrent_simple_signal_assignment.semicolon'>
+--------------------------------------------------------------------------------
+41 |   signal_o  <= O"01234567uxzwlh-";
+<class 'vsg.token.concurrent_simple_signal_assignment.target'>
+<class 'vsg.token.concurrent_simple_signal_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.concurrent_simple_signal_assignment.semicolon'>
+--------------------------------------------------------------------------------
+42 |   signal_so <= sO"01234567uxzwlh-";
+<class 'vsg.token.concurrent_simple_signal_assignment.target'>
+<class 'vsg.token.concurrent_simple_signal_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.concurrent_simple_signal_assignment.semicolon'>
+--------------------------------------------------------------------------------
+43 |   signal_uo <= uO"01234567uxzwlh-";
+<class 'vsg.token.concurrent_simple_signal_assignment.target'>
+<class 'vsg.token.concurrent_simple_signal_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.concurrent_simple_signal_assignment.semicolon'>
+--------------------------------------------------------------------------------
+44 |   signal_x  <= X"0123456789abcdefuxzwlh-";
+<class 'vsg.token.concurrent_simple_signal_assignment.target'>
+<class 'vsg.token.concurrent_simple_signal_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.concurrent_simple_signal_assignment.semicolon'>
+--------------------------------------------------------------------------------
+45 |   signal_sx <= sX"0123456789abcdefuxzwlh-";
+<class 'vsg.token.concurrent_simple_signal_assignment.target'>
+<class 'vsg.token.concurrent_simple_signal_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.concurrent_simple_signal_assignment.semicolon'>
+--------------------------------------------------------------------------------
+46 |   signal_ux <= uX"0123456789abcdefuxzwlh-";
+<class 'vsg.token.concurrent_simple_signal_assignment.target'>
+<class 'vsg.token.concurrent_simple_signal_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.concurrent_simple_signal_assignment.semicolon'>
+--------------------------------------------------------------------------------
+47 |   signal_d  <= D"0123456789";
+<class 'vsg.token.concurrent_simple_signal_assignment.target'>
+<class 'vsg.token.concurrent_simple_signal_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.concurrent_simple_signal_assignment.semicolon'>
+--------------------------------------------------------------------------------
+48 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+49 |   process (all) is
+<class 'vsg.token.process_statement.process_keyword'>
+<class 'vsg.token.process_statement.open_parenthesis'>
+<class 'vsg.token.process_sensitivity_list.all_keyword'>
+<class 'vsg.token.process_statement.close_parenthesis'>
+<class 'vsg.token.process_statement.is_keyword'>
+--------------------------------------------------------------------------------
+50 |   begin
+<class 'vsg.token.process_statement.begin_keyword'>
+--------------------------------------------------------------------------------
+51 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+52 |     variable_b  := B"01uxzwlh-";
+<class 'vsg.token.simple_variable_assignment.simple_name'>
+<class 'vsg.token.simple_variable_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.simple_variable_assignment.semicolon'>
+--------------------------------------------------------------------------------
+53 |     variable_sb := sB"01uxzwlh-";
+<class 'vsg.token.simple_variable_assignment.simple_name'>
+<class 'vsg.token.simple_variable_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.simple_variable_assignment.semicolon'>
+--------------------------------------------------------------------------------
+54 |     variable_ub := uB"01uxzwlh-";
+<class 'vsg.token.simple_variable_assignment.simple_name'>
+<class 'vsg.token.simple_variable_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.simple_variable_assignment.semicolon'>
+--------------------------------------------------------------------------------
+55 |     variable_o  := O"01234567uxzwlh-";
+<class 'vsg.token.simple_variable_assignment.simple_name'>
+<class 'vsg.token.simple_variable_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.simple_variable_assignment.semicolon'>
+--------------------------------------------------------------------------------
+56 |     variable_so := sO"01234567uxzwlh-";
+<class 'vsg.token.simple_variable_assignment.simple_name'>
+<class 'vsg.token.simple_variable_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.simple_variable_assignment.semicolon'>
+--------------------------------------------------------------------------------
+57 |     variable_uo := uO"01234567uxzwlh-";
+<class 'vsg.token.simple_variable_assignment.simple_name'>
+<class 'vsg.token.simple_variable_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.simple_variable_assignment.semicolon'>
+--------------------------------------------------------------------------------
+58 |     variable_x  := X"0123456789abcdefuxzwlh-";
+<class 'vsg.token.simple_variable_assignment.simple_name'>
+<class 'vsg.token.simple_variable_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.simple_variable_assignment.semicolon'>
+--------------------------------------------------------------------------------
+59 |     variable_sx := sX"0123456789abcdefuxzwlh-";
+<class 'vsg.token.simple_variable_assignment.simple_name'>
+<class 'vsg.token.simple_variable_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.simple_variable_assignment.semicolon'>
+--------------------------------------------------------------------------------
+60 |     variable_ux := uX"0123456789abcdefuxzwlh-";
+<class 'vsg.token.simple_variable_assignment.simple_name'>
+<class 'vsg.token.simple_variable_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.simple_variable_assignment.semicolon'>
+--------------------------------------------------------------------------------
+61 |     variable_d  := D"0123456789";
+<class 'vsg.token.simple_variable_assignment.simple_name'>
+<class 'vsg.token.simple_variable_assignment.assignment'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
+<class 'vsg.token.simple_variable_assignment.semicolon'>
+--------------------------------------------------------------------------------
+62 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+63 |   end process;
+<class 'vsg.token.process_statement.end_keyword'>
+<class 'vsg.token.process_statement.end_process_keyword'>
+<class 'vsg.token.process_statement.semicolon'>
+--------------------------------------------------------------------------------
+64 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+65 | end architecture RTL;
+<class 'vsg.token.architecture_body.end_keyword'>
+<class 'vsg.token.architecture_body.end_architecture_keyword'>
+<class 'vsg.token.architecture_body.architecture_simple_name'>
+<class 'vsg.token.architecture_body.semicolon'>

--- a/tests/vhdlFile/bit_string_literal/classification_test_input.vhd
+++ b/tests/vhdlFile/bit_string_literal/classification_test_input.vhd
@@ -1,0 +1,65 @@
+
+architecture RTL of FIFO is
+
+  -- Examples adapted from those given in the LRM.
+
+  constant c_test : std_logic_vector := B"1111_1111_1111"; -- Equivalent to the string literal "111111111111".
+  constant c_test : std_logic_vector := X"FFF";            -- Equivalent to B"1111_1111_1111".
+  constant c_test : std_logic_vector := O"777";            -- Equivalent to B"111_111_111".
+  constant c_test : std_logic_vector := X"777";            -- Equivalent to B"0111_0111_0111".
+  constant c_test : std_logic_vector := B"XXXX_01LH";      -- Equivalent to the string literal "XXXX01LH"
+  constant c_test : unsigned         := UO"27";            -- Equivalent to B"010_111"
+  constant c_test : unsigned         := UO"2C";            -- Equivalent to B"011_CCC"
+  constant c_test : signed           := SX"3W";            -- Equivalent to B"0011_WWWW"
+  constant c_test : std_logic_vector := D"35";             -- Equivalent to B"100011"
+  constant c_test : std_logic_vector := 12UB"X1";          -- Equivalent to B"0000_0000_00X1"
+  constant c_test : std_logic_vector := 12SB"X1";          -- Equivalent to B"XXXX_XXXX_XXX1"
+  constant c_test : unsigned         := 12UX"F-";          -- Equivalent to B"0000_1111_----"
+  constant c_test : signed           := 12SX"F-";          -- Equivalent to B"1111_1111_----"
+  constant c_test : std_logic_vector := 12D"13";           -- Equivalent to B"0000_0000_1101"
+  constant c_test : unsigned         := 12UX"000WWW";      -- Equivalent to B"WWWW_WWWW_WWWW"
+  constant c_test : signed           := 12SX"FFFC00";      -- Equivalent to B"1100_0000_0000"
+  constant c_test : signed           := 12SX"XXXX00";      -- Equivalent to B"XXXX_0000_0000"
+  constant c_test : std_logic_vector := 8D"511";           -- Error
+  constant c_test : unsigned         := 8UO"477";          -- Error
+  constant c_test : signed           := 8SX"0FF";          -- Error
+  constant c_test : signed           := 8SX"FXX";          -- Error
+  constant c1: STRING := B"1111_1111_1111";
+  constant c2: BIT_VECTOR := X"FFF";
+
+  type MVL is ('X', '0', '1', 'Z');
+  type MVL_VECTOR is array (NATURAL range <>) of MVL;
+  constant c3: MVL_VECTOR := O"777";
+
+begin
+
+  assert c1'LENGTH = 12 and c2'LENGTH = 12 and c3 = "111111111";
+
+  signal_b  <= B"01uxzwlh-";
+  signal_sb <= sB"01uxzwlh-";
+  signal_ub <= uB"01uxzwlh-";
+  signal_o  <= O"01234567uxzwlh-";
+  signal_so <= sO"01234567uxzwlh-";
+  signal_uo <= uO"01234567uxzwlh-";
+  signal_x  <= X"0123456789abcdefuxzwlh-";
+  signal_sx <= sX"0123456789abcdefuxzwlh-";
+  signal_ux <= uX"0123456789abcdefuxzwlh-";
+  signal_d  <= D"0123456789";
+
+  process (all) is
+  begin
+
+    variable_b  := B"01uxzwlh-";
+    variable_sb := sB"01uxzwlh-";
+    variable_ub := uB"01uxzwlh-";
+    variable_o  := O"01234567uxzwlh-";
+    variable_so := sO"01234567uxzwlh-";
+    variable_uo := uO"01234567uxzwlh-";
+    variable_x  := X"0123456789abcdefuxzwlh-";
+    variable_sx := sX"0123456789abcdefuxzwlh-";
+    variable_ux := uX"0123456789abcdefuxzwlh-";
+    variable_d  := D"0123456789";
+
+  end process;
+
+end architecture RTL;

--- a/tests/vhdlFile/conditional_waveform_assignment/classification_results.txt
+++ b/tests/vhdlFile/conditional_waveform_assignment/classification_results.txt
@@ -37,8 +37,8 @@
 <class 'vsg.parser.todo'>
 <class 'vsg.token.todo.close_parenthesis'>
 <class 'vsg.token.relational_operator.greater_than_or_equal'>
-<class 'vsg.parser.todo'>
-<class 'vsg.parser.todo'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
 <class 'vsg.token.logical_operator.and_operator'>
 <class 'vsg.token.todo.name'>
 <class 'vsg.token.todo.open_parenthesis'>
@@ -47,8 +47,8 @@
 <class 'vsg.parser.todo'>
 <class 'vsg.token.todo.close_parenthesis'>
 <class 'vsg.token.relational_operator.less_than_or_equal'>
-<class 'vsg.parser.todo'>
-<class 'vsg.parser.todo'>
+<class 'vsg.token.bit_string_literal.base_specifier'>
+<class 'vsg.token.bit_string_literal.bit_value_string'>
 <class 'vsg.parser.close_parenthesis'>
 <class 'vsg.token.conditional_expressions.else_keyword'>
 <class 'vsg.parser.character_literal'>

--- a/tests/vhdlFile/test_bit_string_literal.py
+++ b/tests/vhdlFile/test_bit_string_literal.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import os
+import unittest
+
+from tests import utils
+from vsg import vhdlFile
+
+sLrmUnit = utils.extract_lrm_unit_name(__name__)
+
+lFile, eError = vhdlFile.utils.read_vhdlfile(os.path.join(os.path.dirname(__file__), sLrmUnit, "classification_test_input.vhd"))
+oFile = vhdlFile.vhdlFile(lFile)
+
+
+class test_token(unittest.TestCase):
+    def test_classification(self):
+        self.maxDiff = None
+        sTestDir = os.path.join(os.path.dirname(__file__), sLrmUnit)
+
+        lExpected = []
+        utils.read_file(os.path.join(sTestDir, "classification_results.txt"), lExpected, False)
+
+        lActual = []
+
+        for oObject in utils.extract_objects(oFile, True):
+            lActual.append(str(oObject))
+
+        self.assertEqual(lExpected, lActual)

--- a/vsg/rules/__init__.py
+++ b/vsg/rules/__init__.py
@@ -105,6 +105,7 @@ from vsg.rules import assert_statement
 from vsg.rules import attribute
 from vsg.rules import attribute_declaration
 from vsg.rules import attribute_specification
+from vsg.rules import bit_string_literal
 from vsg.rules import block
 from vsg.rules import block_comment
 from vsg.rules import case

--- a/vsg/rules/bit_string_literal/__init__.py
+++ b/vsg/rules/bit_string_literal/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from .rule_500 import rule_500
+from .rule_501 import rule_501

--- a/vsg/rules/bit_string_literal/rule_500.py
+++ b/vsg/rules/bit_string_literal/rule_500.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+from vsg import token
+from vsg.rules import token_case
+
+lTokens = []
+lTokens.append(token.bit_string_literal.base_specifier)
+
+# TODO problem is does_not_contain_any_alpha_characters - it drops out if token starts with ".
+
+class rule_500(token_case):
+    """
+    This rule checks the base specifier has proper case.
+
+    |configuring_uppercase_and_lowercase_rules_link|
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+        signal test : my_vector := X"FFF";
+
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+       signal test : my_vector := x"FFF";
+    """
+
+    def __init__(self):
+        super().__init__(lTokens)

--- a/vsg/rules/bit_string_literal/rule_500.py
+++ b/vsg/rules/bit_string_literal/rule_500.py
@@ -6,7 +6,6 @@ from vsg.rules import token_case
 lTokens = []
 lTokens.append(token.bit_string_literal.base_specifier)
 
-# TODO problem is does_not_contain_any_alpha_characters - it drops out if token starts with ".
 
 class rule_500(token_case):
     """

--- a/vsg/rules/bit_string_literal/rule_501.py
+++ b/vsg/rules/bit_string_literal/rule_501.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+from vsg import token
+from vsg.rules import token_case
+
+lTokens = []
+lTokens.append(token.bit_string_literal.bit_value)
+
+
+class rule_501(token_case):
+    """
+    This rule checks the bit value has proper case.
+
+    |configuring_uppercase_and_lowercase_rules_link|
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+        signal test : my_vector := x"FFF";
+
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+       signal test : my_vector := x"fff";
+    """
+
+    def __init__(self):
+        super().__init__(lTokens)

--- a/vsg/rules/bit_string_literal/rule_501.py
+++ b/vsg/rules/bit_string_literal/rule_501.py
@@ -4,7 +4,7 @@ from vsg import token
 from vsg.rules import token_case
 
 lTokens = []
-lTokens.append(token.bit_string_literal.bit_value)
+lTokens.append(token.bit_string_literal.bit_value_string)
 
 
 class rule_501(token_case):

--- a/vsg/rules/bit_string_literal/rule_501.py
+++ b/vsg/rules/bit_string_literal/rule_501.py
@@ -13,6 +13,8 @@ class rule_501(token_case):
 
     |configuring_uppercase_and_lowercase_rules_link|
 
+    The default style is :code:`upper`.
+
     **Violation**
 
     .. code-block:: vhdl
@@ -29,3 +31,4 @@ class rule_501(token_case):
 
     def __init__(self):
         super().__init__(lTokens)
+        self.case = "upper"

--- a/vsg/rules/case_utils.py
+++ b/vsg/rules/case_utils.py
@@ -13,7 +13,7 @@ def check_for_case_violation(oToi, self, check_prefix=False, check_suffix=False,
     iMyLine = get_violation_line(oToi, iLine)
     oViolation = None
 
-    if does_not_contain_any_alpha_characters(sObjectValue):
+    if self.name != "bit_string_literal" and does_not_contain_any_alpha_characters(sObjectValue):
         return None
 
     elif case_exception_found(sObjectValue, self):

--- a/vsg/token/bit_string_literal.py
+++ b/vsg/token/bit_string_literal.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from vsg import parser
+
+# TODO Maybe this gets absorbed into base_specifier?
+class integer(parser.integer):
+    """
+    unique_id = bit_string_literal : integer
+    """
+
+    def __init__(self, sString="("):
+        super().__init__()
+
+
+class base_specifier(parser.item):
+    """
+    unique_id = bit_string_literal : base_specifier
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)
+
+# TODO Maybe this gets absorbed into bit value?
+class opening_double_quote(parser.item):
+    """
+    unique_id = bit_string_literal : opening_double_quote
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)
+
+class bit_value(parser.item):
+    """
+    unique_id = bit_string_literal : bit_value
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)
+
+# TODO Maybe this gets absorbed into bit value?
+class closing_double_quote(parser.item):
+    """
+    unique_id = bit_string_literal : closing_double_quote
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)
+

--- a/vsg/token/bit_string_literal.py
+++ b/vsg/token/bit_string_literal.py
@@ -20,29 +20,11 @@ class base_specifier(parser.item):
     def __init__(self, sString):
         super().__init__(sString)
 
-# TODO Maybe this gets absorbed into bit value?
-class opening_double_quote(parser.item):
-    """
-    unique_id = bit_string_literal : opening_double_quote
-    """
 
-    def __init__(self, sString):
-        super().__init__(sString)
-
-class bit_value(parser.item):
+class bit_value_string(parser.item):
     """
-    unique_id = bit_string_literal : bit_value
+    unique_id = bit_string_literal : bit_value_string
     """
 
     def __init__(self, sString):
         super().__init__(sString)
-
-# TODO Maybe this gets absorbed into bit value?
-class closing_double_quote(parser.item):
-    """
-    unique_id = bit_string_literal : closing_double_quote
-    """
-
-    def __init__(self, sString):
-        super().__init__(sString)
-

--- a/vsg/token/bit_string_literal.py
+++ b/vsg/token/bit_string_literal.py
@@ -2,14 +2,13 @@
 
 from vsg import parser
 
-# TODO Maybe this gets absorbed into base_specifier?
 class integer(parser.integer):
     """
     unique_id = bit_string_literal : integer
     """
 
-    def __init__(self, sString="("):
-        super().__init__()
+    def __init__(self, sString):
+        super().__init__(sString)
 
 
 class base_specifier(parser.item):

--- a/vsg/token/bit_string_literal.py
+++ b/vsg/token/bit_string_literal.py
@@ -2,6 +2,7 @@
 
 from vsg import parser
 
+
 class integer(parser.integer):
     """
     unique_id = bit_string_literal : integer

--- a/vsg/tokens.py
+++ b/vsg/tokens.py
@@ -22,7 +22,7 @@ def create(sString):
     oLine.combine_characters_into_words()
     oLine.combine_character_literals()
     oLine.split_natural_numbers()
-    oLine.split_bit_string_literals()
+    oLine.split_bit_string_literal_integer_and_base_specifier()
     return oLine.lChars
 
 
@@ -132,7 +132,7 @@ class New:
 
         self.lChars = lReturn
 
-    def split_bit_string_literals(self):
+    def split_bit_string_literal_integer_and_base_specifier(self):
         lReturn = []
         iIndex = 0
         for iIndex, sChar in enumerate(self.lChars):
@@ -140,16 +140,15 @@ class New:
             if iIndex < len(self.lChars) - 1:
                 sNextChar = self.lChars[iIndex + 1]
                 if sChar.lower().endswith(("b", "o", "x", "d")) and sNextChar.startswith('"'):
-                    lReturn.extend(parse_bit_string_literal(sChar))
+                    lReturn.extend(parse_bit_string_literal_integer_and_base_specifier(sChar))
                     continue
             lReturn.append(sChar)
         self.lChars = lReturn
 
 
-def parse_bit_string_literal(sIntegerAndBaseSpecifier):
+def parse_bit_string_literal_integer_and_base_specifier(sIntegerAndBaseSpecifier):
     lReturn = []
     sTemp = ""
-    iIndex = 0
     bCurrentlyParsingInteger = True
     for sChar in sIntegerAndBaseSpecifier:
         if bCurrentlyParsingInteger:

--- a/vsg/tokens.py
+++ b/vsg/tokens.py
@@ -22,6 +22,7 @@ def create(sString):
     oLine.combine_characters_into_words()
     oLine.combine_character_literals()
     oLine.split_natural_numbers()
+    oLine.split_bit_string_literals()
     return oLine.lChars
 
 
@@ -130,6 +131,39 @@ class New:
                 lReturn.append(sChar)
 
         self.lChars = lReturn
+
+    def split_bit_string_literals(self):
+        lReturn = []
+        iIndex = 0
+        for iIndex, sChar in enumerate(self.lChars):
+            sChar = self.lChars[iIndex]
+            if iIndex < len(self.lChars) - 1:
+                sNextChar = self.lChars[iIndex + 1]
+                if sChar.lower().endswith(("b", "o", "x", "d")) and sNextChar.startswith('"'):
+                    lReturn.extend(parse_bit_string_literal(sChar))
+                    continue
+            lReturn.append(sChar)
+        self.lChars = lReturn
+
+
+def parse_bit_string_literal(sIntegerAndBaseSpecifier):
+    lReturn = []
+    sTemp = ""
+    iIndex = 0
+    bCurrentlyParsingInteger = True
+    for sChar in sIntegerAndBaseSpecifier:
+        if bCurrentlyParsingInteger:
+            if sChar.isdigit():
+                sTemp += sChar
+            else:
+                bCurrentlyParsingInteger = False
+                if sTemp != "":
+                    lReturn.append(sTemp)
+                sTemp = sChar
+        else:
+            sTemp += sChar
+    lReturn.append(sTemp)
+    return lReturn
 
 
 def is_natural_number(sString):

--- a/vsg/tokens.py
+++ b/vsg/tokens.py
@@ -137,14 +137,19 @@ class New:
         iIndex = 0
         for iIndex, sChar in enumerate(self.lChars):
             sChar = self.lChars[iIndex]
-            if iIndex < len(self.lChars) - 1:
-                sNextChar = self.lChars[iIndex + 1]
-                if sChar.lower().endswith(("b", "o", "x", "d")) and sNextChar.startswith('"'):
-                    lReturn.extend(parse_bit_string_literal_integer_and_base_specifier(sChar))
-                    continue
+            if is_bit_string_literal_integer_and_base_specifier(iIndex, self.lChars):
+                lReturn.extend(parse_bit_string_literal_integer_and_base_specifier(sChar))
+                continue
             lReturn.append(sChar)
         self.lChars = lReturn
 
+def is_bit_string_literal_integer_and_base_specifier(iIndex, lChars):
+    if iIndex < len(lChars) - 1:
+        sChar = lChars[iIndex]
+        sNextChar = lChars[iIndex + 1]
+        if sChar.lower().endswith(("b", "o", "x", "d")) and sNextChar.startswith('"'):
+            return True
+        return False
 
 def parse_bit_string_literal_integer_and_base_specifier(sIntegerAndBaseSpecifier):
     lReturn = []

--- a/vsg/tokens.py
+++ b/vsg/tokens.py
@@ -143,6 +143,7 @@ class New:
             lReturn.append(sChar)
         self.lChars = lReturn
 
+
 def is_bit_string_literal_integer_and_base_specifier(iIndex, lChars):
     if iIndex < len(lChars) - 1:
         sChar = lChars[iIndex]
@@ -151,23 +152,20 @@ def is_bit_string_literal_integer_and_base_specifier(iIndex, lChars):
             return True
         return False
 
+
 def parse_bit_string_literal_integer_and_base_specifier(sIntegerAndBaseSpecifier):
     lReturn = []
-    sTemp = ""
-    bCurrentlyParsingInteger = True
-    for sChar in sIntegerAndBaseSpecifier:
-        if bCurrentlyParsingInteger:
-            if sChar.isdigit():
-                sTemp += sChar
-            else:
-                bCurrentlyParsingInteger = False
-                if sTemp != "":
-                    lReturn.append(sTemp)
-                sTemp = sChar
-        else:
-            sTemp += sChar
-    lReturn.append(sTemp)
+    iSplitIndex = get_bit_string_literal_integer_and_base_specifier_split_index(sIntegerAndBaseSpecifier)
+    lReturn.append(sIntegerAndBaseSpecifier[:iSplitIndex])
+    lReturn.append(sIntegerAndBaseSpecifier[iSplitIndex:])
+    lReturn = [x for x in lReturn if x != ""]
     return lReturn
+
+
+def get_bit_string_literal_integer_and_base_specifier_split_index(sIntegerAndBaseSpecifier):
+    for iIndex in range(len(sIntegerAndBaseSpecifier)):
+        if not sIntegerAndBaseSpecifier[iIndex].isdigit():
+            return iIndex
 
 
 def is_natural_number(sString):

--- a/vsg/vhdlFile/classify/bit_string_literal.py
+++ b/vsg/vhdlFile/classify/bit_string_literal.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
 
-from vsg import parser
 from vsg.token import bit_string_literal as token
 from vsg.vhdlFile import utils
+
+sIntegerPattern = r"^\d+$"
+sBaseSpecifierPattern = r"^(([us]?[box])|d)$"
+sBitValueStringPattern = r"^\"[0-9a-fhluwxz\-_]*\"$"
 
 
 def detect(iToken, lObjects):
@@ -12,20 +15,23 @@ def detect(iToken, lObjects):
         [ integer ] base_specifier " [ bit_value ] "
     """
 
-# XXX SUCCESS! We are parsing the bit_value and base specifier!
-# TODO can we split the tokens up?
-
-    if utils.matches_next_token(r"^\d*(([us]?[box])|d)$", iToken, lObjects):
-        iCurrent = utils.find_next_token(iToken, lObjects)
+    iCurrent = utils.find_next_token(iToken, lObjects)
+    if utils.matches_next_token(sIntegerPattern, iToken, lObjects):
         iCurrent += 1
-        if utils.matches_next_token(r"^\"[0-9a-fhluwxz\-_]*\"$", iCurrent, lObjects):
+    if utils.matches_next_token(sBaseSpecifierPattern, iCurrent, lObjects):
+        iCurrent = utils.find_next_token(iCurrent, lObjects)
+        iCurrent += 1
+        if utils.matches_next_token(sBitValueStringPattern, iCurrent, lObjects):
             return classify(iToken, lObjects)
-
     return iToken
 
+
 def classify(iToken, lObjects):
-    iCurrent = utils.assign_next_token(token.base_specifier, iToken, lObjects)
+
+    if utils.matches_next_token(sIntegerPattern, iToken, lObjects):
+        iCurrent = utils.assign_next_token(token.integer, iToken, lObjects)
+    else:
+        iCurrent = iToken
+    iCurrent = utils.assign_next_token(token.base_specifier, iCurrent, lObjects)
     iCurrent = utils.assign_next_token(token.bit_value_string, iCurrent, lObjects)
     return iCurrent
-
-# ["B", "O", "X", "UB", "UO", "UX", "SB", "SO", "SX", "D"]

--- a/vsg/vhdlFile/classify/bit_string_literal.py
+++ b/vsg/vhdlFile/classify/bit_string_literal.py
@@ -27,7 +27,6 @@ def detect(iToken, lObjects):
 
 
 def classify(iToken, lObjects):
-
     if utils.matches_next_token(sIntegerPattern, iToken, lObjects):
         iCurrent = utils.assign_next_token(token.integer, iToken, lObjects)
     else:

--- a/vsg/vhdlFile/classify/bit_string_literal.py
+++ b/vsg/vhdlFile/classify/bit_string_literal.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+
+from vsg import parser
+from vsg.token import bit_string_literal as token
+from vsg.vhdlFile import utils
+
+
+def detect(iToken, lObjects):
+    """
+    bit_string_literal ::=
+        [ integer ] base_specifier " [ bit_value ] "
+    """
+
+# XXX SUCCESS! We are parsing the bit_value and base specifier!
+# TODO can we split the tokens up?
+
+    if utils.matches_next_token(r"^\d*(([us]?[box])|d)$", iToken, lObjects):
+        iCurrent = utils.find_next_token(iToken, lObjects)
+        iCurrent += 1
+        if utils.matches_next_token(r"^\"[0-9a-fhluwxz\-_]*\"$", iCurrent, lObjects):
+            return classify(iToken, lObjects)
+
+    return iToken
+
+def classify(iToken, lObjects):
+    iCurrent = utils.assign_next_token(token.base_specifier, iToken, lObjects)
+    iCurrent = utils.assign_next_token(token.bit_value, iCurrent, lObjects)
+    return iCurrent
+
+# ["B", "O", "X", "UB", "UO", "UX", "SB", "SO", "SX", "D"]

--- a/vsg/vhdlFile/classify/bit_string_literal.py
+++ b/vsg/vhdlFile/classify/bit_string_literal.py
@@ -25,7 +25,7 @@ def detect(iToken, lObjects):
 
 def classify(iToken, lObjects):
     iCurrent = utils.assign_next_token(token.base_specifier, iToken, lObjects)
-    iCurrent = utils.assign_next_token(token.bit_value, iCurrent, lObjects)
+    iCurrent = utils.assign_next_token(token.bit_value_string, iCurrent, lObjects)
     return iCurrent
 
 # ["B", "O", "X", "UB", "UO", "UX", "SB", "SO", "SX", "D"]

--- a/vsg/vhdlFile/classify/bit_string_literal.py
+++ b/vsg/vhdlFile/classify/bit_string_literal.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
+import re
 
 from vsg.token import bit_string_literal as token
 from vsg.vhdlFile import utils
 
-sIntegerPattern = r"^\d+$"
-sBaseSpecifierPattern = r"^(([us]?[box])|d)$"
-sBitValueStringPattern = r"^\"[0-9a-fhluwxz\-_]*\"$"
+oIntegerRegex = re.compile("\d+")
+oBaseSpecifierRegex = re.compile("(([us]?[box])|d)")
+oBitValueStringRegex = re.compile('"[0-9a-fhluwxz\-_]*"')
 
 
 def detect(iToken, lObjects):
@@ -16,18 +17,18 @@ def detect(iToken, lObjects):
     """
 
     iCurrent = utils.find_next_token(iToken, lObjects)
-    if utils.matches_next_token(sIntegerPattern, iToken, lObjects):
+    if utils.matches_next_token(oIntegerRegex, iToken, lObjects):
         iCurrent += 1
-    if utils.matches_next_token(sBaseSpecifierPattern, iCurrent, lObjects):
+    if utils.matches_next_token(oBaseSpecifierRegex, iCurrent, lObjects):
         iCurrent = utils.find_next_token(iCurrent, lObjects)
         iCurrent += 1
-        if utils.matches_next_token(sBitValueStringPattern, iCurrent, lObjects):
+        if utils.matches_next_token(oBitValueStringRegex, iCurrent, lObjects):
             return classify(iToken, lObjects)
     return iToken
 
 
 def classify(iToken, lObjects):
-    if utils.matches_next_token(sIntegerPattern, iToken, lObjects):
+    if utils.matches_next_token(oIntegerRegex, iToken, lObjects):
         iCurrent = utils.assign_next_token(token.integer, iToken, lObjects)
     else:
         iCurrent = iToken

--- a/vsg/vhdlFile/classify/bit_string_literal.py
+++ b/vsg/vhdlFile/classify/bit_string_literal.py
@@ -5,9 +5,9 @@ import re
 from vsg.token import bit_string_literal as token
 from vsg.vhdlFile import utils
 
-oIntegerRegex = re.compile("\d+")
-oBaseSpecifierRegex = re.compile("(([us]?[box])|d)")
-oBitValueStringRegex = re.compile('"[0-9a-fhluwxz\-_]*"')
+oIntegerRegex = re.compile(r"\d+")
+oBaseSpecifierRegex = re.compile(r"(([us]?[box])|d)")
+oBitValueStringRegex = re.compile(r'"[0-9a-fhluwxz\-_]*"')
 
 
 def detect(iToken, lObjects):

--- a/vsg/vhdlFile/classify/expression.py
+++ b/vsg/vhdlFile/classify/expression.py
@@ -55,10 +55,10 @@ def classify_until(lUntils, iToken, lObjects, oType=parser.todo):
                 break
         else:
             iPrevious = iCurrent
-            iCurrent = external_name.detect(iCurrent, lObjects)
-            if iCurrent != iPrevious:
-                continue
-            iCurrent = bit_string_literal.detect(iCurrent, lObjects)
+            for oToken in [external_name, bit_string_literal]:
+                iCurrent = oToken.detect(iCurrent, lObjects)
+                if iCurrent != iPrevious:
+                    continue
             if iCurrent != iPrevious:
                 continue
             utils.assign_special_tokens(lObjects, iCurrent, oType)

--- a/vsg/vhdlFile/classify/expression.py
+++ b/vsg/vhdlFile/classify/expression.py
@@ -3,7 +3,7 @@
 from vsg import parser
 from vsg.token import direction
 from vsg.vhdlFile import utils
-from vsg.vhdlFile.classify import external_name
+from vsg.vhdlFile.classify import external_name, bit_string_literal
 
 
 def classify(iToken, lObjects):
@@ -57,6 +57,9 @@ def classify_until(lUntils, iToken, lObjects, oType=parser.todo):
         else:
             iPrevious = iCurrent
             iCurrent = external_name.detect(iCurrent, lObjects)
+            if iCurrent != iPrevious:
+                continue
+            iCurrent = bit_string_literal.detect(iCurrent, lObjects)
             if iCurrent != iPrevious:
                 continue
             utils.assign_special_tokens(lObjects, iCurrent, oType)

--- a/vsg/vhdlFile/classify/expression.py
+++ b/vsg/vhdlFile/classify/expression.py
@@ -2,7 +2,7 @@
 
 from vsg import parser
 from vsg.vhdlFile import utils
-from vsg.vhdlFile.classify import bit_string_literal,  external_name
+from vsg.vhdlFile.classify import bit_string_literal, external_name
 
 
 def classify(iToken, lObjects):

--- a/vsg/vhdlFile/classify/expression.py
+++ b/vsg/vhdlFile/classify/expression.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from vsg import parser
-from vsg.token import direction
 from vsg.vhdlFile import utils
-from vsg.vhdlFile.classify import external_name, bit_string_literal
+from vsg.vhdlFile.classify import bit_string_literal,  external_name
 
 
 def classify(iToken, lObjects):

--- a/vsg/vhdlFile/utils.py
+++ b/vsg/vhdlFile/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
+import re
 
 from vsg import exceptions, parser
 from vsg.token import (
@@ -111,6 +112,13 @@ def assign_parenthesis_as_todo(iToken, lObjects):
 
 def object_value_is(lAllObjects, iToken, sString):
     if lAllObjects[iToken].get_lower_value() == sString.lower():
+        return True
+    return False
+
+
+def object_value_matches(lAllObjects, iToken, sPattern):
+    oMatch = re.search(sPattern.lower(), lAllObjects[iToken].get_lower_value())
+    if oMatch is not None:
         return True
     return False
 
@@ -416,6 +424,13 @@ def token_is_assignment_operator(iObject, lObjects):
 
 def increment_token_count(iToken):
     return iToken + 1
+
+
+def matches_next_token(sPattern, iToken, lObjects):
+    iCurrent = find_next_token(iToken, lObjects)
+    if object_value_matches(lObjects, iCurrent, sPattern):
+        return True
+    return False
 
 
 def is_next_token(sToken, iToken, lObjects):

--- a/vsg/vhdlFile/utils.py
+++ b/vsg/vhdlFile/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import sys
 import re
+import sys
 
 from vsg import exceptions, parser
 from vsg.token import (

--- a/vsg/vhdlFile/utils.py
+++ b/vsg/vhdlFile/utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import re
 import sys
 
 from vsg import exceptions, parser

--- a/vsg/vhdlFile/utils.py
+++ b/vsg/vhdlFile/utils.py
@@ -116,9 +116,9 @@ def object_value_is(lAllObjects, iToken, sString):
     return False
 
 
-def object_value_matches(lAllObjects, iToken, sPattern):
-    oMatch = re.search(sPattern.lower(), lAllObjects[iToken].get_lower_value())
-    if oMatch is not None:
+def object_value_matches(lAllObjects, iToken, oRegex):
+    sToken = lAllObjects[iToken].get_lower_value()
+    if oRegex.fullmatch(sToken) is not None:
         return True
     return False
 
@@ -426,9 +426,9 @@ def increment_token_count(iToken):
     return iToken + 1
 
 
-def matches_next_token(sPattern, iToken, lObjects):
+def matches_next_token(oRegex, iToken, lObjects):
     iCurrent = find_next_token(iToken, lObjects)
-    if object_value_matches(lObjects, iCurrent, sPattern):
+    if object_value_matches(lObjects, iCurrent, oRegex):
         return True
     return False
 


### PR DESCRIPTION
Resolves #1236.

Potential issues to consider for the reviewer:
- The new rules are part of the case group, but they are not part of any case subgroup. From what I can tell, all other case rules are part of a subgroup, but it didn't seem like these rules fit into any of those groups.
- I've set the default value of rule_501 to "upper". I'm not sure whether there are any other case rule where the default is "upper",  if this is not preferred, we can change the default to match the other case rules.
- It's my first attempt at modifying the classification/tokenisation rules, so I may have done things in a way that is suboptimal. There is probably some room for improvement there, so I'd welcome any suggestions.
- From what I can tell, this is the first time that the classifiers are classifying items that don't match a fixed string (e.g. "constant"). I've introduced regular expressions into vhdlFile/util.py, with functions like `matches_next_token` as an alternative to `is_next_token` that matches a pattern instead of a fixed string. Maybe there is a better/cleaner way to implement this.