### PR TITLE
Partial fix for pytest on Windows

### DIFF
--- a/tests/context/test_main.py
+++ b/tests/context/test_main.py
@@ -30,9 +30,9 @@ class test_context_using_main(unittest.TestCase):
 
     def test_classification_file(self):
         self.maxDiff = None
-        subprocess.check_output([*utils.vsg_exec(), "-f", self._sFileName, "--fix"]).decode("utf-8").split("\n")
+        subprocess.check_output([*utils.vsg_exec(), "-f", self._sFileName, "--fix"]).decode("utf-8").splitlines()
 
-        lActual = pathlib.Path(self._sFileName).read_text().split("\n")
-        lExpected = pathlib.Path(sFixedFile).read_text().split("\n")
+        lActual = pathlib.Path(self._sFileName).read_text().splitlines()
+        lExpected = pathlib.Path(sFixedFile).read_text().splitlines()
 
         self.assertEqual(lExpected, lActual)

--- a/tests/context/test_main.py
+++ b/tests/context/test_main.py
@@ -6,6 +6,7 @@ import subprocess
 import unittest
 from tempfile import TemporaryDirectory
 
+from tests import utils
 from vsg import __main__, severity
 
 sFileName = "context_classification_test_input.vhd"
@@ -29,7 +30,7 @@ class test_context_using_main(unittest.TestCase):
 
     def test_classification_file(self):
         self.maxDiff = None
-        subprocess.check_output(["bin/vsg", "-f", self._sFileName, "--fix"]).decode("utf-8").split("\n")
+        subprocess.check_output([*utils.vsg_exec(), "-f", self._sFileName, "--fix"]).decode("utf-8").split("\n")
 
         lActual = pathlib.Path(self._sFileName).read_text().split("\n")
         lExpected = pathlib.Path(sFixedFile).read_text().split("\n")

--- a/tests/severity/test_main.py
+++ b/tests/severity/test_main.py
@@ -40,7 +40,7 @@ class test_severity_using_main(unittest.TestCase):
 
     def test_entity_without_configuration(self):
         try:
-            subprocess.check_output(["bin/vsg", "-f", self._sEntityFileName])
+            subprocess.check_output([*utils.vsg_exec(), "-f", self._sEntityFileName])
         except subprocess.CalledProcessError as e:
             lActual = e.output.decode("utf-8").split("\n")
             iExitStatus = e.returncode
@@ -52,7 +52,7 @@ class test_severity_using_main(unittest.TestCase):
 
     def test_entity_with_configuration(self):
         try:
-            subprocess.check_output(["bin/vsg", "-f", self._sEntityFileName, "-c", sConfigFile])
+            subprocess.check_output([*utils.vsg_exec(), "-f", self._sEntityFileName, "-c", sConfigFile])
         except subprocess.CalledProcessError as e:
             lActual = e.output.decode("utf-8").split("\n")
             iExitStatus = e.returncode
@@ -63,7 +63,7 @@ class test_severity_using_main(unittest.TestCase):
         self.assertEqual(utils.replace_token(utils.replace_total_count(lActual), self._sEntityFileName, sEntityFileName), lExpected)
 
     def test_entity_with_configuration_and_fixed(self):
-        lActual = subprocess.check_output(["bin/vsg", "-f", self._sEntityFileName, "-c", sConfigFile, "--fix"]).decode("utf-8").split("\n")
+        lActual = subprocess.check_output([*utils.vsg_exec(), "-f", self._sEntityFileName, "-c", sConfigFile, "--fix"]).decode("utf-8").split("\n")
 
         lExpected = pathlib.Path(sOutputFileWithConfigFixed).read_text().split("\n")
 
@@ -71,7 +71,7 @@ class test_severity_using_main(unittest.TestCase):
 
     def test_architecture_without_configuration(self):
         try:
-            subprocess.check_output(["bin/vsg", "-f", self._sArchitectureFileName])
+            subprocess.check_output([*utils.vsg_exec(), "-f", self._sArchitectureFileName])
         except subprocess.CalledProcessError as e:
             lActual = e.output.decode("utf-8").split("\n")
             iExitStatus = e.returncode
@@ -83,7 +83,7 @@ class test_severity_using_main(unittest.TestCase):
 
     def test_architecture_with_configuration(self):
         try:
-            subprocess.check_output(["bin/vsg", "-f", self._sArchitectureFileName, "-c", sConfigFile])
+            subprocess.check_output([*utils.vsg_exec(), "-f", self._sArchitectureFileName, "-c", sConfigFile])
         except subprocess.CalledProcessError as e:
             lActual = e.output.decode("utf-8").split("\n")
             iExitStatus = e.returncode
@@ -94,7 +94,7 @@ class test_severity_using_main(unittest.TestCase):
         self.assertEqual(utils.replace_token(utils.replace_total_count(lActual), self._sArchitectureFileName, sArchitectureFileName), lExpected)
 
     def test_architecture_with_configuration_and_fixed(self):
-        lActual = subprocess.check_output(["bin/vsg", "-f", self._sArchitectureFileName, "-c", sConfigFile, "--fix"]).decode("utf-8").split("\n")
+        lActual = subprocess.check_output([*utils.vsg_exec(), "-f", self._sArchitectureFileName, "-c", sConfigFile, "--fix"]).decode("utf-8").split("\n")
 
         lExpected = pathlib.Path(sArchitectureOutputFileWithConfigFixed).read_text().split("\n")
 
@@ -102,7 +102,7 @@ class test_severity_using_main(unittest.TestCase):
 
     def test_both_with_configuration(self):
         try:
-            subprocess.check_output(["bin/vsg", "-f", self._sEntityFileName, self._sArchitectureFileName, "-c", sConfigFile])
+            subprocess.check_output([*utils.vsg_exec(), "-f", self._sEntityFileName, self._sArchitectureFileName, "-c", sConfigFile])
         except subprocess.CalledProcessError as e:
             lActual = e.output.decode("utf-8").split("\n")
             iExitStatus = e.returncode
@@ -122,7 +122,7 @@ class test_severity_using_main(unittest.TestCase):
 
     def test_both_with_configuration_and_fixed(self):
         lActual = (
-            subprocess.check_output(["bin/vsg", "-f", self._sEntityFileName, self._sArchitectureFileName, "-c", sConfigFile, "--fix"])
+            subprocess.check_output([*utils.vsg_exec(), "-f", self._sEntityFileName, self._sArchitectureFileName, "-c", sConfigFile, "--fix"])
             .decode("utf-8")
             .split("\n")
         )
@@ -141,7 +141,7 @@ class test_severity_using_main(unittest.TestCase):
 
     def test_junit_output(self):
         try:
-            subprocess.check_output(["bin/vsg", "-f", self._sEntityFileName, "-c", sConfigFile, "-j", self._sJUnitFileName])
+            subprocess.check_output([*utils.vsg_exec(), "-f", self._sEntityFileName, "-c", sConfigFile, "-j", self._sJUnitFileName])
         except subprocess.CalledProcessError as e:
             iExitStatus = e.returncode
 

--- a/tests/severity/test_main.py
+++ b/tests/severity/test_main.py
@@ -42,10 +42,10 @@ class test_severity_using_main(unittest.TestCase):
         try:
             subprocess.check_output([*utils.vsg_exec(), "-f", self._sEntityFileName])
         except subprocess.CalledProcessError as e:
-            lActual = e.output.decode("utf-8").split("\n")
+            lActual = e.output.decode("utf-8").splitlines()
             iExitStatus = e.returncode
 
-        lExpected = pathlib.Path(sOutputFileWoConfig).read_text().split("\n")
+        lExpected = pathlib.Path(sOutputFileWoConfig).read_text().splitlines()
 
         self.assertEqual(iExitStatus, 1)
         self.assertEqual(utils.replace_token(utils.replace_total_count(lActual), self._sEntityFileName, sEntityFileName), lExpected)
@@ -54,18 +54,18 @@ class test_severity_using_main(unittest.TestCase):
         try:
             subprocess.check_output([*utils.vsg_exec(), "-f", self._sEntityFileName, "-c", sConfigFile])
         except subprocess.CalledProcessError as e:
-            lActual = e.output.decode("utf-8").split("\n")
+            lActual = e.output.decode("utf-8").splitlines()
             iExitStatus = e.returncode
 
-        lExpected = pathlib.Path(sOutputFileWithConfig).read_text().split("\n")
+        lExpected = pathlib.Path(sOutputFileWithConfig).read_text().splitlines()
 
         self.assertEqual(iExitStatus, 1)
         self.assertEqual(utils.replace_token(utils.replace_total_count(lActual), self._sEntityFileName, sEntityFileName), lExpected)
 
     def test_entity_with_configuration_and_fixed(self):
-        lActual = subprocess.check_output([*utils.vsg_exec(), "-f", self._sEntityFileName, "-c", sConfigFile, "--fix"]).decode("utf-8").split("\n")
+        lActual = subprocess.check_output([*utils.vsg_exec(), "-f", self._sEntityFileName, "-c", sConfigFile, "--fix"]).decode("utf-8").splitlines()
 
-        lExpected = pathlib.Path(sOutputFileWithConfigFixed).read_text().split("\n")
+        lExpected = pathlib.Path(sOutputFileWithConfigFixed).read_text().splitlines()
 
         self.assertEqual(utils.replace_token(utils.replace_total_count(lActual), self._sEntityFileName, sEntityFileName), lExpected)
 
@@ -73,10 +73,10 @@ class test_severity_using_main(unittest.TestCase):
         try:
             subprocess.check_output([*utils.vsg_exec(), "-f", self._sArchitectureFileName])
         except subprocess.CalledProcessError as e:
-            lActual = e.output.decode("utf-8").split("\n")
+            lActual = e.output.decode("utf-8").splitlines()
             iExitStatus = e.returncode
 
-        lExpected = pathlib.Path(sArchitectureOutputFileWoConfig).read_text().split("\n")
+        lExpected = pathlib.Path(sArchitectureOutputFileWoConfig).read_text().splitlines()
 
         self.assertEqual(iExitStatus, 1)
         self.assertEqual(utils.replace_token(utils.replace_total_count(lActual), self._sArchitectureFileName, sArchitectureFileName), lExpected)
@@ -85,18 +85,18 @@ class test_severity_using_main(unittest.TestCase):
         try:
             subprocess.check_output([*utils.vsg_exec(), "-f", self._sArchitectureFileName, "-c", sConfigFile])
         except subprocess.CalledProcessError as e:
-            lActual = e.output.decode("utf-8").split("\n")
+            lActual = e.output.decode("utf-8").splitlines()
             iExitStatus = e.returncode
 
-        lExpected = pathlib.Path(sArchitectureOutputFileWithConfig).read_text().split("\n")
+        lExpected = pathlib.Path(sArchitectureOutputFileWithConfig).read_text().splitlines()
 
         self.assertEqual(iExitStatus, 1)
         self.assertEqual(utils.replace_token(utils.replace_total_count(lActual), self._sArchitectureFileName, sArchitectureFileName), lExpected)
 
     def test_architecture_with_configuration_and_fixed(self):
-        lActual = subprocess.check_output([*utils.vsg_exec(), "-f", self._sArchitectureFileName, "-c", sConfigFile, "--fix"]).decode("utf-8").split("\n")
+        lActual = subprocess.check_output([*utils.vsg_exec(), "-f", self._sArchitectureFileName, "-c", sConfigFile, "--fix"]).decode("utf-8").splitlines()
 
-        lExpected = pathlib.Path(sArchitectureOutputFileWithConfigFixed).read_text().split("\n")
+        lExpected = pathlib.Path(sArchitectureOutputFileWithConfigFixed).read_text().splitlines()
 
         self.assertEqual(utils.replace_token(utils.replace_total_count(lActual), self._sArchitectureFileName, sArchitectureFileName), lExpected)
 
@@ -104,11 +104,11 @@ class test_severity_using_main(unittest.TestCase):
         try:
             subprocess.check_output([*utils.vsg_exec(), "-f", self._sEntityFileName, self._sArchitectureFileName, "-c", sConfigFile])
         except subprocess.CalledProcessError as e:
-            lActual = e.output.decode("utf-8").split("\n")
+            lActual = e.output.decode("utf-8").splitlines()
             iExitStatus = e.returncode
 
-        lExpected1 = pathlib.Path(sOutputFileWithConfig).read_text().rstrip("\n").split("\n")
-        lExpected2 = pathlib.Path(sArchitectureOutputFileWithConfig).read_text().split("\n")
+        lExpected1 = pathlib.Path(sOutputFileWithConfig).read_text().splitlines()
+        lExpected2 = pathlib.Path(sArchitectureOutputFileWithConfig).read_text().splitlines()
 
         self.assertEqual(iExitStatus, 1)
         self.assertEqual(
@@ -124,11 +124,11 @@ class test_severity_using_main(unittest.TestCase):
         lActual = (
             subprocess.check_output([*utils.vsg_exec(), "-f", self._sEntityFileName, self._sArchitectureFileName, "-c", sConfigFile, "--fix"])
             .decode("utf-8")
-            .split("\n")
+            .splitlines()
         )
 
-        lExpected1 = pathlib.Path(sOutputFileWithConfigFixed).read_text().rstrip("\n").split("\n")
-        lExpected2 = pathlib.Path(sArchitectureOutputFileWithConfigFixed).read_text().split("\n")
+        lExpected1 = pathlib.Path(sOutputFileWithConfigFixed).read_text().splitlines()
+        lExpected2 = pathlib.Path(sArchitectureOutputFileWithConfigFixed).read_text().splitlines()
 
         self.assertEqual(
             utils.replace_token(
@@ -145,8 +145,8 @@ class test_severity_using_main(unittest.TestCase):
         except subprocess.CalledProcessError as e:
             iExitStatus = e.returncode
 
-        lActual = pathlib.Path(self._sJUnitFileName).read_text().split("\n")
-        lExpected = pathlib.Path(sJUnitFile).read_text().split("\n")
+        lActual = pathlib.Path(self._sJUnitFileName).read_text().splitlines()
+        lExpected = pathlib.Path(sJUnitFile).read_text().splitlines()
 
         self.assertEqual(iExitStatus, 1)
 

--- a/tests/source_file/test_source_file.py
+++ b/tests/source_file/test_source_file.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import pathlib
+import stat
 import subprocess
 import sys
 import unittest
@@ -37,6 +38,7 @@ class testOSError(unittest.TestCase):
         self.assertEqual(exit_status, 1)
 
     @unittest.skipIf(utils.is_user_admin(), "We are root. Root always has permissions so test will fail.")
+    @unittest.skipIf(utils.is_windows(), "Permissions can not be tested on windows.")
     def test_file_no_permission(self):
         sNoPermissionTempFile = os.path.join(self._tmpdir.name, sNoPermissionFile)
 

--- a/tests/source_file/test_source_file.py
+++ b/tests/source_file/test_source_file.py
@@ -30,7 +30,7 @@ class testOSError(unittest.TestCase):
 
     def test_file_not_found(self):
         try:
-            subprocess.check_output(["bin/vsg", "-f", "no_file.vhd"], stderr=subprocess.STDOUT)
+            subprocess.check_output([*utils.vsg_exec(), "-f", "no_file.vhd"], stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             exit_status: int = e.returncode
 
@@ -43,7 +43,7 @@ class testOSError(unittest.TestCase):
         pathlib.Path(sNoPermissionTempFile).touch(mode=0o222, exist_ok=True)
 
         try:
-            subprocess.check_output(["bin/vsg", "-f", sNoPermissionTempFile])
+            subprocess.check_output([*utils.vsg_exec(), "-f", sNoPermissionTempFile])
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
             iExitStatus = e.returncode
@@ -55,7 +55,7 @@ class testOSError(unittest.TestCase):
 
     def test_file_empty(self):
         try:
-            subprocess.check_output(["bin/vsg", "-f", "tests/source_file/" + sEmptyFile])
+            subprocess.check_output([*utils.vsg_exec(), "-f", "tests/source_file/" + sEmptyFile])
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
             iExitStatus = e.returncode

--- a/tests/source_file/test_source_file.py
+++ b/tests/source_file/test_source_file.py
@@ -45,10 +45,10 @@ class testOSError(unittest.TestCase):
         try:
             subprocess.check_output([*utils.vsg_exec(), "-f", sNoPermissionTempFile])
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
-        lExpected = pathlib.Path(sOutputNoPermission).read_text().split("\n")
+        lExpected = pathlib.Path(sOutputNoPermission).read_text().splitlines()
 
         self.assertEqual(iExitStatus, 1)
         self.assertEqual(utils.replace_token(utils.replace_total_count(lActual), sNoPermissionTempFile, sNoPermissionFile), lExpected)
@@ -57,10 +57,10 @@ class testOSError(unittest.TestCase):
         try:
             subprocess.check_output([*utils.vsg_exec(), "-f", "tests/source_file/" + sEmptyFile])
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
-        lExpected = pathlib.Path(sOutputEmptyFile).read_text().split("\n")
+        lExpected = pathlib.Path(sOutputEmptyFile).read_text().splitlines()
 
         self.assertEqual(iExitStatus, 1)
         self.assertEqual(utils.replace_total_count(lActual), lExpected)

--- a/tests/source_file/test_source_file.py
+++ b/tests/source_file/test_source_file.py
@@ -36,7 +36,7 @@ class testOSError(unittest.TestCase):
 
         self.assertEqual(exit_status, 1)
 
-    @unittest.skipIf("SUDO_UID" in os.environ.keys() or os.geteuid() == 0, "We are root. Root always has permissions so test will fail.")
+    @unittest.skipIf(utils.is_user_admin(), "We are root. Root always has permissions so test will fail.")
     def test_file_no_permission(self):
         sNoPermissionTempFile = os.path.join(self._tmpdir.name, sNoPermissionFile)
 

--- a/tests/tool_integration/quality_report/test_main.py
+++ b/tests/tool_integration/quality_report/test_main.py
@@ -10,9 +10,11 @@ from tempfile import TemporaryDirectory
 from unittest import mock
 
 from vsg import __main__
+from tests import utils
 
 
 class testMain(unittest.TestCase):
+
     def setUp(self):
         self._tmpdir = TemporaryDirectory()
 
@@ -47,4 +49,11 @@ class testMain(unittest.TestCase):
 
         mock_stdout.write.assert_has_calls(lExpected)
         self.assertTrue(os.path.isfile(actual_file))
-        self.assertTrue(filecmp.cmp(actual_file, os.path.join("tests", "tool_integration", "quality_report", "expected.json")))
+
+        lActual = []
+        lActual = utils.read_file(actual_file, lActual)
+
+        lExpected = []
+        lExpected = utils.read_file(os.path.join("tests", "tool_integration", "quality_report", "expected.json"), lExpected)
+
+        self.assertEqual(lExpected, lActual)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,7 +17,7 @@ def debug_lines(oFile, iLineNumber, iNumberOfLines):
 
 
 def read_file(sFilename, lLines, bStrip=True):
-    with open(sFilename) as oFile:
+    with open(sFilename, encoding="utf-8") as oFile:
         for sLine in oFile:
             if bStrip:
                 lLines.append(sLine.rstrip())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ import ctypes
 import os
 import pprint
 import re
+import sys
 
 import yaml
 
@@ -141,3 +142,7 @@ def is_user_admin():
         pass
 
     return ctypes.windll.shell32.IsUserAnAdmin() == 1
+
+
+def vsg_exec():
+    return [sys.executable, "bin/vsg"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import ctypes
 import os
 import pprint
 import re
@@ -128,3 +129,15 @@ def replace_total_count_summary(lOutput):
 
 def replace_token(lOutput, src, dst):
     return [line.replace(src, dst) for line in lOutput]
+
+
+def is_user_admin():
+    if "SUDO_UID" in os.environ.keys():
+        return True
+
+    try:
+        return os.getuid() == 0
+    except AttributeError:
+        pass
+
+    return ctypes.windll.shell32.IsUserAnAdmin() == 1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import ctypes
 import os
+import platform
 import pprint
 import re
 import sys
@@ -146,3 +147,9 @@ def is_user_admin():
 
 def vsg_exec():
     return [sys.executable, "bin/vsg"]
+
+
+def is_windows():
+    if platform.system() == "Windows":
+        return True
+    return False

--- a/tests/vsg/read_configuration_files/test_read_configuration_files_function.py
+++ b/tests/vsg/read_configuration_files/test_read_configuration_files_function.py
@@ -144,5 +144,6 @@ class test_read_configuration_function(unittest.TestCase):
         for iIndex, item in enumerate(dExpected["file_list"]):
             if isinstance(item, dict):
                 sKey = list(item.keys())[0]
+
                 iActualIndex = get_index_of_dictionary_in_list(dActual["file_list"], sKey)
                 self.assertEqual(dActual["file_list"][iActualIndex], dExpected["file_list"][iIndex])

--- a/tests/vsg/test_main.py
+++ b/tests/vsg/test_main.py
@@ -290,7 +290,7 @@ class testMain(unittest.TestCase):
             except SystemExit:
                 pass
 
-        lActual = temp_stdout.getvalue().strip().split("\n")
+        lActual = temp_stdout.getvalue().strip().splitlines()
 
         if lActual[0] == lExpected[1]:
             lExpected = [lExpected[1], lExpected[0]]
@@ -422,7 +422,7 @@ class testMain(unittest.TestCase):
             except SystemExit:
                 pass
 
-        lActual = temp_stdout.getvalue().strip().split("\n")
+        lActual = temp_stdout.getvalue().strip().splitlines()
 
         if lActual[0] == lExpected[1]:
             lExpected = [lExpected[1], lExpected[0]]

--- a/tests/vsg/test_rc.py
+++ b/tests/vsg/test_rc.py
@@ -70,13 +70,12 @@ class testVsg(unittest.TestCase):
     def test_rc_command_line_argument_w_invalid_rule(self):
         lExpected = []
         lExpected.append("ERROR: rule unknown_rule_001 was not found.")
-        lExpected.append("")
         iExitStatus = -1
 
         try:
             subprocess.check_output([*utils.vsg_exec(), "-rc", "unknown_rule_001"])
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)

--- a/tests/vsg/test_rc.py
+++ b/tests/vsg/test_rc.py
@@ -2,6 +2,8 @@
 import subprocess
 import unittest
 
+from tests import utils
+
 
 class command_line_args:
     """This is used as an input into the version command."""
@@ -72,7 +74,7 @@ class testVsg(unittest.TestCase):
         iExitStatus = -1
 
         try:
-            subprocess.check_output(["bin/vsg", "-rc", "unknown_rule_001"])
+            subprocess.check_output([*utils.vsg_exec(), "-rc", "unknown_rule_001"])
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
             iExitStatus = e.returncode

--- a/tests/vsg/test_vsg.py
+++ b/tests/vsg/test_vsg.py
@@ -33,7 +33,9 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         try:
-            subprocess.check_output(["bin/vsg", "--configuration", "tests/vsg/config_1.json", "tests/vsg/config_2.json", "--output_format", "syntastic"])
+            subprocess.check_output(
+                [*utils.vsg_exec(), "--configuration", "tests/vsg/config_1.json", "tests/vsg/config_2.json", "--output_format", "syntastic"],
+            )
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
             iExitStatus = e.returncode
@@ -48,7 +50,7 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         try:
-            subprocess.check_output(["bin/vsg", "--configuration", "tests/vsg/config_1.json", "--output_format", "syntastic"])
+            subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_1.json", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
             iExitStatus = e.returncode
@@ -62,7 +64,7 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         try:
-            subprocess.check_output(["bin/vsg", "--configuration", "tests/vsg/config_2.json", "--output_format", "syntastic"])
+            subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_2.json", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
             iExitStatus = e.returncode
@@ -76,7 +78,7 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         lActual = subprocess.check_output(
-            ["bin/vsg", "--configuration", "tests/vsg/config_3.json", "--output_format", "syntastic", "-f", "tests/vsg/entity1.vhd"],
+            [*utils.vsg_exec(), "--configuration", "tests/vsg/config_3.json", "--output_format", "syntastic", "-f", "tests/vsg/entity1.vhd"],
         )
         lActual = str(lActual.decode("utf-8")).split("\n")
         self.assertEqual(lActual, lExpected)
@@ -89,7 +91,7 @@ class testVsg(unittest.TestCase):
         try:
             subprocess.check_output(
                 [
-                    "bin/vsg",
+                    *utils.vsg_exec(),
                     "--configuration",
                     "tests/vsg/config_3.json",
                     "tests/vsg/config_4.json",
@@ -112,7 +114,16 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         lActual = subprocess.check_output(
-            ["bin/vsg", "--configuration", "tests/vsg/config_4.json", "tests/vsg/config_3.json", "--output_format", "syntastic", "-f", "tests/vsg/entity1.vhd"],
+            [
+                *utils.vsg_exec(),
+                "--configuration",
+                "tests/vsg/config_4.json",
+                "tests/vsg/config_3.json",
+                "--output_format",
+                "syntastic",
+                "-f",
+                "tests/vsg/entity1.vhd",
+            ],
         )
         lActual = str(lActual.decode("utf-8")).split("\n")
         self.assertEqual(lActual, lExpected)
@@ -128,7 +139,7 @@ class testVsg(unittest.TestCase):
         try:
             lActual = subprocess.check_output(
                 [
-                    "bin/vsg",
+                    *utils.vsg_exec(),
                     "--configuration",
                     "tests/vsg/config_error.json",
                     "--output_format",
@@ -163,7 +174,7 @@ class testVsg(unittest.TestCase):
 
         try:
             subprocess.check_output(
-                ["bin/vsg", "--style", "jcl", "-f", "tests/vsg/entity_architecture.vhd", "-of", "syntastic", "-lr", "tests/vsg/local_rules"],
+                [*utils.vsg_exec(), "--style", "jcl", "-f", "tests/vsg/entity_architecture.vhd", "-of", "syntastic", "-lr", "tests/vsg/local_rules"],
             )
             iExitStatus = 0
         except subprocess.CalledProcessError as e:
@@ -182,7 +193,7 @@ class testVsg(unittest.TestCase):
 
         try:
             lActual = subprocess.check_output(
-                ["bin/vsg", "-f", "tests/vsg/entity_architecture.vhd", "-of", "syntastic", "-lr", "tests/vsg/invalid_local_rule_directory"],
+                [*utils.vsg_exec(), "-f", "tests/vsg/entity_architecture.vhd", "-of", "syntastic", "-lr", "tests/vsg/invalid_local_rule_directory"],
             )
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
@@ -198,7 +209,7 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         try:
-            subprocess.check_output(["bin/vsg", "--configuration", "tests/vsg/config_glob.json", "--output_format", "syntastic"])
+            subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_glob.json", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
             iExitStatus = e.returncode
@@ -220,7 +231,7 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         try:
-            subprocess.check_output(["bin/vsg", "--configuration", "tests/vsg/config_1.yaml", "--output_format", "syntastic"])
+            subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_1.yaml", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
             iExitStatus = e.returncode
@@ -234,7 +245,7 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         try:
-            subprocess.check_output(["bin/vsg", "--configuration", "tests/vsg/config_2.json", "--output_format", "syntastic"])
+            subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_2.json", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
             iExitStatus = e.returncode
@@ -250,7 +261,9 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         try:
-            subprocess.check_output(["bin/vsg", "--configuration", "tests/vsg/config_1.yaml", "tests/vsg/config_2.yaml", "--output_format", "syntastic"])
+            subprocess.check_output(
+                [*utils.vsg_exec(), "--configuration", "tests/vsg/config_1.yaml", "tests/vsg/config_2.yaml", "--output_format", "syntastic"],
+            )
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
             iExitStatus = e.returncode
@@ -264,7 +277,7 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         lActual = subprocess.check_output(
-            ["bin/vsg", "--configuration", "tests/vsg/config_3.yaml", "--output_format", "syntastic", "-f", "tests/vsg/entity1.vhd"],
+            [*utils.vsg_exec(), "--configuration", "tests/vsg/config_3.yaml", "--output_format", "syntastic", "-f", "tests/vsg/entity1.vhd"],
         )
         lActual = str(lActual.decode("utf-8")).split("\n")
         self.assertEqual(lActual, lExpected)
@@ -277,7 +290,7 @@ class testVsg(unittest.TestCase):
         try:
             subprocess.check_output(
                 [
-                    "bin/vsg",
+                    *utils.vsg_exec(),
                     "--configuration",
                     "tests/vsg/config_3.yaml",
                     "tests/vsg/config_4.yaml",
@@ -300,7 +313,16 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         lActual = subprocess.check_output(
-            ["bin/vsg", "--configuration", "tests/vsg/config_4.yaml", "tests/vsg/config_3.yaml", "--output_format", "syntastic", "-f", "tests/vsg/entity1.vhd"],
+            [
+                *utils.vsg_exec(),
+                "--configuration",
+                "tests/vsg/config_4.yaml",
+                "tests/vsg/config_3.yaml",
+                "--output_format",
+                "syntastic",
+                "-f",
+                "tests/vsg/entity1.vhd",
+            ],
         )
         lActual = str(lActual.decode("utf-8")).split("\n")
         self.assertEqual(lActual, lExpected)
@@ -312,7 +334,7 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         try:
-            subprocess.check_output(["bin/vsg", "--configuration", "tests/vsg/config_glob.yaml", "--output_format", "syntastic"])
+            subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_glob.yaml", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
             iExitStatus = e.returncode
@@ -331,13 +353,13 @@ class testVsg(unittest.TestCase):
         lExpected = []
         lExpected.append("")
 
-        lActual = subprocess.check_output(["bin/vsg", "-oc", os.path.join(self._tmpdir.name, "deleteme.json")])
+        lActual = subprocess.check_output([*utils.vsg_exec(), "-oc", os.path.join(self._tmpdir.name, "deleteme.json")])
         lActual = str(lActual.decode("utf-8")).split("\n")
         self.assertEqual(lActual, lExpected)
 
     def test_missing_configuration_file(self):
         try:
-            subprocess.check_output(["bin/vsg", "-c", "missing_configuration.yaml"], stderr=subprocess.STDOUT)
+            subprocess.check_output([*utils.vsg_exec(), "-c", "missing_configuration.yaml"], stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             iExitStatus = e.returncode
 
@@ -351,7 +373,7 @@ class testVsg(unittest.TestCase):
         sExpected = f"ERROR: encountered PermissionError, Permission denied while opening configuration file: {sNoPermissionFile}\n"
 
         try:
-            subprocess.check_output(["bin/vsg", "-c", sNoPermissionFile])
+            subprocess.check_output([*utils.vsg_exec(), "-c", sNoPermissionFile])
         except subprocess.CalledProcessError as e:
             sActual = str(e.output.decode("utf-8"))
             iExitStatus = e.returncode
@@ -366,7 +388,7 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         try:
-            subprocess.check_output(["bin/vsg", "-c", "tests/vsg/missing_file_config.yaml", "--output_format", "syntastic"])
+            subprocess.check_output([*utils.vsg_exec(), "-c", "tests/vsg/missing_file_config.yaml", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
             iExitStatus = e.returncode
@@ -380,7 +402,7 @@ class testVsg(unittest.TestCase):
         lExpectedStdOut = [""]
 
         try:
-            subprocess.check_output(["bin/vsg", "-f", "tests/vsg/entity_architecture.vhd", "-of", "summary"], stderr=subprocess.PIPE)
+            subprocess.check_output([*utils.vsg_exec(), "-f", "tests/vsg/entity_architecture.vhd", "-of", "summary"], stderr=subprocess.PIPE)
             iExitStatus = 0
         except subprocess.CalledProcessError as e:
             lActualStdOut = str(e.output.decode("utf-8")).split("\n")
@@ -398,7 +420,7 @@ class testVsg(unittest.TestCase):
 
         try:
             subprocess.check_output(
-                ["bin/vsg", "-f", "tests/vsg/entity_architecture.vhd", "-of", "summary", "-lr", "tests/vsg/local_rules"],
+                [*utils.vsg_exec(), "-f", "tests/vsg/entity_architecture.vhd", "-of", "summary", "-lr", "tests/vsg/local_rules"],
                 stderr=subprocess.PIPE,
             )
             iExitStatus = 0
@@ -416,7 +438,7 @@ class testVsg(unittest.TestCase):
         lExpected = ["File: tests/vsg/entity_architecture.fixed.vhd OK (200 rules checked) [Error: 0] [Warning: 0]", ""]
 
         lActual = (
-            subprocess.check_output(["bin/vsg", "-f", "tests/vsg/entity_architecture.fixed.vhd", "-of", "summary"], stderr=subprocess.STDOUT)
+            subprocess.check_output([*utils.vsg_exec(), "-f", "tests/vsg/entity_architecture.fixed.vhd", "-of", "summary"], stderr=subprocess.STDOUT)
             .decode("utf-8")
             .split("\n")
         )
@@ -435,7 +457,7 @@ class testVsg(unittest.TestCase):
         try:
             subprocess.check_output(
                 [
-                    "bin/vsg",
+                    *utils.vsg_exec(),
                     "-f",
                     "tests/vsg/entity_architecture.vhd",
                     "tests/vsg/entity_architecture.fixed.vhd",
@@ -469,7 +491,7 @@ class testVsg(unittest.TestCase):
         try:
             subprocess.check_output(
                 [
-                    "bin/vsg",
+                    *utils.vsg_exec(),
                     "-f",
                     "tests/vsg/entity_architecture.vhd",
                     "tests/vsg/entity_architecture.fixed.vhd",
@@ -504,7 +526,7 @@ class testVsg(unittest.TestCase):
         try:
             subprocess.check_output(
                 [
-                    "bin/vsg",
+                    *utils.vsg_exec(),
                     "-f",
                     "tests/vsg/entity_architecture.vhd",
                     "tests/vsg/entity_architecture.fixed.vhd",
@@ -533,7 +555,7 @@ class testVsg(unittest.TestCase):
         lExpected.append("")
 
         try:
-            subprocess.check_output(["bin/vsg", "--configuration", "tests/vsg/config_glob_with_file_rules.yaml", "--output_format", "syntastic"])
+            subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_glob_with_file_rules.yaml", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
             iExitStatus = e.returncode
@@ -547,7 +569,7 @@ class testVsg(unittest.TestCase):
 
         try:
             subprocess.check_output(
-                ["bin/vsg", "--configuration", "tests/vsg/config_file_rules.yaml", "-f", "tests/vsg/entity2.vhd", "--output_format", "syntastic"],
+                [*utils.vsg_exec(), "--configuration", "tests/vsg/config_file_rules.yaml", "-f", "tests/vsg/entity2.vhd", "--output_format", "syntastic"],
             )
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
@@ -562,7 +584,7 @@ class testVsg(unittest.TestCase):
 
         try:
             subprocess.check_output(
-                ["bin/vsg", "--configuration", "tests/vsg/config_file_rules.yaml", "-f", "tests/vsg/entity1.vhd", "--output_format", "syntastic"],
+                [*utils.vsg_exec(), "--configuration", "tests/vsg/config_file_rules.yaml", "-f", "tests/vsg/entity1.vhd", "--output_format", "syntastic"],
             )
         except subprocess.CalledProcessError as e:
             lActual = str(e.output.decode("utf-8")).split("\n")
@@ -575,6 +597,9 @@ class testVsg(unittest.TestCase):
             lExpected = []
             lExpected.append("")
 
-            lActual = subprocess.check_output(["bin/vsg", "--configuration", "tests/vsg/config_3.yaml", "--output_format", "syntastic", "--stdin"], stdin=file1)
+            lActual = subprocess.check_output(
+                [*utils.vsg_exec(), "--configuration", "tests/vsg/config_3.yaml", "--output_format", "syntastic", "--stdin"],
+                stdin=file1,
+            )
             lActual = str(lActual.decode("utf-8")).split("\n")
             self.assertEqual(lActual, lExpected)

--- a/tests/vsg/test_vsg.py
+++ b/tests/vsg/test_vsg.py
@@ -343,7 +343,7 @@ class testVsg(unittest.TestCase):
 
         self.assertEqual(iExitStatus, 1)
 
-    @unittest.skipIf("SUDO_UID" in os.environ.keys() or os.geteuid() == 0, "We are root. Root always has permissions so test will fail.")
+    @unittest.skipIf(utils.is_user_admin(), "We are root. Root always has permissions so test will fail.")
     def test_no_permission_configuration_file(self):
         sNoPermissionFile = os.path.join(self._tmpdir.name, "no_permission.yml")
         pathlib.Path(sNoPermissionFile).touch(mode=0o222, exist_ok=True)

--- a/tests/vsg/test_vsg.py
+++ b/tests/vsg/test_vsg.py
@@ -30,14 +30,13 @@ class testVsg(unittest.TestCase):
         lExpected = []
         lExpected.append("ERROR: tests/vsg/entity1.vhd(7)port_007 -- Change number of spaces after *in* to 4.")
         lExpected.append("ERROR: tests/vsg/entity2.vhd(8)port_008 -- Change number of spaces after *out* to 3.")
-        lExpected.append("")
 
         try:
             subprocess.check_output(
                 [*utils.vsg_exec(), "--configuration", "tests/vsg/config_1.json", "tests/vsg/config_2.json", "--output_format", "syntastic"],
             )
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -47,12 +46,11 @@ class testVsg(unittest.TestCase):
     def test_single_configuration_w_filelist(self):
         lExpected = []
         lExpected.append("ERROR: tests/vsg/entity1.vhd(7)port_007 -- Change number of spaces after *in* to 4.")
-        lExpected.append("")
 
         try:
             subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_1.json", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -61,12 +59,11 @@ class testVsg(unittest.TestCase):
 
         lExpected = []
         lExpected.append("ERROR: tests/vsg/entity2.vhd(8)port_008 -- Change number of spaces after *out* to 3.")
-        lExpected.append("")
 
         try:
             subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_2.json", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -75,18 +72,16 @@ class testVsg(unittest.TestCase):
 
     def test_single_configuration_w_rule_disable(self):
         lExpected = []
-        lExpected.append("")
 
         lActual = subprocess.check_output(
             [*utils.vsg_exec(), "--configuration", "tests/vsg/config_3.json", "--output_format", "syntastic", "-f", "tests/vsg/entity1.vhd"],
         )
-        lActual = str(lActual.decode("utf-8")).split("\n")
+        lActual = str(lActual.decode("utf-8")).splitlines()
         self.assertEqual(lActual, lExpected)
 
     def test_multiple_configuration_w_rule_disable(self):
         lExpected = []
         lExpected.append("ERROR: tests/vsg/entity1.vhd(7)port_007 -- Change number of spaces after *in* to 4.")
-        lExpected.append("")
 
         try:
             subprocess.check_output(
@@ -102,7 +97,7 @@ class testVsg(unittest.TestCase):
                 ],
             )
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -111,7 +106,6 @@ class testVsg(unittest.TestCase):
 
     def test_reverse_multiple_configuration_w_rule_disable(self):
         lExpected = []
-        lExpected.append("")
 
         lActual = subprocess.check_output(
             [
@@ -125,7 +119,7 @@ class testVsg(unittest.TestCase):
                 "tests/vsg/entity1.vhd",
             ],
         )
-        lActual = str(lActual.decode("utf-8")).split("\n")
+        lActual = str(lActual.decode("utf-8")).splitlines()
         self.assertEqual(lActual, lExpected)
 
     def test_invalid_configuration(self):
@@ -134,7 +128,6 @@ class testVsg(unittest.TestCase):
         lExpected.append("while parsing a flow node")
         lExpected.append("expected the node content, but found ','")
         lExpected.append('  in "tests/vsg/config_error.json", line 2, column 16')
-        lExpected.append("")
         config_error_file = os.path.join(self._tmpdir.name, "config_error.actual.xml")
         try:
             lActual = subprocess.check_output(
@@ -151,7 +144,7 @@ class testVsg(unittest.TestCase):
                 ],
             )
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(lActual, lExpected)
@@ -170,7 +163,6 @@ class testVsg(unittest.TestCase):
 
     def test_local_rules(self):
         lExpected = ["ERROR: tests/vsg/entity_architecture.vhd(1)localized_001 -- Split entity and architecture into separate files."]
-        lExpected.append("")
 
         try:
             subprocess.check_output(
@@ -178,7 +170,7 @@ class testVsg(unittest.TestCase):
             )
             iExitStatus = 0
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -188,7 +180,6 @@ class testVsg(unittest.TestCase):
     def test_invalid_local_rule_directory(self):
         lExpected = [
             "ERROR: encountered FileNotFoundError, No such file or directory tests/vsg/invalid_local_rule_directory when trying to open local rules file.",
-            "",
         ]
 
         try:
@@ -196,7 +187,7 @@ class testVsg(unittest.TestCase):
                 [*utils.vsg_exec(), "-f", "tests/vsg/entity_architecture.vhd", "-of", "syntastic", "-lr", "tests/vsg/invalid_local_rule_directory"],
             )
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -206,12 +197,11 @@ class testVsg(unittest.TestCase):
         lExpected = []
         lExpected.append("ERROR: tests/vsg/entity2.vhd(8)port_008 -- Change number of spaces after *out* to 3.")
         lExpected.append("ERROR: tests/vsg/entity1.vhd(7)port_007 -- Change number of spaces after *in* to 4.")
-        lExpected.append("")
 
         try:
             subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_glob.json", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         #        print(lActual)
@@ -221,19 +211,17 @@ class testVsg(unittest.TestCase):
             lExpected = []
             lExpected.append("ERROR: tests/vsg/entity1.vhd(7)port_007 -- Change number of spaces after *in* to 4.")
             lExpected.append("ERROR: tests/vsg/entity2.vhd(8)port_008 -- Change number of spaces after *out* to 3.")
-            lExpected.append("")
 
         self.assertEqual(lActual, lExpected)
 
     def test_single_yaml_configuration_w_filelist(self):
         lExpected = []
         lExpected.append("ERROR: tests/vsg/entity1.vhd(7)port_007 -- Change number of spaces after *in* to 4.")
-        lExpected.append("")
 
         try:
             subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_1.yaml", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -242,12 +230,11 @@ class testVsg(unittest.TestCase):
 
         lExpected = []
         lExpected.append("ERROR: tests/vsg/entity2.vhd(8)port_008 -- Change number of spaces after *out* to 3.")
-        lExpected.append("")
 
         try:
             subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_2.json", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -258,14 +245,13 @@ class testVsg(unittest.TestCase):
         lExpected = []
         lExpected.append("ERROR: tests/vsg/entity1.vhd(7)port_007 -- Change number of spaces after *in* to 4.")
         lExpected.append("ERROR: tests/vsg/entity2.vhd(8)port_008 -- Change number of spaces after *out* to 3.")
-        lExpected.append("")
 
         try:
             subprocess.check_output(
                 [*utils.vsg_exec(), "--configuration", "tests/vsg/config_1.yaml", "tests/vsg/config_2.yaml", "--output_format", "syntastic"],
             )
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -274,18 +260,16 @@ class testVsg(unittest.TestCase):
 
     def test_single_yaml_configuration_w_rule_disable(self):
         lExpected = []
-        lExpected.append("")
 
         lActual = subprocess.check_output(
             [*utils.vsg_exec(), "--configuration", "tests/vsg/config_3.yaml", "--output_format", "syntastic", "-f", "tests/vsg/entity1.vhd"],
         )
-        lActual = str(lActual.decode("utf-8")).split("\n")
+        lActual = str(lActual.decode("utf-8")).splitlines()
         self.assertEqual(lActual, lExpected)
 
     def test_multiple_yaml_configuration_w_rule_disable(self):
         lExpected = []
         lExpected.append("ERROR: tests/vsg/entity1.vhd(7)port_007 -- Change number of spaces after *in* to 4.")
-        lExpected.append("")
 
         try:
             subprocess.check_output(
@@ -301,7 +285,7 @@ class testVsg(unittest.TestCase):
                 ],
             )
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -310,7 +294,6 @@ class testVsg(unittest.TestCase):
 
     def test_reverse_yaml_multiple_configuration_w_rule_disable(self):
         lExpected = []
-        lExpected.append("")
 
         lActual = subprocess.check_output(
             [
@@ -324,19 +307,18 @@ class testVsg(unittest.TestCase):
                 "tests/vsg/entity1.vhd",
             ],
         )
-        lActual = str(lActual.decode("utf-8")).split("\n")
+        lActual = str(lActual.decode("utf-8")).splitlines()
         self.assertEqual(lActual, lExpected)
 
     def test_globbing_filenames_in_yaml_configuration(self):
         lExpected = []
         lExpected.append("ERROR: tests/vsg/entity2.vhd(8)port_008 -- Change number of spaces after *out* to 3.")
         lExpected.append("ERROR: tests/vsg/entity1.vhd(7)port_007 -- Change number of spaces after *in* to 4.")
-        lExpected.append("")
 
         try:
             subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_glob.yaml", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -345,16 +327,14 @@ class testVsg(unittest.TestCase):
             lExpected = []
             lExpected.append("ERROR: tests/vsg/entity1.vhd(7)port_007 -- Change number of spaces after *in* to 4.")
             lExpected.append("ERROR: tests/vsg/entity2.vhd(8)port_008 -- Change number of spaces after *out* to 3.")
-            lExpected.append("")
 
         self.assertEqual(lActual, lExpected)
 
     def test_oc_command_line_argument(self):
         lExpected = []
-        lExpected.append("")
 
         lActual = subprocess.check_output([*utils.vsg_exec(), "-oc", os.path.join(self._tmpdir.name, "deleteme.json")])
-        lActual = str(lActual.decode("utf-8")).split("\n")
+        lActual = str(lActual.decode("utf-8")).splitlines()
         self.assertEqual(lActual, lExpected)
 
     def test_missing_configuration_file(self):
@@ -385,12 +365,11 @@ class testVsg(unittest.TestCase):
     def test_missing_files_in_configuration_file(self):
         lExpected = []
         lExpected.append("ERROR: Could not find file missing_file.vhd in configuration file tests/vsg/missing_file_config.yaml")
-        lExpected.append("")
 
         try:
             subprocess.check_output([*utils.vsg_exec(), "-c", "tests/vsg/missing_file_config.yaml", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -398,15 +377,15 @@ class testVsg(unittest.TestCase):
         self.assertEqual(lActual, lExpected)
 
     def test_summary_output_format_error(self):
-        lExpectedStdErr = ["File: tests/vsg/entity_architecture.vhd ERROR (200 rules checked) [Error: 11] [Warning: 0]", ""]
-        lExpectedStdOut = [""]
+        lExpectedStdErr = ["File: tests/vsg/entity_architecture.vhd ERROR (200 rules checked) [Error: 11] [Warning: 0]"]
+        lExpectedStdOut = []
 
         try:
             subprocess.check_output([*utils.vsg_exec(), "-f", "tests/vsg/entity_architecture.vhd", "-of", "summary"], stderr=subprocess.PIPE)
             iExitStatus = 0
         except subprocess.CalledProcessError as e:
-            lActualStdOut = str(e.output.decode("utf-8")).split("\n")
-            lActualStdErr = str(e.stderr.decode("utf-8")).split("\n")
+            lActualStdOut = str(e.output.decode("utf-8")).splitlines()
+            lActualStdErr = str(e.stderr.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -415,8 +394,8 @@ class testVsg(unittest.TestCase):
         self.assertEqual(utils.replace_total_count_summary(lActualStdOut), lExpectedStdOut)
 
     def test_summary_output_format_error_with_local_rules(self):
-        lExpectedStdErr = ["File: tests/vsg/entity_architecture.vhd ERROR (200 rules checked) [Error: 1] [Warning: 0]", ""]
-        lExpectedStdOut = [""]
+        lExpectedStdErr = ["File: tests/vsg/entity_architecture.vhd ERROR (200 rules checked) [Error: 1] [Warning: 0]"]
+        lExpectedStdOut = []
 
         try:
             subprocess.check_output(
@@ -425,8 +404,8 @@ class testVsg(unittest.TestCase):
             )
             iExitStatus = 0
         except subprocess.CalledProcessError as e:
-            lActualStdOut = str(e.output.decode("utf-8")).split("\n")
-            lActualStdErr = str(e.stderr.decode("utf-8")).split("\n")
+            lActualStdOut = str(e.output.decode("utf-8")).splitlines()
+            lActualStdErr = str(e.stderr.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -435,12 +414,12 @@ class testVsg(unittest.TestCase):
         self.assertEqual(utils.replace_total_count_summary(lActualStdOut), lExpectedStdOut)
 
     def test_summary_output_format_ok(self):
-        lExpected = ["File: tests/vsg/entity_architecture.fixed.vhd OK (200 rules checked) [Error: 0] [Warning: 0]", ""]
+        lExpected = ["File: tests/vsg/entity_architecture.fixed.vhd OK (200 rules checked) [Error: 0] [Warning: 0]"]
 
         lActual = (
             subprocess.check_output([*utils.vsg_exec(), "-f", "tests/vsg/entity_architecture.fixed.vhd", "-of", "summary"], stderr=subprocess.STDOUT)
             .decode("utf-8")
-            .split("\n")
+            .splitlines()
         )
 
         self.assertEqual(utils.replace_total_count_summary(lActual), lExpected)
@@ -450,9 +429,8 @@ class testVsg(unittest.TestCase):
             "File: tests/vsg/entity_architecture.vhd ERROR (200 rules checked) [Error: 11] [Warning: 0]",
             "File: tests/vsg/entity1.vhd ERROR (200 rules checked) [Error: 1] [Warning: 0]",
             "File: tests/vsg/entity2.vhd ERROR (200 rules checked) [Error: 1] [Warning: 0]",
-            "",
         ]
-        lExpectedStdOut = ["File: tests/vsg/entity_architecture.fixed.vhd OK (200 rules checked) [Error: 0] [Warning: 0]", ""]
+        lExpectedStdOut = ["File: tests/vsg/entity_architecture.fixed.vhd OK (200 rules checked) [Error: 0] [Warning: 0]"]
 
         try:
             subprocess.check_output(
@@ -470,8 +448,8 @@ class testVsg(unittest.TestCase):
             )
             iExitStatus = 0
         except subprocess.CalledProcessError as e:
-            lActualStdOut = str(e.output.decode("utf-8")).split("\n")
-            lActualStdErr = str(e.stderr.decode("utf-8")).split("\n")
+            lActualStdOut = str(e.output.decode("utf-8")).splitlines()
+            lActualStdErr = str(e.stderr.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -484,9 +462,8 @@ class testVsg(unittest.TestCase):
             "File: tests/vsg/entity_architecture.vhd ERROR (200 rules checked) [Error: 11] [Warning: 0]",
             "File: tests/vsg/entity1.vhd ERROR (200 rules checked) [Error: 1] [Warning: 0]",
             "File: tests/vsg/entity2.vhd ERROR (200 rules checked) [Error: 1] [Warning: 0]",
-            "",
         ]
-        lExpectedStdOut = ["File: tests/vsg/entity_architecture.fixed.vhd OK (200 rules checked) [Error: 0] [Warning: 0]", ""]
+        lExpectedStdOut = ["File: tests/vsg/entity_architecture.fixed.vhd OK (200 rules checked) [Error: 0] [Warning: 0]"]
 
         try:
             subprocess.check_output(
@@ -505,8 +482,8 @@ class testVsg(unittest.TestCase):
             )
             iExitStatus = 0
         except subprocess.CalledProcessError as e:
-            lActualStdOut = str(e.output.decode("utf-8")).split("\n")
-            lActualStdErr = str(e.stderr.decode("utf-8")).split("\n")
+            lActualStdOut = str(e.output.decode("utf-8")).splitlines()
+            lActualStdErr = str(e.stderr.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -519,9 +496,8 @@ class testVsg(unittest.TestCase):
             "File: tests/vsg/entity_architecture.vhd ERROR (200 rules checked) [Error: 11] [Warning: 0]",
             "File: tests/vsg/entity1.vhd ERROR (200 rules checked) [Error: 1] [Warning: 0]",
             "File: tests/vsg/entity2.vhd ERROR (200 rules checked) [Error: 1] [Warning: 0]",
-            "",
         ]
-        lExpectedStdOut = ["File: tests/vsg/entity_architecture.fixed.vhd OK (200 rules checked) [Error: 0] [Warning: 0]", ""]
+        lExpectedStdOut = ["File: tests/vsg/entity_architecture.fixed.vhd OK (200 rules checked) [Error: 0] [Warning: 0]"]
 
         try:
             subprocess.check_output(
@@ -540,8 +516,8 @@ class testVsg(unittest.TestCase):
             )
             iExitStatus = 0
         except subprocess.CalledProcessError as e:
-            lActualStdOut = str(e.output.decode("utf-8")).split("\n")
-            lActualStdErr = str(e.stderr.decode("utf-8")).split("\n")
+            lActualStdOut = str(e.output.decode("utf-8")).splitlines()
+            lActualStdErr = str(e.stderr.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(iExitStatus, 1)
@@ -552,12 +528,11 @@ class testVsg(unittest.TestCase):
     def test_globbing_filenames_in_configuration_with_file_rules(self):
         lExpected = []
         lExpected.append("ERROR: tests/vsg/entity2.vhd(8)port_008 -- Change number of spaces after *out* to 3.")
-        lExpected.append("")
 
         try:
             subprocess.check_output([*utils.vsg_exec(), "--configuration", "tests/vsg/config_glob_with_file_rules.yaml", "--output_format", "syntastic"])
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(lActual, lExpected)
@@ -565,14 +540,13 @@ class testVsg(unittest.TestCase):
     def test_configuration_with_file_rules_and_no_file_list_entity2(self):
         lExpected = []
         lExpected.append("ERROR: tests/vsg/entity2.vhd(8)port_008 -- Change number of spaces after *out* to 3.")
-        lExpected.append("")
 
         try:
             subprocess.check_output(
                 [*utils.vsg_exec(), "--configuration", "tests/vsg/config_file_rules.yaml", "-f", "tests/vsg/entity2.vhd", "--output_format", "syntastic"],
             )
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(lActual, lExpected)
@@ -587,7 +561,7 @@ class testVsg(unittest.TestCase):
                 [*utils.vsg_exec(), "--configuration", "tests/vsg/config_file_rules.yaml", "-f", "tests/vsg/entity1.vhd", "--output_format", "syntastic"],
             )
         except subprocess.CalledProcessError as e:
-            lActual = str(e.output.decode("utf-8")).split("\n")
+            lActual = str(e.output.decode("utf-8")).splitlines()
             iExitStatus = e.returncode
 
         self.assertEqual(lActual, lExpected)
@@ -595,11 +569,10 @@ class testVsg(unittest.TestCase):
     def test_file_as_stdin(self):
         with open("tests/vsg/entity1.vhd") as file1:
             lExpected = []
-            lExpected.append("")
 
             lActual = subprocess.check_output(
                 [*utils.vsg_exec(), "--configuration", "tests/vsg/config_3.yaml", "--output_format", "syntastic", "--stdin"],
                 stdin=file1,
             )
-            lActual = str(lActual.decode("utf-8")).split("\n")
+            lActual = str(lActual.decode("utf-8")).splitlines()
             self.assertEqual(lActual, lExpected)

--- a/tests/vsg/test_vsg.py
+++ b/tests/vsg/test_vsg.py
@@ -346,6 +346,7 @@ class testVsg(unittest.TestCase):
         self.assertEqual(iExitStatus, 1)
 
     @unittest.skipIf(utils.is_user_admin(), "We are root. Root always has permissions so test will fail.")
+    @unittest.skipIf(utils.is_windows(), "Permission based tests can not be run on Windows.")
     def test_no_permission_configuration_file(self):
         sNoPermissionFile = os.path.join(self._tmpdir.name, "no_permission.yml")
         pathlib.Path(sNoPermissionFile).touch(mode=0o222, exist_ok=True)

--- a/vsg/apply_rules.py
+++ b/vsg/apply_rules.py
@@ -94,7 +94,7 @@ def apply_rules(commandLineArguments, oConfig, tIndexFileName):
     try:
         oRules = rule_list.rule_list(oVhdlFile, oConfig.severity_list, commandLineArguments.local_rules)
     except OSError as e:
-        sOutputStd = f"ERROR: encountered {e.__class__.__name__}, {e.args[1]} " + commandLineArguments.local_rules + " when trying to open local rules file."
+        sOutputStd = f"ERROR: encountered {e.__class__.__name__}, No such file or directory " + commandLineArguments.local_rules + " when trying to open local rules file."
         sOutputErr = None
         return 1, None, dJsonEntry, sOutputStd, sOutputErr, bStopProcessingFiles
 

--- a/vsg/config.py
+++ b/vsg/config.py
@@ -142,16 +142,26 @@ def process_file_list_key(dConfig, tempConfiguration, sKey, sConfigFilename):
     for iIndex, sFilename in enumerate(tempConfiguration["file_list"]):
         validate_file_exists(sFilename, sConfigFilename)
         try:
-            for sGlobbedFilename in glob.glob(utils.expand_filename(sFilename), recursive=True):
+            for sGlobbedFilename in glob_filenames(sFilename):
                 dReturn["file_list"].append(sGlobbedFilename)
         except TypeError:
             sKey = list(sFilename.keys())[0]
-            for sGlobbedFilename in glob.glob(utils.expand_filename(sKey), recursive=True):
+            for sGlobbedFilename in glob_filenames(sKey):
                 dTemp = {}
                 dTemp[sGlobbedFilename] = {}
                 dTemp[sGlobbedFilename].update(tempConfiguration["file_list"][iIndex][sKey])
                 dReturn["file_list"].append(dTemp)
     return dReturn
+
+
+def glob_filenames(sFilename):
+    files = glob.glob(utils.expand_filename(sFilename), recursive=True)
+    return replace_backslash_with_forward_slash(files)
+    return(temp)
+
+
+def replace_backslash_with_forward_slash(lStrings):
+    return [f.replace("\\", "/") for f in lStrings]
 
 
 def write_invalid_configuration_junit_file(sFileName, sJUnitFileName):


### PR DESCRIPTION
**Description**
This fixes some of the issues running the tests on Windows.
- Addresses use of `os.geteuid()` to detect root user
- Wraps calls to `vsg` as `python vsg` so tests don't rely on Unix shebang
- Normalize Unix and Windows line-ending comparison using `str.splitlines()`

**Additional context**
Resolves #1334
