### PR TITLE
Issue#1350 Added case and whitespace rules for shift operators.

### DIFF
--- a/docs/configuring_uppercase_and_lowercase_rules.rst
+++ b/docs/configuring_uppercase_and_lowercase_rules.rst
@@ -482,6 +482,8 @@ Rules Enforcing Case
 * `selected_assignment_502 <selected_assignment_rules.html#selected-assignment-502>`_
 * `selected_assignment_503 <selected_assignment_rules.html#selected-assignment-503>`_
 
+* `shift_operator_500 <shift_operator_rules.html#shift-operator-500>`_
+
 * `signal_002 <signal_rules.html#signal-002>`_
 * `signal_004 <signal_rules.html#signal-004>`_
 

--- a/docs/rule_groups/case_keyword_rule_group.rst
+++ b/docs/rule_groups/case_keyword_rule_group.rst
@@ -160,6 +160,7 @@ Rules Enforcing Case::Keyword Rule Group
 * `selected_assignment_501 <../selected_assignment_rules.html#selected-assignment-501>`_
 * `selected_assignment_502 <../selected_assignment_rules.html#selected-assignment-502>`_
 * `selected_assignment_503 <../selected_assignment_rules.html#selected-assignment-503>`_
+* `shift_operator_500 <../shift_operator_rules.html#shift-operator-500>`_
 * `signal_002 <../signal_rules.html#signal-002>`_
 * `subtype_500 <../subtype_rules.html#subtype-500>`_
 * `subtype_502 <../subtype_rules.html#subtype-502>`_

--- a/docs/rule_groups/case_rule_group.rst
+++ b/docs/rule_groups/case_rule_group.rst
@@ -217,6 +217,7 @@ Rules Enforcing Case Rule Group
 * `selected_assignment_501 <../selected_assignment_rules.html#selected-assignment-501>`_
 * `selected_assignment_502 <../selected_assignment_rules.html#selected-assignment-502>`_
 * `selected_assignment_503 <../selected_assignment_rules.html#selected-assignment-503>`_
+* `shift_operator_500 <../shift_operator_rules.html#shift-operator-500>`_
 * `signal_002 <../signal_rules.html#signal-002>`_
 * `signal_004 <../signal_rules.html#signal-004>`_
 * `signal_014 <../signal_rules.html#signal-014>`_

--- a/docs/rule_groups/whitespace_rule_group.rst
+++ b/docs/rule_groups/whitespace_rule_group.rst
@@ -182,3 +182,4 @@ Rules Enforcing Whitespace Rule Group
 * `whitespace_011 <../whitespace_rules.html#whitespace-011>`_
 * `whitespace_013 <../whitespace_rules.html#whitespace-013>`_
 * `whitespace_100 <../whitespace_rules.html#whitespace-100>`_
+* `whitespace_101 <../whitespace_rules.html#whitespace-101>`_

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -75,6 +75,7 @@ The rules are divided into categories depending on the part of the VHDL code bei
    selected_assignment_rules.rst
    sequential_rules.rst
    signal_rules.rst
+   shift_operator_rules.rst
    source_file_rules.rst
    subprogram_body_rules.rst
    subtype_rules.rst

--- a/docs/shift_operator_rules.rst
+++ b/docs/shift_operator_rules.rst
@@ -1,0 +1,25 @@
+.. include:: includes.rst
+
+Shift Operator Rules
+--------------------
+
+shift_operator_500
+##################
+
+|phase_6| |error| |case| |case_keyword|
+
+This rule checks shift operators have proper case.
+
+|configuring_uppercase_and_lowercase_rules_link|
+
+**Violation**
+
+.. code-block:: vhdl
+
+   a <= b SLL c;
+
+**Fix**
+
+.. code-block:: vhdl
+
+   a <= b sll c;

--- a/docs/whitespace_rules.rst
+++ b/docs/whitespace_rules.rst
@@ -269,6 +269,27 @@ This rule checks for at least a single space before and after relational operato
   if readAddr >= writeAddr then
   if readAddr >= writeAddr then
 
+whitespace_101
+##############
+
+|phase_2| |error| |whitespace|
+
+This rule checks for at least a single space before and after logical operators.
+
+**Violation**
+
+.. code-block:: vhdl
+
+  if (a = '1')sll(b = '0')
+  if (a = '0')rol (b = '1')
+
+**Fix**
+
+.. code-block:: vhdl
+
+  if (a = '1') sll (b = '0')
+  if (a = '0') rol (b = '1')
+
 whitespace_200
 ##############
 

--- a/tests/shift_operator/rule_500_test_input.fixed_lower.vhd
+++ b/tests/shift_operator/rule_500_test_input.fixed_lower.vhd
@@ -1,0 +1,10 @@
+
+architecture rtl of fifo is
+
+begin
+
+  x <= a sll b srl c sla d sra e rol f ror g;
+
+  x <= a sll b srl c sla d sra e rol f ror g;
+
+end architecture;

--- a/tests/shift_operator/rule_500_test_input.fixed_upper.vhd
+++ b/tests/shift_operator/rule_500_test_input.fixed_upper.vhd
@@ -1,0 +1,10 @@
+
+architecture rtl of fifo is
+
+begin
+
+  x <= a SLL b SRL c SLA d SRA e ROL f ROR g;
+
+  x <= a SLL b SRL c SLA d SRA e ROL f ROR g;
+
+end architecture;

--- a/tests/shift_operator/rule_500_test_input.vhd
+++ b/tests/shift_operator/rule_500_test_input.vhd
@@ -1,0 +1,10 @@
+
+architecture rtl of fifo is
+
+begin
+
+  x <= a sll b srl c sla d sra e rol f ror g;
+
+  x <= a SLL b SRL c SLA d SRA e ROL f ROR g;
+
+end architecture;

--- a/tests/shift_operator/test_rule_500.py
+++ b/tests/shift_operator/test_rule_500.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from tests import utils
+from vsg import vhdlFile
+from vsg.rules import shift_operator
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_500_test_input.vhd"))
+
+lExpected_lower = []
+lExpected_lower.append("")
+utils.read_file(os.path.join(sTestDir, "rule_500_test_input.fixed_lower.vhd"), lExpected_lower)
+
+lExpected_upper = []
+lExpected_upper.append("")
+utils.read_file(os.path.join(sTestDir, "rule_500_test_input.fixed_upper.vhd"), lExpected_upper)
+
+
+class test_shift_operator_rule(unittest.TestCase):
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_500_lower(self):
+        oRule = shift_operator.rule_500()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "shift_operator")
+        self.assertEqual(oRule.identifier, "500")
+
+        lExpected = [8, 8, 8, 8, 8, 8]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(utils.extract_violation_lines_from_violation_object(oRule.violations), lExpected)
+
+    def test_rule_500_upper(self):
+        oRule = shift_operator.rule_500()
+        oRule.case = "upper"
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "shift_operator")
+        self.assertEqual(oRule.identifier, "500")
+
+        lExpected = [6, 6, 6, 6, 6, 6]
+        oRule.analyze(self.oFile)
+        self.assertEqual(utils.extract_violation_lines_from_violation_object(oRule.violations), lExpected)
+
+    def test_fix_rule_500_lower(self):
+        oRule = shift_operator.rule_500()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_lower, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])
+
+    def test_fix_rule_500_upper(self):
+        oRule = shift_operator.rule_500()
+        oRule.case = "upper"
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected_upper, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/tests/whitespace/rule_101_test_input.fixed.vhd
+++ b/tests/whitespace/rule_101_test_input.fixed.vhd
@@ -1,0 +1,14 @@
+
+architecture RTL of FIFO is
+
+begin
+
+  a <= b sll c srl d sla e sra f rol g ror h;
+
+  a <= (b) sll (c) srl (d) sla (e) sra (f) rol (g) ror (h);
+
+  -- Violations
+
+  a <= (b) sll (c) srl (d) sla (e) sra (f) rol (g) ror (h);
+
+end architecture RTL;

--- a/tests/whitespace/rule_101_test_input.vhd
+++ b/tests/whitespace/rule_101_test_input.vhd
@@ -1,0 +1,14 @@
+
+architecture RTL of FIFO is
+
+begin
+
+  a <= b sll c srl d sla e sra f rol g ror h;
+
+  a <= (b) sll (c) srl (d) sla (e) sra (f) rol (g) ror (h);
+
+  -- Violations
+
+  a <= (b)sll(c)srl(d)sla(e)sra(f)rol(g)ror(h);
+
+end architecture RTL;

--- a/tests/whitespace/test_rule_003.py
+++ b/tests/whitespace/test_rule_003.py
@@ -15,7 +15,7 @@ lExpected.append("")
 utils.read_file(os.path.join(sTestDir, "rule_003_test_input.fixed.vhd"), lExpected)
 
 
-class test_context_rule(unittest.TestCase):
+class test_whitespace_rule(unittest.TestCase):
     def setUp(self):
         self.oFile = vhdlFile.vhdlFile(lFile)
         self.assertIsNone(eError)

--- a/tests/whitespace/test_rule_004.py
+++ b/tests/whitespace/test_rule_004.py
@@ -15,7 +15,7 @@ lExpected.append("")
 utils.read_file(os.path.join(sTestDir, "rule_004_test_input.fixed.vhd"), lExpected)
 
 
-class test_context_rule(unittest.TestCase):
+class test_whitespace_rule(unittest.TestCase):
     def setUp(self):
         self.oFile = vhdlFile.vhdlFile(lFile)
         self.assertIsNone(eError)

--- a/tests/whitespace/test_rule_005.py
+++ b/tests/whitespace/test_rule_005.py
@@ -15,7 +15,7 @@ lExpected.append("")
 utils.read_file(os.path.join(sTestDir, "rule_005_test_input.fixed.vhd"), lExpected)
 
 
-class test_context_rule(unittest.TestCase):
+class test_whitespace_rule(unittest.TestCase):
     def setUp(self):
         self.oFile = vhdlFile.vhdlFile(lFile)
         self.assertIsNone(eError)

--- a/tests/whitespace/test_rule_006.py
+++ b/tests/whitespace/test_rule_006.py
@@ -15,7 +15,7 @@ lExpected.append("")
 utils.read_file(os.path.join(sTestDir, "rule_006_test_input.fixed.vhd"), lExpected)
 
 
-class test_context_rule(unittest.TestCase):
+class test_whitespace_rule(unittest.TestCase):
     def setUp(self):
         self.oFile = vhdlFile.vhdlFile(lFile)
         self.assertIsNone(eError)

--- a/tests/whitespace/test_rule_007.py
+++ b/tests/whitespace/test_rule_007.py
@@ -15,7 +15,7 @@ lExpected.append("")
 utils.read_file(os.path.join(sTestDir, "rule_007_test_input.fixed.vhd"), lExpected)
 
 
-class test_context_rule(unittest.TestCase):
+class test_whitespace_rule(unittest.TestCase):
     def setUp(self):
         self.oFile = vhdlFile.vhdlFile(lFile)
         self.assertIsNone(eError)

--- a/tests/whitespace/test_rule_008.py
+++ b/tests/whitespace/test_rule_008.py
@@ -15,7 +15,7 @@ lExpected.append("")
 utils.read_file(os.path.join(sTestDir, "rule_008_test_input.fixed.vhd"), lExpected)
 
 
-class test_context_rule(unittest.TestCase):
+class test_whitespace_rule(unittest.TestCase):
     def setUp(self):
         self.oFile = vhdlFile.vhdlFile(lFile)
         self.assertIsNone(eError)

--- a/tests/whitespace/test_rule_010.py
+++ b/tests/whitespace/test_rule_010.py
@@ -15,7 +15,7 @@ lExpected.append("")
 utils.read_file(os.path.join(sTestDir, "rule_010_test_input.fixed.vhd"), lExpected)
 
 
-class test_context_rule(unittest.TestCase):
+class test_whitespace_rule(unittest.TestCase):
     def setUp(self):
         self.oFile = vhdlFile.vhdlFile(lFile)
         self.assertIsNone(eError)

--- a/tests/whitespace/test_rule_011.py
+++ b/tests/whitespace/test_rule_011.py
@@ -15,7 +15,7 @@ lExpected.append("")
 utils.read_file(os.path.join(sTestDir, "rule_011_test_input.fixed.vhd"), lExpected)
 
 
-class test_context_rule(unittest.TestCase):
+class test_whitespace_rule(unittest.TestCase):
     def setUp(self):
         self.oFile = vhdlFile.vhdlFile(lFile)
         self.assertIsNone(eError)

--- a/tests/whitespace/test_rule_013.py
+++ b/tests/whitespace/test_rule_013.py
@@ -15,7 +15,7 @@ lExpected.append("")
 utils.read_file(os.path.join(sTestDir, "rule_013_test_input.fixed.vhd"), lExpected)
 
 
-class test_context_rule(unittest.TestCase):
+class test_whitespace_rule(unittest.TestCase):
     def setUp(self):
         self.oFile = vhdlFile.vhdlFile(lFile)
         self.assertIsNone(eError)

--- a/tests/whitespace/test_rule_101.py
+++ b/tests/whitespace/test_rule_101.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from tests import utils
+from vsg import vhdlFile
+from vsg.rules import whitespace
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_101_test_input.vhd"))
+lExpected = []
+lExpected.append("")
+utils.read_file(os.path.join(sTestDir, "rule_101_test_input.fixed.vhd"), lExpected)
+
+
+class test_context_rule(unittest.TestCase):
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_101(self):
+        oRule = whitespace.rule_101()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "whitespace")
+        self.assertEqual(oRule.identifier, "101")
+
+        lExpected = [14, 14, 14, 14, 14, 14, 14]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_101(self):
+        oRule = whitespace.rule_101()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/tests/whitespace/test_rule_101.py
+++ b/tests/whitespace/test_rule_101.py
@@ -15,7 +15,7 @@ lExpected.append("")
 utils.read_file(os.path.join(sTestDir, "rule_101_test_input.fixed.vhd"), lExpected)
 
 
-class test_context_rule(unittest.TestCase):
+class test_whitespace_rule(unittest.TestCase):
     def setUp(self):
         self.oFile = vhdlFile.vhdlFile(lFile)
         self.assertIsNone(eError)

--- a/tests/whitespace/test_rule_101.py
+++ b/tests/whitespace/test_rule_101.py
@@ -26,7 +26,7 @@ class test_context_rule(unittest.TestCase):
         self.assertEqual(oRule.name, "whitespace")
         self.assertEqual(oRule.identifier, "101")
 
-        lExpected = [14, 14, 14, 14, 14, 14, 14]
+        lExpected = [12, 12, 12, 12, 12, 12, 12]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))

--- a/tests/whitespace/test_rule_101.py
+++ b/tests/whitespace/test_rule_101.py
@@ -26,7 +26,7 @@ class test_whitespace_rule(unittest.TestCase):
         self.assertEqual(oRule.name, "whitespace")
         self.assertEqual(oRule.identifier, "101")
 
-        lExpected = [12, 12, 12, 12, 12, 12, 12]
+        lExpected = [12, 12, 12, 12, 12, 12]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))

--- a/vsg/rules/__init__.py
+++ b/vsg/rules/__init__.py
@@ -175,6 +175,7 @@ from vsg.rules import return_statement
 from vsg.rules import selected_assignment
 from vsg.rules import sequential
 from vsg.rules import signal
+from vsg.rules import shift_operator
 from vsg.rules import source_file
 from vsg.rules import subprogram_body
 from vsg.rules import subtype

--- a/vsg/rules/shift_operator/__init__.py
+++ b/vsg/rules/shift_operator/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from .rule_500 import rule_500

--- a/vsg/rules/shift_operator/rule_500.py
+++ b/vsg/rules/shift_operator/rule_500.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from vsg import token
+from vsg.rules import token_case
+
+lTokens = []
+lTokens.append(token.shift_operator.sll)
+lTokens.append(token.shift_operator.srl)
+lTokens.append(token.shift_operator.sla)
+lTokens.append(token.shift_operator.sra)
+lTokens.append(token.shift_operator.rol)
+lTokens.append(token.shift_operator.ror)
+
+
+class rule_500(token_case):
+    """
+    This rule checks shift operators have proper case.
+
+    |configuring_uppercase_and_lowercase_rules_link|
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+       a <= b SLL c;
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+       a <= b sll c;
+    """
+
+    def __init__(self):
+        super().__init__(lTokens)
+        self.groups.append("case::keyword")

--- a/vsg/rules/whitespace/__init__.py
+++ b/vsg/rules/whitespace/__init__.py
@@ -13,4 +13,5 @@ from .rule_011 import rule_011
 from .rule_012 import rule_012
 from .rule_013 import rule_013
 from .rule_100 import rule_100
+from .rule_101 import rule_101
 from .rule_200 import rule_200

--- a/vsg/rules/whitespace/rule_013.py
+++ b/vsg/rules/whitespace/rule_013.py
@@ -28,5 +28,5 @@ class rule_013(n_spaces_before_and_after_tokens):
 
     def __init__(self):
         super().__init__(1, lTokens, bNIsMinimum=True)
-        self.solution = "Ensure a single space before and after concat operator."
+        self.solution = "Ensure a single space before and after logical operator."
         self.configuration_documentation_link = None

--- a/vsg/rules/whitespace/rule_101.py
+++ b/vsg/rules/whitespace/rule_101.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from vsg import token
+from vsg.rules import n_spaces_before_and_after_tokens
+
+lTokens = []
+lTokens.append(token.shift_operator.sll)
+lTokens.append(token.shift_operator.srl)
+lTokens.append(token.shift_operator.sla)
+lTokens.append(token.shift_operator.sra)
+lTokens.append(token.shift_operator.rol)
+lTokens.append(token.shift_operator.ror)
+
+
+class rule_101(n_spaces_before_and_after_tokens):
+    """
+    This rule checks for at least a single space before and after logical operators.
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+      if (a = '1')sll(b = '0')
+      if (a = '0')rol (b = '1')
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+      if (a = '1') sll (b = '0')
+      if (a = '0') rol (b = '1')
+    """
+
+    def __init__(self):
+        super().__init__(1, lTokens, bNIsMinimum=True)
+        self.solution = "Ensure a single space before and after shift operator."
+        self.configuration_documentation_link = None


### PR DESCRIPTION
Resolves #1350.
I also snuck in some fixes for a couple of minor mistakes (incorrect class names, missing init files).