### PR TITLE
use with FIPS

### DIFF
--- a/vsg/report/quality_report.py
+++ b/vsg/report/quality_report.py
@@ -46,7 +46,7 @@ def build_fingerprint(dFile, dViolation, iViolation):
     sHashString += dFile["file_path"]
     sHashString += str(dViolation["linenumber"])
     sHashString += str(iViolation)
-    sHash = hashlib.md5(sHashString.encode("utf-8")).hexdigest()
+    sHash = hashlib.new("md5", sHashString.encode("utf-8"), usedforsecurity=False).hexdigest()
     return sHash
 
 


### PR DESCRIPTION
**Description**
hashlib.md5 needs `usedforsecurity=False` when used on FIPS enabled systems

using `new()` allows python < 3.9 to still work (when usedforsecurity was introduced)