### PR TITLE
Tag "productions" to allow using VSG as a VHDL parser

### DIFF
--- a/vsg/parser.py
+++ b/vsg/parser.py
@@ -107,7 +107,7 @@ class item:
         elif issubclass(token, item):
             oReturn = token(self.value)
         else:
-            raise RuntimeError('Invalid replacement token')
+            raise RuntimeError("Invalid replacement token")
         oReturn.indent = self.indent
         oReturn.hierarchy = self.hierarchy
         oReturn.context = self.context

--- a/vsg/parser.py
+++ b/vsg/parser.py
@@ -100,13 +100,22 @@ class item:
         return self.filename
 
     def convert_to(self, token):
-        oReturn = token(self.value)
+        # If we are given an token instance, just copy over the attributes from the original token
+        if isinstance(token, item):
+            oReturn = token
+        # If we are given a token class, create an instance from it and then copy the attributes
+        elif issubclass(token, item):
+            oReturn = token(self.value)
+        else:
+            raise RuntimeError('Invalid replacement token')
         oReturn.indent = self.indent
         oReturn.hierarchy = self.hierarchy
         oReturn.context = self.context
         oReturn.code_tags = self.code_tags
         oReturn.base_token, self.sub_token = self.update_token_types()
         oReturn.filename = self.filename
+        oReturn.enter_prod = self.enter_prod
+        oReturn.leave_prod = self.leave_prod
         oReturn.iId = self.iId
         oReturn.base_token, oReturn.sub_token = oReturn.update_token_types()
         return oReturn

--- a/vsg/parser.py
+++ b/vsg/parser.py
@@ -20,6 +20,8 @@ class item:
         self.base_token, self.sub_token = self.update_token_types()
         self.filename = None
         self.iId = None
+        self.enter_prod = []  # list of productions that start at this token
+        self.leave_prod = []  # list of productions that exit at this token
 
     def update_token_types(self):
         try:

--- a/vsg/vhdlFile/classify/entity_declaration.py
+++ b/vsg/vhdlFile/classify/entity_declaration.py
@@ -25,7 +25,7 @@ def detect(iToken, lObjects):
     else:
         return iToken
 
-
+@utils.tagged_production
 def classify(iToken, lObjects):
     iCurrent = classify_opening_declaration(iToken, lObjects)
 

--- a/vsg/vhdlFile/classify/entity_declaration.py
+++ b/vsg/vhdlFile/classify/entity_declaration.py
@@ -25,6 +25,7 @@ def detect(iToken, lObjects):
     else:
         return iToken
 
+
 @utils.tagged_production
 def classify(iToken, lObjects):
     iCurrent = classify_opening_declaration(iToken, lObjects)

--- a/vsg/vhdlFile/classify/expression.py
+++ b/vsg/vhdlFile/classify/expression.py
@@ -63,5 +63,5 @@ def classify_until(lUntils, iToken, lObjects, oType=parser.todo):
                 continue
             utils.assign_special_tokens(lObjects, iCurrent, oType)
             iCurrent += 1
-    utils.tag_production(iToken, iCurrent, lObjects, __name__)
+    # utils.tag_production(iToken, iCurrent, lObjects, __name__)
     return iCurrent

--- a/vsg/vhdlFile/classify/expression.py
+++ b/vsg/vhdlFile/classify/expression.py
@@ -4,7 +4,7 @@ from vsg import parser
 from vsg.vhdlFile import utils
 from vsg.vhdlFile.classify import bit_string_literal, external_name
 
-
+@utils.tagged_production
 def classify(iToken, lObjects):
     """
     expression ::=
@@ -63,4 +63,5 @@ def classify_until(lUntils, iToken, lObjects, oType=parser.todo):
                 continue
             utils.assign_special_tokens(lObjects, iCurrent, oType)
             iCurrent += 1
+    utils.tag_production(iToken, iCurrent, lObjects, __name__)
     return iCurrent

--- a/vsg/vhdlFile/classify/expression.py
+++ b/vsg/vhdlFile/classify/expression.py
@@ -4,6 +4,7 @@ from vsg import parser
 from vsg.vhdlFile import utils
 from vsg.vhdlFile.classify import bit_string_literal, external_name
 
+
 @utils.tagged_production
 def classify(iToken, lObjects):
     """

--- a/vsg/vhdlFile/classify/generic_clause.py
+++ b/vsg/vhdlFile/classify/generic_clause.py
@@ -14,7 +14,7 @@ def detect(iToken, lObjects):
         return classify(iToken, lObjects)
     return iToken
 
-
+@utils.tagged_production
 def classify(iToken, lObjects):
     iCurrent = utils.assign_next_token_required("generic", token.generic_keyword, iToken, lObjects)
     iCurrent = utils.assign_next_token_required("(", token.open_parenthesis, iCurrent, lObjects)

--- a/vsg/vhdlFile/classify/generic_clause.py
+++ b/vsg/vhdlFile/classify/generic_clause.py
@@ -14,6 +14,7 @@ def detect(iToken, lObjects):
         return classify(iToken, lObjects)
     return iToken
 
+
 @utils.tagged_production
 def classify(iToken, lObjects):
     iCurrent = utils.assign_next_token_required("generic", token.generic_keyword, iToken, lObjects)

--- a/vsg/vhdlFile/classify/interface_unknown_declaration.py
+++ b/vsg/vhdlFile/classify/interface_unknown_declaration.py
@@ -21,7 +21,6 @@ def detect(iToken, lObjects):
         return classify(iToken, lObjects)
 
 
-
 @utils.tagged_production
 def classify(iToken, lObjects):
     iCurrent = identifier_list.classify_until([":"], iToken, lObjects, token.identifier)

--- a/vsg/vhdlFile/classify/interface_unknown_declaration.py
+++ b/vsg/vhdlFile/classify/interface_unknown_declaration.py
@@ -21,6 +21,8 @@ def detect(iToken, lObjects):
         return classify(iToken, lObjects)
 
 
+
+@utils.tagged_production
 def classify(iToken, lObjects):
     iCurrent = identifier_list.classify_until([":"], iToken, lObjects, token.identifier)
 

--- a/vsg/vhdlFile/classify/port_clause.py
+++ b/vsg/vhdlFile/classify/port_clause.py
@@ -15,7 +15,7 @@ def detect(iToken, lObjects):
         return classify(iToken, lObjects)
     return iToken
 
-
+@utils.tagged_production
 def classify(iToken, lObjects):
     iCurrent = utils.assign_next_token_required("port", token.port_keyword, iToken, lObjects)
     iCurrent = utils.assign_next_token_required("(", token.open_parenthesis, iCurrent, lObjects)

--- a/vsg/vhdlFile/classify/port_clause.py
+++ b/vsg/vhdlFile/classify/port_clause.py
@@ -15,6 +15,7 @@ def detect(iToken, lObjects):
         return classify(iToken, lObjects)
     return iToken
 
+
 @utils.tagged_production
 def classify(iToken, lObjects):
     iCurrent = utils.assign_next_token_required("port", token.port_keyword, iToken, lObjects)

--- a/vsg/vhdlFile/utils.py
+++ b/vsg/vhdlFile/utils.py
@@ -15,7 +15,7 @@ from vsg.token.ieee.std_logic_1164 import types
 
 
 def tag_production(iStart, iEnd, lObjects, sName, verbose=0):
-    """ Tag the first and last token in the token list to indicate
+    """Tag the first and last token in the token list to indicate
     when we enter and leave the specified production rule.
 
     Parameters:
@@ -31,7 +31,7 @@ def tag_production(iStart, iEnd, lObjects, sName, verbose=0):
             using  the module ``__name__`` as `sName`.
 
     """
-    sName = sName.rsplit('.')[-1]  # keep only last element of the module hierarchy
+    sName = sName.rsplit(".")[-1]  # keep only last element of the module hierarchy
     # Tag the starting token
     oToken = lObjects[find_next_non_whitespace_token(iStart, lObjects)]  # skip leading comments and whitespaces to keep them out of the production
     assert not oToken.enter_prod, f"Tried to add a enter_classify name {sName} on Token {oToken} which already has {oToken.enter_prod}"
@@ -42,12 +42,15 @@ def tag_production(iStart, iEnd, lObjects, sName, verbose=0):
         print(f"Tried to add a leave_classify name {sName} on Token {oToken} which already has {oToken.leave_prod}")
     oToken.leave_prod.insert(0, sName)
 
+
 def tagged_production(func):
     def prod(iToken, lObjects):
         iCurrent = func(iToken, lObjects)
         tag_production(iToken, iCurrent, lObjects, func.__module__)
         return iCurrent
+
     return prod
+
 
 def assign_tokens_until(sToken, token, iToken, lObjects):
     iCurrent = iToken

--- a/vsg/vhdlFile/vhdlFile.py
+++ b/vsg/vhdlFile/vhdlFile.py
@@ -630,7 +630,7 @@ def set_aggregate_tokens(lTokens):
                 replace_token(iToken, lTokens, token.aggregate.close_parenthesis(), iId=oToken.iId)
 #        if isinstance(oToken, token.element_association.assignment):
         if len(lOpenParens) > 0 and (isinstance(oToken, token.element_association.assignment) or type(oToken) == parser.comma):
-            replace_token(lOpenParens[-1], lTokens, token.aggregate.open_parenthesis(), iId=lTokens[lOpenParens[-1]])
+            replace_token(lOpenParens[-1], lTokens, token.aggregate.open_parenthesis(), iId=lTokens[lOpenParens[-1]].iId)
 
 
 

--- a/vsg/vhdlFile/vhdlFile.py
+++ b/vsg/vhdlFile/vhdlFile.py
@@ -442,15 +442,17 @@ def split_on_carriage_return(lObjects):
         lReturn.append(lMyObjects)
     return lReturn
 
+
 def replace_token(iToken, lTokens, new_token, **kwargs):
     lTokens[iToken] = lTokens[iToken].convert_to(new_token)
 
     # Update  attributes of new token with values specified in kwargs
-    for key,value in kwargs.items():
+    for key, value in kwargs.items():
         setattr(lTokens[iToken], key, value)
 
+
 def replace_token_if_adjacent_tokens_in_list(iToken, lTokens, token_list, token_in_list, token_not_in_list):
-    """ Replace token at ``lTokens[iToken]`` with token ``token_in_list`` if the previous and optionally the next token matches any of the tokens in ``token_list``,
+    """Replace token at ``lTokens[iToken]`` with token ``token_in_list`` if the previous and optionally the next token matches any of the tokens in ``token_list``,
     otherwise replace it with ``token_not_in_list``.
 
     If an element in ``token_list`` is a token type, a match is obtained if that token precede the target token.
@@ -460,14 +462,18 @@ def replace_token_if_adjacent_tokens_in_list(iToken, lTokens, token_list, token_
     """
     for token in token_list:
         if isinstance(token, tuple):
-            match = (utils.are_previous_consecutive_token_types_ignoring_whitespace([token[0]], iToken - 1, lTokens) and
-                     utils.are_next_consecutive_token_types_ignoring_whitespace([token[1]], iToken + 1, lTokens))
+            match = utils.are_previous_consecutive_token_types_ignoring_whitespace(
+                [token[0]],
+                iToken - 1,
+                lTokens,
+            ) and utils.are_next_consecutive_token_types_ignoring_whitespace([token[1]], iToken + 1, lTokens)
         else:
             match = utils.are_previous_consecutive_token_types_ignoring_whitespace([token], iToken - 1, lTokens)
         if match:
             replace_token(iToken, lTokens, token_in_list)
             return
     replace_token(iToken, lTokens, token_not_in_list)
+
 
 def post_token_assignments(lTokens):
     oCodeTags = code_tags.New()
@@ -492,19 +498,23 @@ def post_token_assignments(lTokens):
             if sValue == "&":
                 replace_token(iToken, lTokens, adding_operator.concat())
 
-            elif sValue  == "+":
+            elif sValue == "+":
                 replace_token_if_adjacent_tokens_in_list(
-                    iToken, lTokens,
+                    iToken,
+                    lTokens,
                     (parser.open_parenthesis, parser.keyword, parser.assignment, parser.comma, choices.bar),
                     sign.plus(),
-                    adding_operator.plus())
+                    adding_operator.plus(),
+                )
 
-            elif sValue  == "-":
+            elif sValue == "-":
                 replace_token_if_adjacent_tokens_in_list(
-                    iToken, lTokens,
+                    iToken,
+                    lTokens,
                     (parser.open_parenthesis, parser.keyword, parser.assignment, parser.comma, choices.bar),
                     sign.minus(),
-                    adding_operator.minus())
+                    adding_operator.minus(),
+                )
 
             elif sValue == "(":
                 iParenId += 1
@@ -525,45 +535,57 @@ def post_token_assignments(lTokens):
 
             elif sLowerValue == "and":
                 replace_token_if_adjacent_tokens_in_list(
-                    iToken, lTokens,
+                    iToken,
+                    lTokens,
                     (parser.open_parenthesis, parser.assignment, parser.comma, logical_operator.logical_operator, (parser.keyword, parser.open_parenthesis)),
                     unary_logical_operator.and_operator(sValue),
-                    logical_operator.and_operator(sValue))
+                    logical_operator.and_operator(sValue),
+                )
 
             elif sLowerValue == "or":
                 replace_token_if_adjacent_tokens_in_list(
-                    iToken, lTokens,
+                    iToken,
+                    lTokens,
                     (parser.open_parenthesis, parser.assignment, parser.comma, logical_operator.logical_operator, (parser.keyword, parser.open_parenthesis)),
                     unary_logical_operator.or_operator(sValue),
-                    logical_operator.or_operator(sValue))
+                    logical_operator.or_operator(sValue),
+                )
 
             elif sLowerValue == "nand":
                 replace_token_if_adjacent_tokens_in_list(
-                    iToken, lTokens,
+                    iToken,
+                    lTokens,
                     (parser.open_parenthesis, parser.assignment, parser.comma, logical_operator.logical_operator, (parser.keyword, parser.open_parenthesis)),
                     unary_logical_operator.nand_operator(sValue),
-                    logical_operator.nand_operator(sValue))
+                    logical_operator.nand_operator(sValue),
+                )
 
             elif sLowerValue == "nor":
                 replace_token_if_adjacent_tokens_in_list(
-                    iToken, lTokens,
+                    iToken,
+                    lTokens,
                     (parser.open_parenthesis, parser.assignment, parser.comma, logical_operator.logical_operator, (parser.keyword, parser.open_parenthesis)),
                     unary_logical_operator.nor_operator(sValue),
-                    logical_operator.nor_operator(sValue))
+                    logical_operator.nor_operator(sValue),
+                )
 
             elif sLowerValue == "xor":
                 replace_token_if_adjacent_tokens_in_list(
-                    iToken, lTokens,
+                    iToken,
+                    lTokens,
                     (parser.open_parenthesis, parser.assignment, parser.comma, logical_operator.logical_operator, (parser.keyword, parser.open_parenthesis)),
                     unary_logical_operator.xor_operator(sValue),
-                    logical_operator.xor_operator(sValue))
+                    logical_operator.xor_operator(sValue),
+                )
 
             elif sLowerValue == "xnor":
                 replace_token_if_adjacent_tokens_in_list(
-                    iToken, lTokens,
+                    iToken,
+                    lTokens,
                     (parser.open_parenthesis, parser.assignment, parser.comma, logical_operator.logical_operator, (parser.keyword, parser.open_parenthesis)),
                     unary_logical_operator.xnor_operator(sValue),
-                    logical_operator.xnor_operator(sValue))
+                    logical_operator.xnor_operator(sValue),
+                )
 
             elif sLowerValue == "**":
                 replace_token(iToken, lTokens, miscellaneous_operator.double_star(sValue))
@@ -607,18 +629,22 @@ def post_token_assignments(lTokens):
                 replace_token(iToken, lTokens, parser.character_literal(sValue))
         else:
             sValue = oToken.get_value()
-            if sValue  == "+":
+            if sValue == "+":
                 replace_token_if_adjacent_tokens_in_list(
-                    iToken, lTokens,
+                    iToken,
+                    lTokens,
                     (parser.open_parenthesis, exponent.e_keyword, parser.keyword),
                     sign.plus(),
-                    adding_operator.plus())
-            elif sValue  == "-":
+                    adding_operator.plus(),
+                )
+            elif sValue == "-":
                 replace_token_if_adjacent_tokens_in_list(
-                    iToken, lTokens,
+                    iToken,
+                    lTokens,
                     (parser.open_parenthesis, exponent.e_keyword, parser.keyword),
                     sign.minus(),
-                    adding_operator.minus())
+                    adding_operator.minus(),
+                )
             elif sValue == "*":
                 replace_token(iToken, lTokens, multiplying_operator.star(sValue))
             elif sValue == "/":
@@ -676,10 +702,9 @@ def set_aggregate_tokens(lTokens):
             iIndex = lOpenParens.pop()
             if isinstance(lTokens[iIndex], token.aggregate.open_parenthesis):
                 replace_token(iToken, lTokens, token.aggregate.close_parenthesis(), iId=oToken.iId)
-#        if isinstance(oToken, token.element_association.assignment):
+        #        if isinstance(oToken, token.element_association.assignment):
         if len(lOpenParens) > 0 and (isinstance(oToken, token.element_association.assignment) or type(oToken) == parser.comma):
             replace_token(lOpenParens[-1], lTokens, token.aggregate.open_parenthesis(), iId=lTokens[lOpenParens[-1]].iId)
-
 
 
 def set_todo_tokens(lTokens):


### PR DESCRIPTION
**Description**

I was looking for a pure-python VHDL parser to serve as a back-end for a Sphinx domain that would allow extracting documentation straight from the VHDL source code, like we do with Python docstrings. 
After looking around and testing various tools, VSG turned out the only VHDL processor that was fast and robust enough to process my code base. The only thing that was missing was information on the hierarchy of the VHDL elements (entities, ports, etc.), also known as "productions".  VSG  knows about this hierarchy when it "classfies" the tokens, but it does not save the information. (See Discussion #1131)

This pull requests adds a minimally-intrusive mechanism to tag the productions. A `@utils.tagged_production`  decorator, when applied to a `classify` function, adds the name of the current production in the `enter_prod` list of the token at the beginning of the classify code, and also adds the name of that production to the `leave_prod` list of the token when the classify function exits. It is then trivial to reconstruct the hierarchy of the whole code using these tags. 

This pull requests adds a tagging function and decoration in `vhdlFile/utils.py`, the two abovementioned lists in the `item` class (`parser.py`), and a few classify functions have been decorated. This is currently sufficient for me to extract the entity interface information, although so much more could be done. The code has been modified to make sure that `convert_to` is always used when we replace a token by another, otherwise we lose our production tagging information.

This pull request also simplifies the `post_token_assignments()` function in `vhdlFile.py` by removing some code repetitions. Although I did that work a few months ago, I am submitting it just anow and I just realised that  another PR #1301 was submitted a few days ago to the same effect. That PR seems to implement changes that I also had in mind but did not dare do yet. I'd be happy to update my PR to harmonize it with PR #1301 if that helps.

The code passes the tox tests. 

This is my first public PR ever. Let me know if other information is required.
JF
