### PR TITLE
Update tox.ini to include python 3.13

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ requires =
     tox-gh-actions
 envlist =  # order is important
     style
-    {test, wheel}-py3{8,9,10,11,12}
+    {test, wheel}-py3{8,9,10,11,12,13}
 
 [gh-actions]
 python =
@@ -15,6 +15,7 @@ python =
     3.10: {test}-py310
     3.11: {test}-py311
     3.12: {test}-py312
+    3.13: {test}-py313
 
 [testenv]
 setenv =
@@ -27,7 +28,7 @@ extras =
 commands =
     pre-commit run --all-files {posargs}
 
-[testenv:test-py3{8,9,10,11,12}]
+[testenv:test-py3{8,9,10,11,12,13}]
 extras =
     tests
 setenv =
@@ -40,7 +41,7 @@ commands =
         --html=build.out/{envname}/test/pytest.html \
         {posargs:tests}
 
-[testenv:lint-py3{8,9,10,11,12}]
+[testenv:lint-py3{8,9,10,11,12,13}]
 extras =
     dev
 commands =
@@ -48,7 +49,7 @@ commands =
         vsg \
         tests
 
-[testenv:wheel-py3{8,9,10,11,12}]
+[testenv:wheel-py3{8,9,10,11,12,13}]
 package = skip
 deps =
     build


### PR DESCRIPTION
**Description**
Including python 3.13 in tox.ini, so that it can build on systems running python 3.13.

Is there anything else to do?
