### PR TITLE
Issue#1415:  Fixing classification of + and - when used with predefined attributes.

### DIFF
--- a/tests/whitespace/rule_011_test_input.fixed.vhd
+++ b/tests/whitespace/rule_011_test_input.fixed.vhd
@@ -126,3 +126,25 @@ begin
   a <= -1 + 10;
 
 end architecture RTL;
+
+-- test attributes
+
+architecture rtl of fifo is
+
+begin
+
+   -- passing
+   a <= b'left + type_bits;
+   a <= b'right - type_bits;
+   a <= b'left / type_bits;
+   a <= b'right * type_bits;
+   a <= b'left ** type_bits;
+
+   -- failing
+   a <= b'left + type_bits;
+   a <= b'right - type_bits;
+   a <= b'left / type_bits;
+   a <= b'right * type_bits;
+   a <= b'left ** type_bits;
+
+end architecture rtl;

--- a/tests/whitespace/rule_011_test_input.vhd
+++ b/tests/whitespace/rule_011_test_input.vhd
@@ -126,3 +126,25 @@ begin
   a <= -1 + 10;
 
 end architecture RTL;
+
+-- test attributes
+
+architecture rtl of fifo is
+
+begin
+
+   -- passing
+   a <= b'left + type_bits;
+   a <= b'right - type_bits;
+   a <= b'left / type_bits;
+   a <= b'right * type_bits;
+   a <= b'left ** type_bits;
+
+   -- failing
+   a <= b'left+type_bits;
+   a <= b'right-type_bits;
+   a <= b'left/type_bits;
+   a <= b'right*type_bits;
+   a <= b'left**type_bits;
+
+end architecture rtl;

--- a/tests/whitespace/test_rule_011.py
+++ b/tests/whitespace/test_rule_011.py
@@ -41,6 +41,7 @@ class test_whitespace_rule(unittest.TestCase):
         lExpected.extend(range(100, 105))
         lExpected.extend(range(106, 111))
         lExpected.extend(range(112, 117))
+        lExpected.extend(range(144, 149))
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))

--- a/vsg/vhdlFile/vhdlFile.py
+++ b/vsg/vhdlFile/vhdlFile.py
@@ -678,7 +678,9 @@ def remove_beginning_of_file_tokens(lTokens):
 
 
 def assign_token_of_addition_operator_that_can_be_either_unary_and_binary(iToken, lTokens, sValue, dTokenTypes):
-    if (
+    if utils.are_previous_consecutive_token_types_ignoring_whitespace([predefined_attribute.keyword], iToken - 1, lTokens):
+        lTokens[iToken] = dTokenTypes["binary"](sValue)
+    elif (
         utils.are_previous_consecutive_token_types_ignoring_whitespace([parser.open_parenthesis], iToken - 1, lTokens)
         or utils.are_previous_consecutive_token_types_ignoring_whitespace([parser.keyword], iToken - 1, lTokens)
         or utils.are_previous_consecutive_token_types_ignoring_whitespace([parser.assignment], iToken - 1, lTokens)


### PR DESCRIPTION
Resolves #1415 