### PR TITLE
Minor improvements in documentation

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -57,8 +57,6 @@ VSG was developed using a Test Driven Development (TDD) process.
 There are over 1000 tests which cover individual rules and other features of VSG.
 For each pull request, an accompanying test to validate the pull request would be appreciated.
 
-Refer to `Setting up a Development Environment <setting_up_a_development_environment.html#running-unit-tests>`_ for more information on how to get started.
-
 Quality Control
 ###############
 

--- a/docs/developing/adding_a_rule.rst
+++ b/docs/developing/adding_a_rule.rst
@@ -61,7 +61,7 @@ Links to the icons are stored in a file named :code:`icons.rst` and is included 
 The summary is a very brief description of what issue the rule is attempting to resolve.
 
 If the rule has configuration options, a link to the configuration information will be given.
-The links are sored in a file named :code:`links.rst` and in included into each file using an include at the top of every file.
+The links are stored in a file named :code:`links.rst` and in included into each file using an include at the top of every file.
 
 The Violation Example provides a visual indicating what the issue is.
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -15,10 +15,10 @@ It can be installed using **pip**.
 
 This is the preferred method for installing VSG.
 
-Git Hub
--------
+GitHub
+------
 
-The latest development version can be cloned from the git hub repo.
+The latest development version can be cloned from the GitHub repo.
 
 .. code-block:: bash
 


### PR DESCRIPTION
* Git Hub / git hub -> GitHub
* sored -> stored
* Remove dead link to setting_up_a_development_environment (removed in a9805046712a1a22d1374006ccf7233ad6695b90)

I'm not sure removing `setting_up_a_development_environment.rst` in the aforementioned commit was intentional. If it wasn't I will undo removing the reference to it. 
