### PR TITLE
Issue#1243: Fixed external names parsing bug

### DIFF
--- a/tests/vhdlFile/external_name/classification_results.txt
+++ b/tests/vhdlFile/external_name/classification_results.txt
@@ -387,7 +387,75 @@
 50 |
 <class 'vsg.parser.blank_line'>
 --------------------------------------------------------------------------------
-51 | end architecture RTL;
+51 |   probe_signal <= << constant some.hierarchy.hier(i).test(i).my_loop(i).test : std_logic >> or
+<class 'vsg.token.concurrent_simple_signal_assignment.target'>
+<class 'vsg.token.concurrent_simple_signal_assignment.assignment'>
+<class 'vsg.token.external_constant_name.double_less_than'>
+<class 'vsg.token.external_constant_name.constant_keyword'>
+<class 'vsg.token.external_constant_name.external_pathname'>
+<class 'vsg.parser.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.parser.close_parenthesis'>
+<class 'vsg.token.external_constant_name.external_pathname'>
+<class 'vsg.parser.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.parser.close_parenthesis'>
+<class 'vsg.token.external_constant_name.external_pathname'>
+<class 'vsg.parser.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.parser.close_parenthesis'>
+<class 'vsg.token.external_constant_name.external_pathname'>
+<class 'vsg.token.external_constant_name.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.std_logic'>
+<class 'vsg.token.external_constant_name.double_greater_than'>
+<class 'vsg.token.logical_operator.or_operator'>
+--------------------------------------------------------------------------------
+52 |                   << signal some.hieararchy(i).test(i).my_loop(i).test : std_logic >> or
+<class 'vsg.token.external_signal_name.double_less_than'>
+<class 'vsg.token.external_signal_name.signal_keyword'>
+<class 'vsg.token.external_signal_name.external_pathname'>
+<class 'vsg.parser.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.parser.close_parenthesis'>
+<class 'vsg.token.external_signal_name.external_pathname'>
+<class 'vsg.parser.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.parser.close_parenthesis'>
+<class 'vsg.token.external_signal_name.external_pathname'>
+<class 'vsg.parser.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.parser.close_parenthesis'>
+<class 'vsg.token.external_signal_name.external_pathname'>
+<class 'vsg.token.external_signal_name.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.std_logic'>
+<class 'vsg.token.external_signal_name.double_greater_than'>
+<class 'vsg.token.logical_operator.or_operator'>
+--------------------------------------------------------------------------------
+53 |                   << variable some.hierarchy.ab.cd.(i).test(i).my_loop(i).test : std_logic >>;
+<class 'vsg.token.external_variable_name.double_less_than'>
+<class 'vsg.token.external_variable_name.variable_keyword'>
+<class 'vsg.token.external_variable_name.external_pathname'>
+<class 'vsg.parser.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.parser.close_parenthesis'>
+<class 'vsg.token.external_variable_name.external_pathname'>
+<class 'vsg.parser.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.parser.close_parenthesis'>
+<class 'vsg.token.external_variable_name.external_pathname'>
+<class 'vsg.parser.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.parser.close_parenthesis'>
+<class 'vsg.token.external_variable_name.external_pathname'>
+<class 'vsg.token.external_variable_name.colon'>
+<class 'vsg.token.ieee.std_logic_1164.types.std_logic'>
+<class 'vsg.token.external_variable_name.double_greater_than'>
+<class 'vsg.token.concurrent_simple_signal_assignment.semicolon'>
+--------------------------------------------------------------------------------
+54 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+55 | end architecture RTL;
 <class 'vsg.token.architecture_body.end_keyword'>
 <class 'vsg.token.architecture_body.end_architecture_keyword'>
 <class 'vsg.token.architecture_body.architecture_simple_name'>

--- a/tests/vhdlFile/external_name/classification_test_input.vhd
+++ b/tests/vhdlFile/external_name/classification_test_input.vhd
@@ -48,4 +48,8 @@ begin
                   << signal some.hieararchy(i) : std_logic >> or
                   << variable some.hierarchy.ab.cd.(i) : std_logic >>;
 
+  probe_signal <= << constant some.hierarchy.hier(i).test(i).my_loop(i).test : std_logic >> or
+                  << signal some.hieararchy(i).test(i).my_loop(i).test : std_logic >> or
+                  << variable some.hierarchy.ab.cd.(i).test(i).my_loop(i).test : std_logic >>;
+
 end architecture RTL;

--- a/vsg/vhdlFile/classify/external_constant_name.py
+++ b/vsg/vhdlFile/classify/external_constant_name.py
@@ -23,7 +23,7 @@ def classify(iToken, lObjects):
     iCurrent = utils.assign_next_token_required("constant", token.constant_keyword, iCurrent, lObjects)
     iCurrent = utils.assign_next_token(token.external_pathname, iCurrent, lObjects)
 
-    while not utils.is_next_token(":", iCurrent, lObjects):
+    while utils.is_next_token("(", iCurrent, lObjects):
         iCurrent = utils.assign_parenthesis_as_todo(iCurrent, lObjects)
         iCurrent = utils.assign_next_token_if_not(":", token.external_pathname, iCurrent, lObjects)
 

--- a/vsg/vhdlFile/classify/external_constant_name.py
+++ b/vsg/vhdlFile/classify/external_constant_name.py
@@ -23,7 +23,9 @@ def classify(iToken, lObjects):
     iCurrent = utils.assign_next_token_required("constant", token.constant_keyword, iCurrent, lObjects)
     iCurrent = utils.assign_next_token(token.external_pathname, iCurrent, lObjects)
 
-    iCurrent = utils.assign_parenthesis_as_todo(iCurrent, lObjects)
+    while not utils.is_next_token(":", iCurrent, lObjects):
+        iCurrent = utils.assign_parenthesis_as_todo(iCurrent, lObjects)
+        iCurrent = utils.assign_next_token_if_not(":", token.external_pathname, iCurrent, lObjects)
 
     iCurrent = utils.assign_next_token_required(":", token.colon, iCurrent, lObjects)
 

--- a/vsg/vhdlFile/classify/external_signal_name.py
+++ b/vsg/vhdlFile/classify/external_signal_name.py
@@ -23,7 +23,9 @@ def classify(iToken, lObjects):
     iCurrent = utils.assign_next_token_required("signal", token.signal_keyword, iToken, lObjects)
     iCurrent = utils.assign_next_token(token.external_pathname, iToken, lObjects)
 
-    iCurrent = utils.assign_parenthesis_as_todo(iCurrent, lObjects)
+    while not utils.is_next_token(":", iCurrent, lObjects):
+        iCurrent = utils.assign_parenthesis_as_todo(iCurrent, lObjects)
+        iCurrent = utils.assign_next_token_if_not(":", token.external_pathname, iCurrent, lObjects)
 
     iCurrent = utils.assign_next_token_required(":", token.colon, iCurrent, lObjects)
 

--- a/vsg/vhdlFile/classify/external_signal_name.py
+++ b/vsg/vhdlFile/classify/external_signal_name.py
@@ -23,7 +23,7 @@ def classify(iToken, lObjects):
     iCurrent = utils.assign_next_token_required("signal", token.signal_keyword, iToken, lObjects)
     iCurrent = utils.assign_next_token(token.external_pathname, iToken, lObjects)
 
-    while not utils.is_next_token(":", iCurrent, lObjects):
+    while utils.is_next_token("(", iCurrent, lObjects):
         iCurrent = utils.assign_parenthesis_as_todo(iCurrent, lObjects)
         iCurrent = utils.assign_next_token_if_not(":", token.external_pathname, iCurrent, lObjects)
 

--- a/vsg/vhdlFile/classify/external_variable_name.py
+++ b/vsg/vhdlFile/classify/external_variable_name.py
@@ -1,3 +1,7 @@
+
+    while not utils.is_next_token(":", iCurrent, lObjects):
+        iCurrent = utils.assign_parenthesis_as_todo(iCurrent, lObjects)
+        iCurrent = utils.assign_next_token_if_not(":", token.external_pathname, iCurrent, lObjects)
 # -*- coding: utf-8 -*-
 
 from vsg import parser
@@ -23,7 +27,9 @@ def classify(iToken, lObjects):
     iCurrent = utils.assign_next_token_required("variable", token.variable_keyword, iToken, lObjects)
     iCurrent = utils.assign_next_token(token.external_pathname, iToken, lObjects)
 
-    iCurrent = utils.assign_parenthesis_as_todo(iCurrent, lObjects)
+    while not utils.is_next_token(":", iCurrent, lObjects):
+        iCurrent = utils.assign_parenthesis_as_todo(iCurrent, lObjects)
+        iCurrent = utils.assign_next_token_if_not(":", token.external_pathname, iCurrent, lObjects)
 
     iCurrent = utils.assign_next_token_required(":", token.colon, iCurrent, lObjects)
 

--- a/vsg/vhdlFile/classify/external_variable_name.py
+++ b/vsg/vhdlFile/classify/external_variable_name.py
@@ -1,7 +1,3 @@
-
-    while not utils.is_next_token(":", iCurrent, lObjects):
-        iCurrent = utils.assign_parenthesis_as_todo(iCurrent, lObjects)
-        iCurrent = utils.assign_next_token_if_not(":", token.external_pathname, iCurrent, lObjects)
 # -*- coding: utf-8 -*-
 
 from vsg import parser

--- a/vsg/vhdlFile/classify/external_variable_name.py
+++ b/vsg/vhdlFile/classify/external_variable_name.py
@@ -23,7 +23,7 @@ def classify(iToken, lObjects):
     iCurrent = utils.assign_next_token_required("variable", token.variable_keyword, iToken, lObjects)
     iCurrent = utils.assign_next_token(token.external_pathname, iToken, lObjects)
 
-    while not utils.is_next_token(":", iCurrent, lObjects):
+    while utils.is_next_token("(", iCurrent, lObjects):
         iCurrent = utils.assign_parenthesis_as_todo(iCurrent, lObjects)
         iCurrent = utils.assign_next_token_if_not(":", token.external_pathname, iCurrent, lObjects)
 


### PR DESCRIPTION
Resolves #1243.

I've solved the problem by iteratively checking for opening parentheses at the end of the current portion of the pathname,e .g .
```vhdl
probe_signal <= << constant some.hierarchy.hier(i).test(i).my_loop(i).test : std_logic >>;
-- while loop checks at these points           ^       ^          ^       ^
```
It's possible that an alternative solution would be to absorb the parentheses into the pathname token? But perhaps the parentheses are separated to allow for multiline indentation rules and we need to keep them separate. Happy to hear any feedback.