### PR TITLE
Issue#1263: Rules for enforcing case on parameter class in functions and parameters

### DIFF
--- a/docs/configuring_uppercase_and_lowercase_rules.rst
+++ b/docs/configuring_uppercase_and_lowercase_rules.rst
@@ -333,6 +333,7 @@ Rules Enforcing Case
 * `function_501 <function_rules.html#function-501>`_
 * `function_502 <function_rules.html#function-502>`_
 * `function_506 <function_rules.html#function-506>`_
+* `function_511 <function_rules.html#function-511>`_
 
 * `generate_005 <generate_rules.html#generate-005>`_
 * `generate_009 <generate_rules.html#generate-009>`_
@@ -416,6 +417,7 @@ Rules Enforcing Case
 * `procedure_504 <procedure_rules.html#procedure-504>`_
 * `procedure_505 <procedure_rules.html#procedure-505>`_
 * `procedure_506 <procedure_rules.html#procedure-506>`_
+* `procedure_511 <procedure_rules.html#procedure-511>`_
 
 * `procedure_call_500 <procedure_call_rules.html#procedure-call-500>`_
 * `procedure_call_501 <procedure_call_rules.html#procedure-call-501>`_

--- a/docs/function_rules.rst
+++ b/docs/function_rules.rst
@@ -583,6 +583,39 @@ This rule checks the function designator has proper case on the end function dec
 
    end function overflow;
 
+function_511
+############
+
+|phase_6| |error| |case| |case_keyword|
+
+This rule checks the parameter class has proper case.
+
+|configuring_uppercase_and_lowercase_rules_link|
+
+**Violation**
+
+.. code-block:: vhdl
+
+  function my_func (
+    a          : integer;
+    VARIABLE b : integer;
+    CONSTANT c : integer;
+    SIGNAL   d : integer;
+    FILE     e : file_type
+  ) is return integer;
+
+**Fix**
+
+.. code-block:: vhdl
+
+  function my_func (
+    a          : integer;
+    variable b : integer;
+    constant c : integer;
+    signal   d : integer;
+    file     e : file_type
+  ) is return integer;
+
 function_600
 ############
 

--- a/docs/procedure_rules.rst
+++ b/docs/procedure_rules.rst
@@ -771,3 +771,36 @@ This rule checks for consistent capitalization of procedure names.
      end process;
 
    end architecture rtl;
+
+procedure_511
+#############
+
+|phase_6| |error| |case| |case_keyword|
+
+This rule checks the parameter class has proper case.
+
+|configuring_uppercase_and_lowercase_rules_link|
+
+**Violation**
+
+.. code-block:: vhdl
+
+  procedure my_func (
+    a          : integer;
+    VARIABLE b : integer;
+    CONSTANT c : integer;
+    SIGNAL   d : integer;
+    FILE     e : file_type
+  );
+
+**Fix**
+
+.. code-block:: vhdl
+
+  procedure my_func (
+    a          : integer;
+    variable b : integer;
+    constant c : integer;
+    signal   d : integer;
+    file     e : file_type
+  );

--- a/docs/rule_groups/case_keyword_rule_group.rst
+++ b/docs/rule_groups/case_keyword_rule_group.rst
@@ -69,6 +69,7 @@ Rules Enforcing Case::Keyword Rule Group
 * `function_014 <../function_rules.html#function-014>`_
 * `function_501 <../function_rules.html#function-501>`_
 * `function_502 <../function_rules.html#function-502>`_
+* `function_511 <../function_rules.html#function-511>`_
 * `generate_009 <../generate_rules.html#generate-009>`_
 * `generate_010 <../generate_rules.html#generate-010>`_
 * `generate_500 <../generate_rules.html#generate-500>`_
@@ -118,6 +119,7 @@ Rules Enforcing Case::Keyword Rule Group
 * `procedure_503 <../procedure_rules.html#procedure-503>`_
 * `procedure_504 <../procedure_rules.html#procedure-504>`_
 * `procedure_505 <../procedure_rules.html#procedure-505>`_
+* `procedure_511 <../procedure_rules.html#procedure-511>`_
 * `procedure_call_501 <../procedure_call_rules.html#procedure-call-501>`_
 * `process_004 <../process_rules.html#process-004>`_
 * `process_005 <../process_rules.html#process-005>`_

--- a/docs/rule_groups/case_rule_group.rst
+++ b/docs/rule_groups/case_rule_group.rst
@@ -98,6 +98,7 @@ Rules Enforcing Case Rule Group
 * `function_501 <../function_rules.html#function-501>`_
 * `function_502 <../function_rules.html#function-502>`_
 * `function_506 <../function_rules.html#function-506>`_
+* `function_511 <../function_rules.html#function-511>`_
 * `generate_005 <../generate_rules.html#generate-005>`_
 * `generate_009 <../generate_rules.html#generate-009>`_
 * `generate_010 <../generate_rules.html#generate-010>`_
@@ -166,6 +167,7 @@ Rules Enforcing Case Rule Group
 * `procedure_505 <../procedure_rules.html#procedure-505>`_
 * `procedure_506 <../procedure_rules.html#procedure-506>`_
 * `procedure_507 <../procedure_rules.html#procedure-507>`_
+* `procedure_511 <../procedure_rules.html#procedure-511>`_
 * `procedure_call_500 <../procedure_call_rules.html#procedure-call-500>`_
 * `procedure_call_501 <../procedure_call_rules.html#procedure-call-501>`_
 * `process_004 <../process_rules.html#process-004>`_

--- a/tests/function/rule_511_test_input.fixed_lower.vhd
+++ b/tests/function/rule_511_test_input.fixed_lower.vhd
@@ -1,0 +1,47 @@
+package rule_511_test_input is
+
+  function overflow (
+    a          : integer;
+    variable a : integer;
+    constant a : integer;
+    signal   a : integer;
+    file     a : file_type
+  ) return integer;
+
+  function overflow (
+    a          : integer;
+    variable a : integer;
+    constant a : integer;
+    signal   a : integer;
+    file     a : file_type
+  ) return integer;
+
+end package;
+
+architecture rtl of test is
+
+  function overflow (
+    a          : integer;
+    variable a : integer;
+    constant a : integer;
+    signal   a : integer;
+    file     a : file_type
+  ) return integer is
+  begin
+
+  end function overflow;
+
+  function overflow (
+    a          : integer;
+    variable a : integer;
+    constant a : integer;
+    signal   a : integer;
+    file     a : file_type
+  ) return integer is
+  begin
+
+  end function overflow;
+
+begin
+
+end architecture rtl;

--- a/tests/function/rule_511_test_input.fixed_upper.vhd
+++ b/tests/function/rule_511_test_input.fixed_upper.vhd
@@ -1,0 +1,47 @@
+package rule_511_test_input is
+
+  function overflow (
+    a          : integer;
+    VARIABLE a : integer;
+    CONSTANT a : integer;
+    SIGNAL   a : integer;
+    FILE     a : file_type
+  ) return integer;
+
+  function overflow (
+    a          : integer;
+    VARIABLE a : integer;
+    CONSTANT a : integer;
+    SIGNAL   a : integer;
+    FILE     a : file_type
+  ) return integer;
+
+end package;
+
+architecture rtl of test is
+
+  function overflow (
+    a          : integer;
+    VARIABLE a : integer;
+    CONSTANT a : integer;
+    SIGNAL   a : integer;
+    FILE     a : file_type
+  ) return integer is
+  begin
+
+  end function overflow;
+
+  function overflow (
+    a          : integer;
+    VARIABLE a : integer;
+    CONSTANT a : integer;
+    SIGNAL   a : integer;
+    FILE     a : file_type
+  ) return integer is
+  begin
+
+  end function overflow;
+
+begin
+
+end architecture rtl;

--- a/tests/function/rule_511_test_input.vhd
+++ b/tests/function/rule_511_test_input.vhd
@@ -1,0 +1,47 @@
+package rule_511_test_input is
+
+  function overflow (
+    a          : integer;
+    variable a : integer;
+    constant a : integer;
+    signal   a : integer;
+    file     a : file_type
+  ) return integer;
+
+  function overflow (
+    a          : integer;
+    VARIABLE a : integer;
+    CONSTANT a : integer;
+    SIGNAL   a : integer;
+    FILE     a : file_type
+  ) return integer;
+
+end package;
+
+architecture rtl of test is
+
+  function overflow (
+    a          : integer;
+    variable a : integer;
+    constant a : integer;
+    signal   a : integer;
+    file     a : file_type
+  ) return integer is
+  begin
+
+  end function overflow;
+
+  function overflow (
+    a          : integer;
+    VARIABLE a : integer;
+    CONSTANT a : integer;
+    SIGNAL   a : integer;
+    FILE     a : file_type
+  ) return integer is
+  begin
+
+  end function overflow;
+
+begin
+
+end architecture rtl;

--- a/tests/function/test_rule_511.py
+++ b/tests/function/test_rule_511.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from tests import utils
+from vsg import vhdlFile
+from vsg.rules import function
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_511_test_input.vhd"))
+
+lExpected_lower = []
+lExpected_lower.append("")
+utils.read_file(os.path.join(sTestDir, "rule_511_test_input.fixed_lower.vhd"), lExpected_lower)
+
+lExpected_upper = []
+lExpected_upper.append("")
+utils.read_file(os.path.join(sTestDir, "rule_511_test_input.fixed_upper.vhd"), lExpected_upper)
+
+
+class test_function_rule(unittest.TestCase):
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_511_lower(self):
+        oRule = function.rule_511()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "function")
+        self.assertEqual(oRule.identifier, "511")
+
+        lExpected = [13, 14, 15, 16, 36, 37, 38, 39]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(utils.extract_violation_lines_from_violation_object(oRule.violations), lExpected)
+
+    def test_rule_511_upper(self):
+        oRule = function.rule_511()
+        oRule.case = "upper"
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "function")
+        self.assertEqual(oRule.identifier, "511")
+
+        lExpected = [5, 6, 7, 8, 25, 26, 27, 28]
+        oRule.analyze(self.oFile)
+        self.assertEqual(utils.extract_violation_lines_from_violation_object(oRule.violations), lExpected)
+
+    def test_fix_rule_511_lower(self):
+        oRule = function.rule_511()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_lower, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])
+
+    def test_fix_rule_511_upper(self):
+        oRule = function.rule_511()
+        oRule.case = "upper"
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_upper, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/tests/procedure/rule_511_test_input.fixed_lower.vhd
+++ b/tests/procedure/rule_511_test_input.fixed_lower.vhd
@@ -1,0 +1,47 @@
+package rule_511_test_input is
+
+  procedure overflow (
+    a          : integer;
+    variable a : integer;
+    constant a : integer;
+    signal   a : integer;
+    file     a : file_type
+  );
+
+  procedure overflow (
+    a          : integer;
+    variable a : integer;
+    constant a : integer;
+    signal   a : integer;
+    file     a : file_type
+  );
+
+end package;
+
+architecture rtl of test is
+
+  procedure overflow (
+    a          : integer;
+    variable a : integer;
+    constant a : integer;
+    signal   a : integer;
+    file     a : file_type
+  ) is
+  begin
+
+  end procedure overflow;
+
+  procedure overflow (
+    a          : integer;
+    variable a : integer;
+    constant a : integer;
+    signal   a : integer;
+    file     a : file_type
+  ) is
+  begin
+
+  end procedure overflow;
+
+begin
+
+end architecture rtl;

--- a/tests/procedure/rule_511_test_input.fixed_upper.vhd
+++ b/tests/procedure/rule_511_test_input.fixed_upper.vhd
@@ -1,0 +1,47 @@
+package rule_511_test_input is
+
+  procedure overflow (
+    a          : integer;
+    VARIABLE a : integer;
+    CONSTANT a : integer;
+    SIGNAL   a : integer;
+    FILE     a : file_type
+  );
+
+  procedure overflow (
+    a          : integer;
+    VARIABLE a : integer;
+    CONSTANT a : integer;
+    SIGNAL   a : integer;
+    FILE     a : file_type
+  );
+
+end package;
+
+architecture rtl of test is
+
+  procedure overflow (
+    a          : integer;
+    VARIABLE a : integer;
+    CONSTANT a : integer;
+    SIGNAL   a : integer;
+    FILE     a : file_type
+  ) is
+  begin
+
+  end procedure overflow;
+
+  procedure overflow (
+    a          : integer;
+    VARIABLE a : integer;
+    CONSTANT a : integer;
+    SIGNAL   a : integer;
+    FILE     a : file_type
+  ) is
+  begin
+
+  end procedure overflow;
+
+begin
+
+end architecture rtl;

--- a/tests/procedure/rule_511_test_input.vhd
+++ b/tests/procedure/rule_511_test_input.vhd
@@ -1,0 +1,47 @@
+package rule_511_test_input is
+
+  procedure overflow (
+    a          : integer;
+    variable a : integer;
+    constant a : integer;
+    signal   a : integer;
+    file     a : file_type
+  );
+
+  procedure overflow (
+    a          : integer;
+    VARIABLE a : integer;
+    CONSTANT a : integer;
+    SIGNAL   a : integer;
+    FILE     a : file_type
+  );
+
+end package;
+
+architecture rtl of test is
+
+  procedure overflow (
+    a          : integer;
+    variable a : integer;
+    constant a : integer;
+    signal   a : integer;
+    file     a : file_type
+  ) is
+  begin
+
+  end procedure overflow;
+
+  procedure overflow (
+    a          : integer;
+    VARIABLE a : integer;
+    CONSTANT a : integer;
+    SIGNAL   a : integer;
+    FILE     a : file_type
+  ) is
+  begin
+
+  end procedure overflow;
+
+begin
+
+end architecture rtl;

--- a/tests/procedure/test_rule_511.py
+++ b/tests/procedure/test_rule_511.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from tests import utils
+from vsg import vhdlFile
+from vsg.rules import procedure
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_511_test_input.vhd"))
+
+lExpected_lower = []
+lExpected_lower.append("")
+utils.read_file(os.path.join(sTestDir, "rule_511_test_input.fixed_lower.vhd"), lExpected_lower)
+
+lExpected_upper = []
+lExpected_upper.append("")
+utils.read_file(os.path.join(sTestDir, "rule_511_test_input.fixed_upper.vhd"), lExpected_upper)
+
+
+class test_function_rule(unittest.TestCase):
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_511_lower(self):
+        oRule = procedure.rule_511()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "procedure")
+        self.assertEqual(oRule.identifier, "511")
+
+        lExpected = [13, 14, 15, 16, 36, 37, 38, 39]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(utils.extract_violation_lines_from_violation_object(oRule.violations), lExpected)
+
+    def test_rule_511_upper(self):
+        oRule = procedure.rule_511()
+        oRule.case = "upper"
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "procedure")
+        self.assertEqual(oRule.identifier, "511")
+
+        lExpected = [5, 6, 7, 8, 25, 26, 27, 28]
+        oRule.analyze(self.oFile)
+        self.assertEqual(utils.extract_violation_lines_from_violation_object(oRule.violations), lExpected)
+
+    def test_fix_rule_511_lower(self):
+        oRule = procedure.rule_511()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_lower, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])
+
+    def test_fix_rule_511_upper(self):
+        oRule = procedure.rule_511()
+        oRule.case = "upper"
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_upper, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/vsg/rules/function/__init__.py
+++ b/vsg/rules/function/__init__.py
@@ -29,5 +29,6 @@ from .rule_300 import rule_300
 from .rule_501 import rule_501
 from .rule_502 import rule_502
 from .rule_506 import rule_506
+from .rule_511 import rule_511
 from .rule_600 import rule_600
 from .rule_601 import rule_601

--- a/vsg/rules/function/rule_511.py
+++ b/vsg/rules/function/rule_511.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from vsg import token
+from vsg.rules import token_case_in_range_bounded_by_tokens
+
+lTokens = []
+lTokens.append(token.interface_variable_declaration.variable_keyword)
+lTokens.append(token.interface_constant_declaration.constant_keyword)
+lTokens.append(token.interface_signal_declaration.signal_keyword)
+lTokens.append(token.interface_signal_declaration.signal_keyword)
+lTokens.append(token.interface_file_declaration.file_keyword)
+
+oStart = token.function_specification.open_parenthesis
+oEnd = token.function_specification.close_parenthesis
+
+
+class rule_511(token_case_in_range_bounded_by_tokens):
+    """
+    This rule checks the parameter direction has proper case.
+    |configuring_uppercase_and_lowercase_rules_link|
+    **Violation**
+    .. code-block:: vhdl
+
+      function my_func (
+        a          : integer;
+        VARIABLE b : integer;
+        CONSTANT c : integer;
+        SIGNAL   d : integer;
+        FILE     e : file_type
+      ) is return integer;
+
+    **Fix**
+    .. code-block:: vhdl
+
+      function my_func (
+        a          : integer;
+        variable b : integer;
+        constant c : integer;
+        signal   d : integer;
+        file     e : file_type
+      ) is return integer;
+    """
+
+    def __init__(self):
+        super().__init__(lTokens, oStart, oEnd)
+        self.groups.append("case::keyword")

--- a/vsg/rules/function/rule_511.py
+++ b/vsg/rules/function/rule_511.py
@@ -7,7 +7,6 @@ lTokens = []
 lTokens.append(token.interface_variable_declaration.variable_keyword)
 lTokens.append(token.interface_constant_declaration.constant_keyword)
 lTokens.append(token.interface_signal_declaration.signal_keyword)
-lTokens.append(token.interface_signal_declaration.signal_keyword)
 lTokens.append(token.interface_file_declaration.file_keyword)
 
 oStart = token.function_specification.open_parenthesis

--- a/vsg/rules/function/rule_511.py
+++ b/vsg/rules/function/rule_511.py
@@ -15,7 +15,7 @@ oEnd = token.function_specification.close_parenthesis
 
 class rule_511(token_case_in_range_bounded_by_tokens):
     """
-    This rule checks the parameter direction has proper case.
+    This rule checks the parameter class has proper case.
     |configuring_uppercase_and_lowercase_rules_link|
     **Violation**
     .. code-block:: vhdl

--- a/vsg/rules/function/rule_511.py
+++ b/vsg/rules/function/rule_511.py
@@ -16,8 +16,11 @@ oEnd = token.function_specification.close_parenthesis
 class rule_511(token_case_in_range_bounded_by_tokens):
     """
     This rule checks the parameter class has proper case.
+
     |configuring_uppercase_and_lowercase_rules_link|
+
     **Violation**
+
     .. code-block:: vhdl
 
       function my_func (
@@ -29,6 +32,7 @@ class rule_511(token_case_in_range_bounded_by_tokens):
       ) is return integer;
 
     **Fix**
+
     .. code-block:: vhdl
 
       function my_func (

--- a/vsg/rules/procedure/__init__.py
+++ b/vsg/rules/procedure/__init__.py
@@ -34,3 +34,4 @@ from .rule_504 import rule_504
 from .rule_505 import rule_505
 from .rule_506 import rule_506
 from .rule_507 import rule_507
+from .rule_511 import rule_511

--- a/vsg/rules/procedure/rule_511.py
+++ b/vsg/rules/procedure/rule_511.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from vsg import token
+from vsg.rules import token_case_in_range_bounded_by_tokens
+
+lTokens = []
+lTokens.append(token.interface_variable_declaration.variable_keyword)
+lTokens.append(token.interface_constant_declaration.constant_keyword)
+lTokens.append(token.interface_signal_declaration.signal_keyword)
+lTokens.append(token.interface_signal_declaration.signal_keyword)
+lTokens.append(token.interface_file_declaration.file_keyword)
+
+oStart = token.procedure_specification.open_parenthesis
+oEnd = token.procedure_specification.close_parenthesis
+
+
+class rule_511(token_case_in_range_bounded_by_tokens):
+    """
+    This rule checks the parameter direction has proper case.
+    |configuring_uppercase_and_lowercase_rules_link|
+    **Violation**
+    .. code-block:: vhdl
+
+      procedure my_func (
+        a          : integer;
+        VARIABLE b : integer;
+        CONSTANT c : integer;
+        SIGNAL   d : integer;
+        FILE     e : file_type
+      );
+
+    **Fix**
+    .. code-block:: vhdl
+
+      procedure my_func (
+        a          : integer;
+        variable b : integer;
+        constant c : integer;
+        signal   d : integer;
+        file     e : file_type
+      );
+    """
+
+    def __init__(self):
+        super().__init__(lTokens, oStart, oEnd)
+        self.groups.append("case::keyword")

--- a/vsg/rules/procedure/rule_511.py
+++ b/vsg/rules/procedure/rule_511.py
@@ -15,7 +15,7 @@ oEnd = token.procedure_specification.close_parenthesis
 
 class rule_511(token_case_in_range_bounded_by_tokens):
     """
-    This rule checks the parameter direction has proper case.
+    This rule checks the parameter class has proper case.
     |configuring_uppercase_and_lowercase_rules_link|
     **Violation**
     .. code-block:: vhdl

--- a/vsg/rules/procedure/rule_511.py
+++ b/vsg/rules/procedure/rule_511.py
@@ -16,8 +16,11 @@ oEnd = token.procedure_specification.close_parenthesis
 class rule_511(token_case_in_range_bounded_by_tokens):
     """
     This rule checks the parameter class has proper case.
+
     |configuring_uppercase_and_lowercase_rules_link|
+
     **Violation**
+
     .. code-block:: vhdl
 
       procedure my_func (
@@ -29,6 +32,7 @@ class rule_511(token_case_in_range_bounded_by_tokens):
       );
 
     **Fix**
+
     .. code-block:: vhdl
 
       procedure my_func (

--- a/vsg/rules/procedure/rule_511.py
+++ b/vsg/rules/procedure/rule_511.py
@@ -7,7 +7,6 @@ lTokens = []
 lTokens.append(token.interface_variable_declaration.variable_keyword)
 lTokens.append(token.interface_constant_declaration.constant_keyword)
 lTokens.append(token.interface_signal_declaration.signal_keyword)
-lTokens.append(token.interface_signal_declaration.signal_keyword)
 lTokens.append(token.interface_file_declaration.file_keyword)
 
 oStart = token.procedure_specification.open_parenthesis


### PR DESCRIPTION
Resolves #1263.
The rule numbering skips a few numbers to avoid conflicts with other active branches.