### PR TITLE
fix SyntaxWarning for py3.13 compatibility

### DIFF
--- a/vsg/rules/whitespace/rule_011.py
+++ b/vsg/rules/whitespace/rule_011.py
@@ -13,7 +13,7 @@ lTokens.append(token.miscellaneous_operator.double_star)
 
 class rule_011(n_spaces_before_and_after_tokens):
     r"""
-    This rule checks for at least a single space before and after math operators +, -, /, * and \*\*.
+    This rule checks for at least a single space before and after math operators +, -, /, * and **.
 
     **Violation**
 


### PR DESCRIPTION
**Description**
seeing some syntax warning when running with py3.13

```
/opt/homebrew/Cellar/vsg/3.31.0/libexec/lib/python3.13/site-packages/vsg/rules/whitespace/rule_011.py:16: SyntaxWarning: invalid escape sequence '\*'
  This rule checks for at least a single space before and after math operators +, -, /, * and \*\*.
```
