### PR TITLE
Add rules to require **begin** keyword for generate statements

### DIFF
--- a/docs/configuring_disabled_rules.rst
+++ b/docs/configuring_disabled_rules.rst
@@ -58,6 +58,7 @@ Rules Disabled by Default
 * `generic_600 <generic_rules.html#generic-600>`_
 * `generic_map_600 <generic_map_rules.html#generic-map-600>`_
 * `generic_map_601 <generic_map_rules.html#generic-map-601>`_
+* `if_generate_statement_001 <if_generate_statement_rules.html#if-generate-statement-001>`_
 * `instantiation_600 <instantiation_rules.html#instantiation-600>`_
 * `instantiation_601 <instantiation_rules.html#instantiation-601>`_
 * `loop_statement_006 <loop_statement_rules.html#loop-statement-006>`_

--- a/docs/configuring_disabled_rules.rst
+++ b/docs/configuring_disabled_rules.rst
@@ -47,6 +47,7 @@ Rules Disabled by Default
 * `context_ref_008 <context_ref_rules.html#context-ref-008>`_
 * `context_ref_009 <context_ref_rules.html#context-ref-009>`_
 * `file_100 <file_rules.html#file-100>`_
+* `for_generate_statement_001 <for_generate_statement_rules.html#for-generate-statement-001>`_
 * `function_600 <function_rules.html#function-600>`_
 * `function_601 <function_rules.html#function-601>`_
 * `generate_017 <generate_rules.html#generate-017>`_

--- a/docs/configuring_optional_items.rst
+++ b/docs/configuring_optional_items.rst
@@ -94,6 +94,7 @@ Rules Enforcing Optional Items
 * `context_022 <context_rules.html#context-022>`_
 * `entity_015 <entity_rules.html#entity-015>`_
 * `entity_019 <entity_rules.html#entity-019>`_
+* `for_generate_statement_001 <for_generate_statement_rules.html#for-generate-statement-001>`_
 * `function_018 <function_rules.html#function-018>`_
 * `function_020 <function_rules.html#function-020>`_
 * `generate_011 <generate_rules.html#generate-011>`_

--- a/docs/configuring_optional_items.rst
+++ b/docs/configuring_optional_items.rst
@@ -98,6 +98,7 @@ Rules Enforcing Optional Items
 * `function_018 <function_rules.html#function-018>`_
 * `function_020 <function_rules.html#function-020>`_
 * `generate_011 <generate_rules.html#generate-011>`_
+* `if_generate_statement_001 <if_generate_statement_rules.html#if-generate-statement-001>`_
 * `instantiation_033 <instantiation_rules.html#instantiation-033>`_
 * `loop_statement_007 <loop_statement_rules.html#loop-statement-007>`_
 * `package_007 <package_rules.html#package-007>`_

--- a/docs/for_generate_statement_rules.rst
+++ b/docs/for_generate_statement_rules.rst
@@ -3,6 +3,29 @@
 For Generate Statement Rules
 ----------------------------
 
+for_generate_statement_001
+##########################
+
+|phase_1| |disabled| |error| |structure| |structure_optional|
+
+This rule checks for the existence of the **begin** keyword.
+
+|configuring_optional_items_link|
+
+**Violation**
+
+.. code-block:: vhdl
+
+   ram_array : for i in 0 to 7 generate
+   end generate;
+
+**Fix**
+
+.. code-block:: vhdl
+
+   ram_array : for i in 0 to 7 generate begin
+   end generate;
+
 for_generate_statement_500
 ##########################
 

--- a/docs/if_generate_statement_rules.rst
+++ b/docs/if_generate_statement_rules.rst
@@ -3,6 +3,29 @@
 If Generate Statement Rules
 ---------------------------
 
+if_generate_statement_001
+#########################
+
+|phase_1| |disabled| |error| |structure| |structure_optional|
+
+This rule checks for the existence of the **begin** keyword.
+
+|configuring_optional_items_link|
+
+**Violation**
+
+.. code-block:: vhdl
+
+   ram_array : if condition generate
+   end generate;
+
+**Fix**
+
+.. code-block:: vhdl
+
+   ram_array : if condition generate begin
+   end generate;
+
 if_generate_statement_300
 #########################
 

--- a/docs/rule_groups/structure_optional_rule_group.rst
+++ b/docs/rule_groups/structure_optional_rule_group.rst
@@ -15,6 +15,7 @@ Rules Enforcing Structure::Optional Rule Group
 * `context_022 <../context_rules.html#context-022>`_
 * `entity_015 <../entity_rules.html#entity-015>`_
 * `entity_019 <../entity_rules.html#entity-019>`_
+* `for_generate_statement_001 <../for_generate_statement_rules.html#for-generate-statement-001>`_
 * `function_018 <../function_rules.html#function-018>`_
 * `function_020 <../function_rules.html#function-020>`_
 * `generate_011 <../generate_rules.html#generate-011>`_

--- a/docs/rule_groups/structure_optional_rule_group.rst
+++ b/docs/rule_groups/structure_optional_rule_group.rst
@@ -19,6 +19,7 @@ Rules Enforcing Structure::Optional Rule Group
 * `function_018 <../function_rules.html#function-018>`_
 * `function_020 <../function_rules.html#function-020>`_
 * `generate_011 <../generate_rules.html#generate-011>`_
+* `if_generate_statement_001 <../if_generate_statement_rules.html#if-generate-statement-001>`_
 * `instantiation_033 <../instantiation_rules.html#instantiation-033>`_
 * `loop_statement_007 <../loop_statement_rules.html#loop-statement-007>`_
 * `package_007 <../package_rules.html#package-007>`_

--- a/docs/rule_groups/structure_rule_group.rst
+++ b/docs/rule_groups/structure_rule_group.rst
@@ -81,6 +81,7 @@ Rules Enforcing Structure Rule Group
 * `generic_map_004 <../generic_map_rules.html#generic-map-004>`_
 * `generic_map_005 <../generic_map_rules.html#generic-map-005>`_
 * `generic_map_008 <../generic_map_rules.html#generic-map-008>`_
+* `if_generate_statement_001 <../if_generate_statement_rules.html#if-generate-statement-001>`_
 * `if_002 <../if_rules.html#if-002>`_
 * `if_020 <../if_rules.html#if-020>`_
 * `if_021 <../if_rules.html#if-021>`_

--- a/docs/rule_groups/structure_rule_group.rst
+++ b/docs/rule_groups/structure_rule_group.rst
@@ -64,6 +64,7 @@ Rules Enforcing Structure Rule Group
 * `entity_027 <../entity_rules.html#entity-027>`_
 * `entity_028 <../entity_rules.html#entity-028>`_
 * `entity_029 <../entity_rules.html#entity-029>`_
+* `for_generate_statement_001 <../for_generate_statement_rules.html#for-generate-statement-001>`_
 * `function_018 <../function_rules.html#function-018>`_
 * `function_019 <../function_rules.html#function-019>`_
 * `function_020 <../function_rules.html#function-020>`_

--- a/tests/for_generate_statement/rule_001_test_input.fixed.vhd
+++ b/tests/for_generate_statement/rule_001_test_input.fixed.vhd
@@ -1,0 +1,17 @@
+
+architecture rtl of fifo is
+
+begin
+
+  gen0 : for i in 0 to 7 generate
+  begin
+  end generate;
+
+  -- Violations below
+
+  gen1 : for i in 0 to 7 generate begin
+  end generate;
+
+  gen2 : for i in 0 to 7 generate begin end generate;
+
+end;

--- a/tests/for_generate_statement/rule_001_test_input.vhd
+++ b/tests/for_generate_statement/rule_001_test_input.vhd
@@ -1,0 +1,17 @@
+
+architecture rtl of fifo is
+
+begin
+
+  gen0 : for i in 0 to 7 generate
+  begin
+  end generate;
+
+  -- Violations below
+
+  gen1 : for i in 0 to 7 generate
+  end generate;
+
+  gen2 : for i in 0 to 7 generate end generate;
+
+end;

--- a/tests/for_generate_statement/test_rule_001.py
+++ b/tests/for_generate_statement/test_rule_001.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from tests import utils
+from vsg import vhdlFile
+from vsg.rules.for_generate_statement import rule_001 as rule
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_001_test_input.vhd"))
+
+lExpected = []
+lExpected.append("")
+utils.read_file(os.path.join(sTestDir, "rule_001_test_input.fixed.vhd"), lExpected)
+
+
+class test_generate_rule(unittest.TestCase):
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_001(self):
+        oRule = rule()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "for_generate_statement")
+        self.assertEqual(oRule.identifier, "001")
+
+        lExpected = [12, 15]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_001(self):
+        oRule = rule()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/tests/if_generate_statement/rule_001_test_input.fixed.vhd
+++ b/tests/if_generate_statement/rule_001_test_input.fixed.vhd
@@ -1,0 +1,17 @@
+
+architecture rtl of fifo is
+
+begin
+
+  gen0 : if condition generate
+  begin
+  end generate;
+
+  -- Violations below
+
+  gen1 : if condition generate begin
+  end generate;
+
+  gen2 : if condition generate begin end generate;
+
+end;

--- a/tests/if_generate_statement/rule_001_test_input.vhd
+++ b/tests/if_generate_statement/rule_001_test_input.vhd
@@ -1,0 +1,17 @@
+
+architecture rtl of fifo is
+
+begin
+
+  gen0 : if condition generate
+  begin
+  end generate;
+
+  -- Violations below
+
+  gen1 : if condition generate
+  end generate;
+
+  gen2 : if condition generate end generate;
+
+end;

--- a/tests/if_generate_statement/test_rule_001.py
+++ b/tests/if_generate_statement/test_rule_001.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from tests import utils
+from vsg import vhdlFile
+from vsg.rules.if_generate_statement import rule_001 as rule
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_001_test_input.vhd"))
+
+lExpected = []
+lExpected.append("")
+utils.read_file(os.path.join(sTestDir, "rule_001_test_input.fixed.vhd"), lExpected)
+
+
+class test_generate_rule(unittest.TestCase):
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_001(self):
+        oRule = rule()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "if_generate_statement")
+        self.assertEqual(oRule.identifier, "001")
+
+        lExpected = [12, 15]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_001(self):
+        oRule = rule()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/vsg/rules/for_generate_statement/__init__.py
+++ b/vsg/rules/for_generate_statement/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
+from .rule_001 import rule_001
 from .rule_500 import rule_500
 from .rule_501 import rule_501

--- a/vsg/rules/for_generate_statement/rule_001.py
+++ b/vsg/rules/for_generate_statement/rule_001.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from vsg.rules import insert_token_right_of_token_if_it_does_not_exist_before_token
+from vsg.token.for_generate_statement import end_keyword, generate_keyword
+from vsg.token.generate_statement_body import begin_keyword
+
+
+class rule_001(insert_token_right_of_token_if_it_does_not_exist_before_token):
+    """
+    This rule checks for the existence of the **begin** keyword.
+
+    |configuring_optional_items_link|
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+       ram_array : for i in 0 to 7 generate
+       end generate;
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+       ram_array : for i in 0 to 7 generate begin
+       end generate;
+    """
+
+    def __init__(self):
+        super().__init__(begin_keyword("begin"), generate_keyword, end_keyword)
+        self.solution = "*begin* keyword"
+        self.groups.append("structure::optional")
+        self.disable = True

--- a/vsg/rules/if_generate_statement/__init__.py
+++ b/vsg/rules/if_generate_statement/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from .rule_001 import rule_001
 from .rule_300 import rule_300
 from .rule_301 import rule_301
 from .rule_500 import rule_500

--- a/vsg/rules/if_generate_statement/rule_001.py
+++ b/vsg/rules/if_generate_statement/rule_001.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from vsg.rules import insert_token_right_of_token_if_it_does_not_exist_before_token
+from vsg.token.generate_statement_body import begin_keyword
+from vsg.token.if_generate_statement import end_keyword, generate_keyword
+
+
+class rule_001(insert_token_right_of_token_if_it_does_not_exist_before_token):
+    """
+    This rule checks for the existence of the **begin** keyword.
+
+    |configuring_optional_items_link|
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+       ram_array : if condition generate
+       end generate;
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+       ram_array : if condition generate begin
+       end generate;
+    """
+
+    def __init__(self):
+        super().__init__(begin_keyword("begin"), generate_keyword, end_keyword)
+        self.solution = "*begin* keyword"
+        self.groups.append("structure::optional")
+        self.disable = True


### PR DESCRIPTION
As discussed in #1239 I think these would be a nice addition to the rules.

I wanted to add an accompanying `case_generate_alternative_001`, but this was a bit more tricky to figure out.

I guess we'd need a new base-rule e.g. `insert_token_right_of_token_if_it_does_not_exist_before_possible_tokens` to list the following two tokens as possible end tokens
- `vsg.token.case_generate_alternative.when_keyword`
- `vsg.token.case_generate_statement.end_keyword`

---

Should there be separate rules for the following?
- `elsif condition generate` -> `elsif condition generate begin`
- `else generate` -> `else generate begin`