### PR TITLE
Issue#1295: Update multiline_alignment_between_tokens.py to skip variable array assignments

### DIFF
--- a/vsg/rules/multiline_alignment_between_tokens.py
+++ b/vsg/rules/multiline_alignment_between_tokens.py
@@ -578,4 +578,7 @@ def _analyze_align_paren_no_align_left_no(iFirstLine, iLastLine, lParens, dActua
 
 
 def toi_is_an_array(oToi):
-    return utils.are_next_consecutive_tokens_ignoring_whitespace(["<=", "("], 0, oToi.get_tokens())
+    for sAssignmentToken in ["<=", ":="]:
+        if utils.are_next_consecutive_tokens_ignoring_whitespace([sAssignmentToken, "("], 0, oToi.get_tokens()):
+            return True
+    return False


### PR DESCRIPTION
Resolves #2195.