### PR TITLE
Issue 1475: Add support for VHDL 2019 views

### DIFF
--- a/docs/port_rules.rst
+++ b/docs/port_rules.rst
@@ -566,6 +566,7 @@ This rule checks for missing modes in port declarations.
      WR_EN    : std_logic;
      RD_EN    : std_logic;
      OVERFLOW : std_logic;
+     V_TEST   : some_view;
      DATA     : inout std_logic
    );
 
@@ -577,6 +578,7 @@ This rule checks for missing modes in port declarations.
      WR_EN    : in    std_logic;
      RD_EN    : in    std_logic;
      OVERFLOW : out   std_logic;
+     V_TEST   : view  some_view;
      DATA     : inout std_logic
    );
 

--- a/tests/port/rule_023_test_input.vhd
+++ b/tests/port/rule_023_test_input.vhd
@@ -1,10 +1,11 @@
 
 entity FIFO is
   port (
-    I_WR_EN : in  std_logic;
-    I_DATA  : out std_logic_vector(31 downto 0);
-    I_RD_EN : in  std_logic;
-    O_DATA  : out std_logic_vector(31 downto 0)
+    I_WR_EN : in   std_logic;
+    I_DATA  : out  std_logic_vector(31 downto 0);
+    I_RD_EN : in   std_logic;
+    O_DATA  : out  std_logic_vector(31 downto 0);
+    V_DATA  : view some_view
   );
 end entity FIFO;
 
@@ -14,6 +15,7 @@ entity FIFO is
     I_WR_EN : std_logic;
     I_DATA  : std_logic_vector(31 downto 0);
     I_RD_EN : std_logic;
-    O_DATA  : std_logic_vector(31 downto 0)
+    O_DATA  : std_logic_vector(31 downto 0);
+    V_DATA  : some_view
   );
 end entity FIFO;

--- a/tests/port/test_rule_023.py
+++ b/tests/port/test_rule_023.py
@@ -24,7 +24,7 @@ class test_port_rule(unittest.TestCase):
         self.assertEqual(oRule.identifier, "023")
         self.assertEqual(oRule.groups, ["structure"])
 
-        lExpected = [14, 15, 16, 17]
+        lExpected = [15, 16, 17, 18, 19]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))

--- a/tests/vhdlFile/alias_declaration/classification_results.txt
+++ b/tests/vhdlFile/alias_declaration/classification_results.txt
@@ -195,13 +195,25 @@
 22 |
 <class 'vsg.parser.blank_line'>
 --------------------------------------------------------------------------------
-23 | begin
-<class 'vsg.token.architecture_body.begin_keyword'>
+23 |   alias opposite_view is some_view'converse;
+<class 'vsg.token.alias_declaration.alias_keyword'>
+<class 'vsg.token.alias_declaration.alias_designator'>
+<class 'vsg.token.alias_declaration.is_keyword'>
+<class 'vsg.parser.todo'>
+<class 'vsg.parser.tic'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.alias_declaration.semicolon'>
 --------------------------------------------------------------------------------
 24 |
 <class 'vsg.parser.blank_line'>
 --------------------------------------------------------------------------------
-25 | end architecture RTL;
+25 | begin
+<class 'vsg.token.architecture_body.begin_keyword'>
+--------------------------------------------------------------------------------
+26 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+27 | end architecture RTL;
 <class 'vsg.token.architecture_body.end_keyword'>
 <class 'vsg.token.architecture_body.end_architecture_keyword'>
 <class 'vsg.token.architecture_body.architecture_simple_name'>

--- a/tests/vhdlFile/alias_declaration/classification_test_input.vhd
+++ b/tests/vhdlFile/alias_declaration/classification_test_input.vhd
@@ -20,6 +20,8 @@ architecture RTL of FIFO is
 
   alias s_event_count : natural range 0 to 2**16 - 1 is << signal some.reference.some_signal : natural range 0 to 2**16 - 1 >>;
 
+  alias opposite_view is some_view'converse;
+
 begin
 
 end architecture RTL;

--- a/tests/vhdlFile/component_declaration/classification_results.txt
+++ b/tests/vhdlFile/component_declaration/classification_results.txt
@@ -78,7 +78,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -86,7 +86,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 --------------------------------------------------------------------------------
 21 |     );
@@ -119,7 +119,7 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -128,7 +128,7 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.out_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 --------------------------------------------------------------------------------
 29 |     );
@@ -160,7 +160,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -168,7 +168,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 --------------------------------------------------------------------------------
 37 |     );
@@ -184,7 +184,7 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -193,7 +193,7 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.out_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 --------------------------------------------------------------------------------
 41 |     );
@@ -225,7 +225,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -251,7 +251,7 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -260,7 +260,7 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.out_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 --------------------------------------------------------------------------------
 53 |     );

--- a/tests/vhdlFile/entity_header/classification_results.txt
+++ b/tests/vhdlFile/entity_header/classification_results.txt
@@ -20,7 +20,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -30,7 +30,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.character_literal'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -110,7 +110,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -120,7 +120,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.character_literal'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------

--- a/tests/vhdlFile/function_specification/classification_results.txt
+++ b/tests/vhdlFile/function_specification/classification_results.txt
@@ -223,7 +223,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 <class 'vsg.token.interface_unknown_declaration.identifier'>
@@ -270,7 +270,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 <class 'vsg.token.interface_unknown_declaration.identifier'>

--- a/tests/vhdlFile/interface_function_specification/classification_results.txt
+++ b/tests/vhdlFile/interface_function_specification/classification_results.txt
@@ -40,8 +40,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -76,8 +76,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -118,8 +118,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -154,8 +154,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -196,8 +196,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -232,8 +232,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -274,8 +274,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -310,8 +310,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -354,8 +354,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -390,8 +390,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -431,8 +431,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -467,8 +467,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -508,8 +508,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -544,8 +544,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -585,8 +585,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -621,8 +621,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------

--- a/tests/vhdlFile/interface_signal_declaration/classification_results.txt
+++ b/tests/vhdlFile/interface_signal_declaration/classification_results.txt
@@ -35,7 +35,7 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.inout_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
 8 |     port1 : buffer std_logic bus := "asdf";
@@ -43,8 +43,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.buffer_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -53,38 +53,122 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.linkage_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
-10 |     port1 : std_logic
+10 |     port1 : std_logic;
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
+<class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
-11 |   );
+11 |     port1 : view some_view;
+<class 'vsg.token.interface_unknown_declaration.identifier'>
+<class 'vsg.token.interface_unknown_declaration.colon'>
+<class 'vsg.token.record_mode_view_indication.view_keyword'>
+<class 'vsg.token.record_mode_view_indication.name'>
+<class 'vsg.token.interface_list.semicolon'>
+--------------------------------------------------------------------------------
+12 |     port1 : view some_view of rec;
+<class 'vsg.token.interface_unknown_declaration.identifier'>
+<class 'vsg.token.interface_unknown_declaration.colon'>
+<class 'vsg.token.record_mode_view_indication.view_keyword'>
+<class 'vsg.token.record_mode_view_indication.name'>
+<class 'vsg.token.record_mode_view_indication.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.interface_list.semicolon'>
+--------------------------------------------------------------------------------
+13 |     port1 : view some_view of rec(f1(5 downto 0));
+<class 'vsg.token.interface_unknown_declaration.identifier'>
+<class 'vsg.token.interface_unknown_declaration.colon'>
+<class 'vsg.token.record_mode_view_indication.view_keyword'>
+<class 'vsg.token.record_mode_view_indication.name'>
+<class 'vsg.token.record_mode_view_indication.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.record_constraint.open_parenthesis'>
+<class 'vsg.token.record_element_constraint.record_element_simple_name'>
+<class 'vsg.token.index_constraint.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.direction.downto'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.index_constraint.close_parenthesis'>
+<class 'vsg.token.record_constraint.close_parenthesis'>
+<class 'vsg.token.interface_list.semicolon'>
+--------------------------------------------------------------------------------
+14 |     port1 : view some_view of rec(f1(5 downto 0), f2(0 to 1));
+<class 'vsg.token.interface_unknown_declaration.identifier'>
+<class 'vsg.token.interface_unknown_declaration.colon'>
+<class 'vsg.token.record_mode_view_indication.view_keyword'>
+<class 'vsg.token.record_mode_view_indication.name'>
+<class 'vsg.token.record_mode_view_indication.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.record_constraint.open_parenthesis'>
+<class 'vsg.token.record_element_constraint.record_element_simple_name'>
+<class 'vsg.token.index_constraint.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.direction.downto'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.index_constraint.close_parenthesis'>
+<class 'vsg.token.record_constraint.comma'>
+<class 'vsg.token.record_element_constraint.record_element_simple_name'>
+<class 'vsg.token.index_constraint.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.direction.to'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.index_constraint.close_parenthesis'>
+<class 'vsg.token.record_constraint.close_parenthesis'>
+<class 'vsg.token.interface_list.semicolon'>
+--------------------------------------------------------------------------------
+15 |     port1 : view (some_array_view) of rec_array;
+<class 'vsg.token.interface_unknown_declaration.identifier'>
+<class 'vsg.token.interface_unknown_declaration.colon'>
+<class 'vsg.token.array_mode_view_indication.view_keyword'>
+<class 'vsg.token.array_mode_view_indication.open_parenthesis'>
+<class 'vsg.token.array_mode_view_indication.name'>
+<class 'vsg.token.array_mode_view_indication.close_parenthesis'>
+<class 'vsg.token.array_mode_view_indication.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.interface_list.semicolon'>
+--------------------------------------------------------------------------------
+16 |     port1 : view (some_array_view) of rec_array(0 to 7)
+<class 'vsg.token.interface_unknown_declaration.identifier'>
+<class 'vsg.token.interface_unknown_declaration.colon'>
+<class 'vsg.token.array_mode_view_indication.view_keyword'>
+<class 'vsg.token.array_mode_view_indication.open_parenthesis'>
+<class 'vsg.token.array_mode_view_indication.name'>
+<class 'vsg.token.array_mode_view_indication.close_parenthesis'>
+<class 'vsg.token.array_mode_view_indication.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.index_constraint.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.direction.to'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.index_constraint.close_parenthesis'>
+--------------------------------------------------------------------------------
+17 |   );
 <class 'vsg.token.port_clause.close_parenthesis'>
 <class 'vsg.token.port_clause.semicolon'>
 --------------------------------------------------------------------------------
-12 | end entity FIFO;
+18 | end entity FIFO;
 <class 'vsg.token.entity_declaration.end_keyword'>
 <class 'vsg.token.entity_declaration.end_entity_keyword'>
 <class 'vsg.token.entity_declaration.entity_simple_name'>
 <class 'vsg.token.entity_declaration.semicolon'>
 --------------------------------------------------------------------------------
-13 |
+19 |
 <class 'vsg.parser.blank_line'>
 --------------------------------------------------------------------------------
-14 | entity FIFO is
+20 | entity FIFO is
 <class 'vsg.token.entity_declaration.entity_keyword'>
 <class 'vsg.token.entity_declaration.identifier'>
 <class 'vsg.token.entity_declaration.is_keyword'>
 --------------------------------------------------------------------------------
-15 |   port (
+21 |   port (
 <class 'vsg.token.port_clause.port_keyword'>
 <class 'vsg.token.port_clause.open_parenthesis'>
 --------------------------------------------------------------------------------
-16 |     signal port1 : in std_logic;
+22 |     signal port1 : in std_logic;
 <class 'vsg.token.interface_signal_declaration.signal_keyword'>
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
@@ -92,7 +176,7 @@
 <class 'vsg.token.type_mark.name'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
-17 |     signal port1 : out std_logic;
+23 |     signal port1 : out std_logic;
 <class 'vsg.token.interface_signal_declaration.signal_keyword'>
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
@@ -100,7 +184,7 @@
 <class 'vsg.token.type_mark.name'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
-18 |     signal port1 : inout std_logic;
+24 |     signal port1 : inout std_logic;
 <class 'vsg.token.interface_signal_declaration.signal_keyword'>
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
@@ -108,7 +192,7 @@
 <class 'vsg.token.type_mark.name'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
-19 |     signal port1 : buffer std_logic;
+25 |     signal port1 : buffer std_logic;
 <class 'vsg.token.interface_signal_declaration.signal_keyword'>
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
@@ -116,7 +200,7 @@
 <class 'vsg.token.type_mark.name'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
-20 |     signal port1 : linkage std_logic;
+26 |     signal port1 : linkage std_logic;
 <class 'vsg.token.interface_signal_declaration.signal_keyword'>
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
@@ -124,17 +208,107 @@
 <class 'vsg.token.type_mark.name'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
-21 |     signal port1 : std_logic
+27 |     signal port1 : std_logic;
 <class 'vsg.token.interface_signal_declaration.signal_keyword'>
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
+<class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
-22 |   );
+28 |     signal port1 : view some_view;
+<class 'vsg.token.interface_signal_declaration.signal_keyword'>
+<class 'vsg.token.interface_signal_declaration.identifier'>
+<class 'vsg.token.interface_signal_declaration.colon'>
+<class 'vsg.token.record_mode_view_indication.view_keyword'>
+<class 'vsg.token.record_mode_view_indication.name'>
+<class 'vsg.token.interface_list.semicolon'>
+--------------------------------------------------------------------------------
+29 |     signal port1 : view some_view of rec;
+<class 'vsg.token.interface_signal_declaration.signal_keyword'>
+<class 'vsg.token.interface_signal_declaration.identifier'>
+<class 'vsg.token.interface_signal_declaration.colon'>
+<class 'vsg.token.record_mode_view_indication.view_keyword'>
+<class 'vsg.token.record_mode_view_indication.name'>
+<class 'vsg.token.record_mode_view_indication.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.interface_list.semicolon'>
+--------------------------------------------------------------------------------
+30 |     signal port1 : view some_view of rec(f1(5 downto 0));
+<class 'vsg.token.interface_signal_declaration.signal_keyword'>
+<class 'vsg.token.interface_signal_declaration.identifier'>
+<class 'vsg.token.interface_signal_declaration.colon'>
+<class 'vsg.token.record_mode_view_indication.view_keyword'>
+<class 'vsg.token.record_mode_view_indication.name'>
+<class 'vsg.token.record_mode_view_indication.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.record_constraint.open_parenthesis'>
+<class 'vsg.token.record_element_constraint.record_element_simple_name'>
+<class 'vsg.token.index_constraint.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.direction.downto'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.index_constraint.close_parenthesis'>
+<class 'vsg.token.record_constraint.close_parenthesis'>
+<class 'vsg.token.interface_list.semicolon'>
+--------------------------------------------------------------------------------
+31 |     signal port1 : view some_view of rec(f1(5 downto 0), f2(0 to 1));
+<class 'vsg.token.interface_signal_declaration.signal_keyword'>
+<class 'vsg.token.interface_signal_declaration.identifier'>
+<class 'vsg.token.interface_signal_declaration.colon'>
+<class 'vsg.token.record_mode_view_indication.view_keyword'>
+<class 'vsg.token.record_mode_view_indication.name'>
+<class 'vsg.token.record_mode_view_indication.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.record_constraint.open_parenthesis'>
+<class 'vsg.token.record_element_constraint.record_element_simple_name'>
+<class 'vsg.token.index_constraint.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.direction.downto'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.index_constraint.close_parenthesis'>
+<class 'vsg.token.record_constraint.comma'>
+<class 'vsg.token.record_element_constraint.record_element_simple_name'>
+<class 'vsg.token.index_constraint.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.direction.to'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.index_constraint.close_parenthesis'>
+<class 'vsg.token.record_constraint.close_parenthesis'>
+<class 'vsg.token.interface_list.semicolon'>
+--------------------------------------------------------------------------------
+32 |     signal port1 : view (some_array_view) of rec_array;
+<class 'vsg.token.interface_signal_declaration.signal_keyword'>
+<class 'vsg.token.interface_signal_declaration.identifier'>
+<class 'vsg.token.interface_signal_declaration.colon'>
+<class 'vsg.token.array_mode_view_indication.view_keyword'>
+<class 'vsg.token.array_mode_view_indication.open_parenthesis'>
+<class 'vsg.token.array_mode_view_indication.name'>
+<class 'vsg.token.array_mode_view_indication.close_parenthesis'>
+<class 'vsg.token.array_mode_view_indication.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.interface_list.semicolon'>
+--------------------------------------------------------------------------------
+33 |     signal port1 : view (some_array_view) of rec_array(0 to 7)
+<class 'vsg.token.interface_signal_declaration.signal_keyword'>
+<class 'vsg.token.interface_signal_declaration.identifier'>
+<class 'vsg.token.interface_signal_declaration.colon'>
+<class 'vsg.token.array_mode_view_indication.view_keyword'>
+<class 'vsg.token.array_mode_view_indication.open_parenthesis'>
+<class 'vsg.token.array_mode_view_indication.name'>
+<class 'vsg.token.array_mode_view_indication.close_parenthesis'>
+<class 'vsg.token.array_mode_view_indication.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.index_constraint.open_parenthesis'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.direction.to'>
+<class 'vsg.parser.todo'>
+<class 'vsg.token.index_constraint.close_parenthesis'>
+--------------------------------------------------------------------------------
+34 |   );
 <class 'vsg.token.port_clause.close_parenthesis'>
 <class 'vsg.token.port_clause.semicolon'>
 --------------------------------------------------------------------------------
-23 | end entity FIFO;
+35 | end entity FIFO;
 <class 'vsg.token.entity_declaration.end_keyword'>
 <class 'vsg.token.entity_declaration.end_entity_keyword'>
 <class 'vsg.token.entity_declaration.entity_simple_name'>

--- a/tests/vhdlFile/interface_signal_declaration/classification_test_input.vhd
+++ b/tests/vhdlFile/interface_signal_declaration/classification_test_input.vhd
@@ -7,7 +7,13 @@ entity FIFO is
     port1 : inout std_logic bus;
     port1 : buffer std_logic bus := "asdf";
     port1 : linkage std_logic := "asdf";
-    port1 : std_logic
+    port1 : std_logic;
+    port1 : view some_view;
+    port1 : view some_view of rec;
+    port1 : view some_view of rec(f1(5 downto 0));
+    port1 : view some_view of rec(f1(5 downto 0), f2(0 to 1));
+    port1 : view (some_array_view) of rec_array;
+    port1 : view (some_array_view) of rec_array(0 to 7)
   );
 end entity FIFO;
 
@@ -18,6 +24,12 @@ entity FIFO is
     signal port1 : inout std_logic;
     signal port1 : buffer std_logic;
     signal port1 : linkage std_logic;
-    signal port1 : std_logic
+    signal port1 : std_logic;
+    signal port1 : view some_view;
+    signal port1 : view some_view of rec;
+    signal port1 : view some_view of rec(f1(5 downto 0));
+    signal port1 : view some_view of rec(f1(5 downto 0), f2(0 to 1));
+    signal port1 : view (some_array_view) of rec_array;
+    signal port1 : view (some_array_view) of rec_array(0 to 7)
   );
 end entity FIFO;

--- a/tests/vhdlFile/mode_view_declaration/classification_results.txt
+++ b/tests/vhdlFile/mode_view_declaration/classification_results.txt
@@ -1,0 +1,157 @@
+--------------------------------------------------------------------------------
+0 |
+--------------------------------------------------------------------------------
+1 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+2 | package interfaces is
+<class 'vsg.token.package_declaration.package_keyword'>
+<class 'vsg.token.package_declaration.identifier'>
+<class 'vsg.token.package_declaration.is_keyword'>
+--------------------------------------------------------------------------------
+3 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+4 |     view streaming of streaming_bus is
+<class 'vsg.token.mode_view_declaration.view_keyword'>
+<class 'vsg.token.mode_view_declaration.identifier'>
+<class 'vsg.token.mode_view_declaration.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.mode_view_declaration.is_keyword'>
+--------------------------------------------------------------------------------
+5 |         valid, data : out;
+<class 'vsg.token.record_element_list.simple_name'>
+<class 'vsg.token.record_element_list.comma'>
+<class 'vsg.token.record_element_list.simple_name'>
+<class 'vsg.token.mode_view_element_definition.colon'>
+<class 'vsg.token.mode.out_keyword'>
+<class 'vsg.token.mode_view_element_definition.semicolon'>
+--------------------------------------------------------------------------------
+6 |         ack         : in;
+<class 'vsg.token.record_element_list.simple_name'>
+<class 'vsg.token.mode_view_element_definition.colon'>
+<class 'vsg.token.mode.in_keyword'>
+<class 'vsg.token.mode_view_element_definition.semicolon'>
+--------------------------------------------------------------------------------
+7 |         nested      : view inner_streaming_bus;
+<class 'vsg.token.record_element_list.simple_name'>
+<class 'vsg.token.mode_view_element_definition.colon'>
+<class 'vsg.token.element_record_mode_view_indication.view_keyword'>
+<class 'vsg.token.element_record_mode_view_indication.name'>
+<class 'vsg.token.mode_view_element_definition.semicolon'>
+--------------------------------------------------------------------------------
+8 |     end view streaming;
+<class 'vsg.token.mode_view_declaration.end_keyword'>
+<class 'vsg.token.mode_view_declaration.end_view_keyword'>
+<class 'vsg.token.mode_view_declaration.end_view_label'>
+<class 'vsg.token.mode_view_declaration.semicolon'>
+--------------------------------------------------------------------------------
+9 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+10 | end package;
+<class 'vsg.token.package_declaration.end_keyword'>
+<class 'vsg.token.package_declaration.end_package_keyword'>
+<class 'vsg.token.package_declaration.semicolon'>
+--------------------------------------------------------------------------------
+11 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+12 | architecture rtl of entity1 is
+<class 'vsg.token.architecture_body.architecture_keyword'>
+<class 'vsg.token.architecture_body.identifier'>
+<class 'vsg.token.architecture_body.of_keyword'>
+<class 'vsg.token.architecture_body.entity_name'>
+<class 'vsg.token.architecture_body.is_keyword'>
+--------------------------------------------------------------------------------
+13 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+14 |     view streaming of streaming_bus is
+<class 'vsg.token.mode_view_declaration.view_keyword'>
+<class 'vsg.token.mode_view_declaration.identifier'>
+<class 'vsg.token.mode_view_declaration.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.mode_view_declaration.is_keyword'>
+--------------------------------------------------------------------------------
+15 |         valid, data : out;
+<class 'vsg.token.record_element_list.simple_name'>
+<class 'vsg.token.record_element_list.comma'>
+<class 'vsg.token.record_element_list.simple_name'>
+<class 'vsg.token.mode_view_element_definition.colon'>
+<class 'vsg.token.mode.out_keyword'>
+<class 'vsg.token.mode_view_element_definition.semicolon'>
+--------------------------------------------------------------------------------
+16 |         ack         : in;
+<class 'vsg.token.record_element_list.simple_name'>
+<class 'vsg.token.mode_view_element_definition.colon'>
+<class 'vsg.token.mode.in_keyword'>
+<class 'vsg.token.mode_view_element_definition.semicolon'>
+--------------------------------------------------------------------------------
+17 |     end view;
+<class 'vsg.token.mode_view_declaration.end_keyword'>
+<class 'vsg.token.mode_view_declaration.end_view_keyword'>
+<class 'vsg.token.mode_view_declaration.semicolon'>
+--------------------------------------------------------------------------------
+18 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+19 |   begin
+<class 'vsg.token.architecture_body.begin_keyword'>
+--------------------------------------------------------------------------------
+20 |     b1 : block
+<class 'vsg.token.block_statement.block_label'>
+<class 'vsg.token.block_statement.label_colon'>
+<class 'vsg.token.block_statement.block_keyword'>
+--------------------------------------------------------------------------------
+21 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+22 |         view streaming of streaming_bus is
+<class 'vsg.token.mode_view_declaration.view_keyword'>
+<class 'vsg.token.mode_view_declaration.identifier'>
+<class 'vsg.token.mode_view_declaration.of_keyword'>
+<class 'vsg.token.type_mark.name'>
+<class 'vsg.token.mode_view_declaration.is_keyword'>
+--------------------------------------------------------------------------------
+23 |             valid, data : out;
+<class 'vsg.token.record_element_list.simple_name'>
+<class 'vsg.token.record_element_list.comma'>
+<class 'vsg.token.record_element_list.simple_name'>
+<class 'vsg.token.mode_view_element_definition.colon'>
+<class 'vsg.token.mode.out_keyword'>
+<class 'vsg.token.mode_view_element_definition.semicolon'>
+--------------------------------------------------------------------------------
+24 |             ack         : in;
+<class 'vsg.token.record_element_list.simple_name'>
+<class 'vsg.token.mode_view_element_definition.colon'>
+<class 'vsg.token.mode.in_keyword'>
+<class 'vsg.token.mode_view_element_definition.semicolon'>
+--------------------------------------------------------------------------------
+25 |         end view;
+<class 'vsg.token.mode_view_declaration.end_keyword'>
+<class 'vsg.token.mode_view_declaration.end_view_keyword'>
+<class 'vsg.token.mode_view_declaration.semicolon'>
+--------------------------------------------------------------------------------
+26 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+27 |     begin
+<class 'vsg.token.block_statement.begin_keyword'>
+--------------------------------------------------------------------------------
+28 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+29 |     end block;
+<class 'vsg.token.block_statement.end_keyword'>
+<class 'vsg.token.block_statement.end_block_keyword'>
+<class 'vsg.token.block_statement.semicolon'>
+--------------------------------------------------------------------------------
+30 |
+<class 'vsg.parser.blank_line'>
+--------------------------------------------------------------------------------
+31 | end architecture rtl;
+<class 'vsg.token.architecture_body.end_keyword'>
+<class 'vsg.token.architecture_body.end_architecture_keyword'>
+<class 'vsg.token.architecture_body.architecture_simple_name'>
+<class 'vsg.token.architecture_body.semicolon'>

--- a/tests/vhdlFile/mode_view_declaration/classification_test_input.vhd
+++ b/tests/vhdlFile/mode_view_declaration/classification_test_input.vhd
@@ -1,0 +1,31 @@
+
+package interfaces is
+
+    view streaming of streaming_bus is
+        valid, data : out;
+        ack         : in;
+        nested      : view inner_streaming_bus;
+    end view streaming;
+
+end package;
+
+architecture rtl of entity1 is
+
+    view streaming of streaming_bus is
+        valid, data : out;
+        ack         : in;
+    end view;
+
+  begin
+    b1 : block
+
+        view streaming of streaming_bus is
+            valid, data : out;
+            ack         : in;
+        end view;
+
+    begin
+
+    end block;
+
+end architecture rtl;

--- a/tests/vhdlFile/package_header/classification_results.txt
+++ b/tests/vhdlFile/package_header/classification_results.txt
@@ -78,8 +78,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -91,8 +91,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.out_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -104,8 +104,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.inout_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -117,8 +117,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.buffer_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -130,8 +130,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.linkage_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -146,7 +146,7 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
 20 |     signal sig1, sig2 : out     std_logic bus;
@@ -157,7 +157,7 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.out_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
 21 |     signal sig1, sig2 : inout   std_logic bus;
@@ -168,7 +168,7 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.inout_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
 22 |     signal sig1, sig2 : buffer  std_logic bus;
@@ -179,7 +179,7 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.buffer_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
 23 |     signal sig1, sig2 : linkage std_logic bus;
@@ -190,7 +190,7 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.linkage_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
 24 |
@@ -203,8 +203,8 @@
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -215,8 +215,8 @@
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -227,8 +227,8 @@
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -239,8 +239,8 @@
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -251,8 +251,8 @@
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -266,7 +266,7 @@
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -277,7 +277,7 @@
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -288,7 +288,7 @@
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -299,7 +299,7 @@
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -310,7 +310,7 @@
 <class 'vsg.token.interface_signal_declaration.identifier'>
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -600,8 +600,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -612,8 +612,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.out_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -624,8 +624,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.inout_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -636,8 +636,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.buffer_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -648,8 +648,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.linkage_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -663,7 +663,7 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
 76 |     sig1, sig2 : out     std_logic bus;
@@ -673,7 +673,7 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.out_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
 77 |     sig1, sig2 : inout   std_logic bus;
@@ -683,7 +683,7 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.inout_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
 78 |     sig1, sig2 : buffer  std_logic bus;
@@ -693,7 +693,7 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.buffer_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
 79 |     sig1, sig2 : linkage std_logic bus;
@@ -703,7 +703,7 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.linkage_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
 80 |
@@ -715,8 +715,8 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -726,8 +726,8 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -737,8 +737,8 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -748,8 +748,8 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -759,8 +759,8 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -773,7 +773,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -783,7 +783,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -793,7 +793,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -803,7 +803,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -813,7 +813,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -920,8 +920,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -956,8 +956,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -995,8 +995,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1031,8 +1031,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1069,8 +1069,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1105,8 +1105,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1143,8 +1143,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1179,8 +1179,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1250,8 +1250,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1286,8 +1286,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1328,8 +1328,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1364,8 +1364,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1406,8 +1406,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1442,8 +1442,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1484,8 +1484,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1520,8 +1520,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1564,8 +1564,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1600,8 +1600,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1641,8 +1641,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1677,8 +1677,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1718,8 +1718,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1754,8 +1754,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1795,8 +1795,8 @@
 <class 'vsg.token.interface_signal_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_signal_declaration.bus_keyword'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------
@@ -1831,8 +1831,8 @@
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.mode.in_keyword'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.bus_keyword'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.bus_keyword'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 --------------------------------------------------------------------------------

--- a/tests/vhdlFile/procedure_specification/classification_results.txt
+++ b/tests/vhdlFile/procedure_specification/classification_results.txt
@@ -163,7 +163,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 <class 'vsg.token.interface_unknown_declaration.identifier'>
@@ -208,7 +208,7 @@
 <class 'vsg.token.interface_unknown_declaration.identifier'>
 <class 'vsg.token.interface_unknown_declaration.colon'>
 <class 'vsg.token.type_mark.name'>
-<class 'vsg.token.interface_unknown_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.interface_list.semicolon'>
 <class 'vsg.token.interface_unknown_declaration.identifier'>
@@ -418,7 +418,7 @@
 <class 'vsg.token.direction.downto'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.index_constraint.close_parenthesis'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.token.aggregate.open_parenthesis'>
 <class 'vsg.token.choice.others_keyword'>
 <class 'vsg.token.element_association.assignment'>
@@ -503,7 +503,7 @@
 <class 'vsg.token.direction.downto'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.index_constraint.close_parenthesis'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.token.aggregate.open_parenthesis'>
 <class 'vsg.token.choice.others_keyword'>
 <class 'vsg.token.element_association.assignment'>
@@ -588,7 +588,7 @@
 <class 'vsg.token.direction.downto'>
 <class 'vsg.parser.todo'>
 <class 'vsg.token.index_constraint.close_parenthesis'>
-<class 'vsg.token.interface_signal_declaration.assignment'>
+<class 'vsg.token.simple_mode_indication.assignment'>
 <class 'vsg.token.aggregate.open_parenthesis'>
 <class 'vsg.token.choice.others_keyword'>
 <class 'vsg.token.element_association.assignment'>

--- a/vsg/parser.py
+++ b/vsg/parser.py
@@ -560,15 +560,6 @@ class choices(item):
         super().__init__(sString)
 
 
-class mode_indication(item):
-    """
-    unique_id = parser : mode_indication
-    """
-
-    def __init__(self, sString):
-        super().__init__(sString)
-
-
 class beginning_of_file(item):
     """
     unique_id = parser : choices

--- a/vsg/parser.py
+++ b/vsg/parser.py
@@ -560,6 +560,15 @@ class choices(item):
         super().__init__(sString)
 
 
+class mode_indication(item):
+    """
+    unique_id = parser : mode_indication
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)
+
+
 class beginning_of_file(item):
     """
     unique_id = parser : choices

--- a/vsg/rules/entity/rule_018.py
+++ b/vsg/rules/entity/rule_018.py
@@ -4,7 +4,7 @@ from vsg import token
 from vsg.rules import align_tokens_in_region_between_tokens
 
 lAlign = []
-lAlign.append(token.interface_unknown_declaration.assignment)
+lAlign.append(token.simple_mode_indication.assignment)
 
 
 class rule_018(align_tokens_in_region_between_tokens):

--- a/vsg/rules/generic/rule_006.py
+++ b/vsg/rules/generic/rule_006.py
@@ -6,10 +6,9 @@ from vsg.rules.whitespace_after_token import Rule
 
 lTokens = []
 lTokens.append(token.interface_constant_declaration.assignment)
-lTokens.append(token.interface_signal_declaration.assignment)
+lTokens.append(token.simple_mode_indication.assignment)
 lTokens.append(token.interface_variable_declaration.assignment)
 lTokens.append(token.interface_file_declaration.colon)
-lTokens.append(token.interface_unknown_declaration.assignment)
 
 oStart = token.generic_clause.open_parenthesis
 oEnd = token.generic_clause.close_parenthesis

--- a/vsg/rules/port/rule_012.py
+++ b/vsg/rules/port/rule_012.py
@@ -5,7 +5,6 @@ from vsg.rule_group import structure
 
 lTokens = []
 lTokens.append(token.interface_constant_declaration.assignment)
-lTokens.append(token.simple_mode_indication.assignment)
 lTokens.append(token.interface_variable_declaration.assignment)
 lTokens.append(token.simple_mode_indication.assignment)
 

--- a/vsg/rules/port/rule_012.py
+++ b/vsg/rules/port/rule_012.py
@@ -5,9 +5,9 @@ from vsg.rule_group import structure
 
 lTokens = []
 lTokens.append(token.interface_constant_declaration.assignment)
-lTokens.append(token.interface_signal_declaration.assignment)
+lTokens.append(token.simple_mode_indication.assignment)
 lTokens.append(token.interface_variable_declaration.assignment)
-lTokens.append(token.interface_unknown_declaration.assignment)
+lTokens.append(token.simple_mode_indication.assignment)
 
 
 class rule_012(structure.Rule):

--- a/vsg/rules/port/rule_023.py
+++ b/vsg/rules/port/rule_023.py
@@ -3,6 +3,7 @@
 from vsg import violation
 from vsg.rule_group import structure
 from vsg.token import mode, port_clause as token
+from vsg.token.mode_view_indication import view_keyword
 
 
 class rule_023(structure.Rule):
@@ -19,6 +20,7 @@ class rule_023(structure.Rule):
          WR_EN    : std_logic;
          RD_EN    : std_logic;
          OVERFLOW : std_logic;
+         V_TEST   : some_view;
          DATA     : inout std_logic
        );
 
@@ -30,13 +32,14 @@ class rule_023(structure.Rule):
          WR_EN    : in    std_logic;
          RD_EN    : in    std_logic;
          OVERFLOW : out   std_logic;
+         V_TEST   : view  some_view;
          DATA     : inout std_logic
        );
     """
 
     def __init__(self):
         super().__init__()
-        self.solution = "Add mode"
+        self.solution = "Add mode or view"
         self.fixable = False
         self.configuration_documentation_link = None
 
@@ -47,7 +50,7 @@ class rule_023(structure.Rule):
         for oToi in lToi:
             lTokens = oToi.get_tokens()
             for oToken in lTokens:
-                if isinstance(oToken, mode.mode):
+                if isinstance(oToken, mode.mode) or isinstance(oToken, view_keyword):
                     break
             else:
                 self.add_violation(violation.New(oToi.get_line_number(), oToi, self.solution))

--- a/vsg/rules/port/rule_100.py
+++ b/vsg/rules/port/rule_100.py
@@ -4,7 +4,7 @@ from vsg import token
 from vsg.rules.whitespace_before_token import Rule
 
 lTokens = []
-lTokens.append(token.interface_unknown_declaration.assignment)
+lTokens.append(token.simple_mode_indication.assignment)
 
 
 class rule_100(Rule):

--- a/vsg/rules/port/rule_101.py
+++ b/vsg/rules/port/rule_101.py
@@ -4,7 +4,7 @@ from vsg import token
 from vsg.rules.whitespace_after_token import Rule
 
 lTokens = []
-lTokens.append(token.interface_unknown_declaration.assignment)
+lTokens.append(token.simple_mode_indication.assignment)
 
 
 class rule_101(Rule):

--- a/vsg/rules/procedure/rule_411.py
+++ b/vsg/rules/procedure/rule_411.py
@@ -4,10 +4,10 @@ from vsg import token
 from vsg.rules import align_tokens_in_region_between_tokens
 
 lAlign = []
-lAlign.append(token.interface_signal_declaration.assignment)
+lAlign.append(token.simple_mode_indication.assignment)
 lAlign.append(token.interface_constant_declaration.assignment)
 lAlign.append(token.interface_variable_declaration.assignment)
-lAlign.append(token.interface_unknown_declaration.assignment)
+lAlign.append(token.simple_mode_indication.assignment)
 
 
 class rule_411(align_tokens_in_region_between_tokens):

--- a/vsg/rules/procedure/rule_411.py
+++ b/vsg/rules/procedure/rule_411.py
@@ -4,7 +4,6 @@ from vsg import token
 from vsg.rules import align_tokens_in_region_between_tokens
 
 lAlign = []
-lAlign.append(token.simple_mode_indication.assignment)
 lAlign.append(token.interface_constant_declaration.assignment)
 lAlign.append(token.interface_variable_declaration.assignment)
 lAlign.append(token.simple_mode_indication.assignment)

--- a/vsg/token/array_mode_view_indication.py
+++ b/vsg/token/array_mode_view_indication.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from vsg import parser
+from vsg.token import mode_view_indication
+
+
+class view_keyword(mode_view_indication.view_keyword):
+    """
+    unique_id = array_mode_view_indication : view_keyword
+    """
+
+    def __init__(self, sString="view"):
+        super().__init__(sString)
+
+
+class open_parenthesis(parser.open_parenthesis):
+    """
+    unique_id = array_mode_view_indication : open_parenthesis
+    """
+
+    def __init__(self, sString="("):
+        super().__init__()
+
+
+class name(parser.name):
+    """
+    unique_id = array_mode_view_indication : name
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)
+
+
+class close_parenthesis(parser.close_parenthesis):
+    """
+    unique_id = array_mode_view_indication : close_parenthesis
+    """
+
+    def __init__(self, sString=")"):
+        super().__init__()
+
+
+class of_keyword(parser.keyword):
+    """
+    unique_id = array_mode_view_indication : of_keyword
+    """
+
+    def __init__(self, sString="of"):
+        super().__init__(sString)
+
+
+class subtype_indication(parser.subtype_indication):
+    """
+    unique_id = array_mode_view_indication : subtype_indication
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)

--- a/vsg/token/element_array_mode_view_indication.py
+++ b/vsg/token/element_array_mode_view_indication.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from vsg import parser
+
+
+class view_keyword(parser.keyword):
+    """
+    unique_id = element_array_mode_view_indication : view_keyword
+    """
+
+    def __init__(self, sString="view"):
+        super().__init__(sString)
+
+
+class open_parenthesis(parser.open_parenthesis):
+    """
+    unique_id = element_array_mode_view_indication : open_parenthesis
+    """
+
+    def __init__(self, sString="("):
+        super().__init__()
+
+
+class name(parser.name):
+    """
+    unique_id = element_array_mode_view_indication : name
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)
+
+
+class close_parenthesis(parser.close_parenthesis):
+    """
+    unique_id = element_array_mode_view_indication : close_parenthesis
+    """
+
+    def __init__(self, sString=")"):
+        super().__init__()

--- a/vsg/token/element_record_mode_view_indication.py
+++ b/vsg/token/element_record_mode_view_indication.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from vsg import parser
+
+
+class view_keyword(parser.keyword):
+    """
+    unique_id = element_record_mode_view_indication : view_keyword
+    """
+
+    def __init__(self, sString="view"):
+        super().__init__(sString)
+
+
+class name(parser.name):
+    """
+    unique_id = element_record_mode_view_indication : name
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)

--- a/vsg/token/interface_signal_declaration.py
+++ b/vsg/token/interface_signal_declaration.py
@@ -27,22 +27,4 @@ class colon(parser.colon):
     """
 
     def __init__(self, sString=":"):
-        super().__init__()
-
-
-class bus_keyword(parser.keyword):
-    """
-    unique_id = interface_signal_declaration : bus_keyword
-    """
-
-    def __init__(self, sString):
-        super().__init__(sString)
-
-
-class assignment(parser.assignment):
-    """
-    unique_id = interface_signal_declaration : assignment
-    """
-
-    def __init__(self, sString):
         super().__init__(sString)

--- a/vsg/token/interface_unknown_declaration.py
+++ b/vsg/token/interface_unknown_declaration.py
@@ -19,21 +19,3 @@ class colon(parser.colon):
 
     def __init__(self, sString=":"):
         super().__init__()
-
-
-class bus_keyword(parser.keyword):
-    """
-    unique_id = interface_unknown_declaration : bus_keyword
-    """
-
-    def __init__(self, sString):
-        super().__init__(sString)
-
-
-class assignment(parser.assignment):
-    """
-    unique_id = interface_unknown_declaration : assignment
-    """
-
-    def __init__(self, sString):
-        super().__init__(sString)

--- a/vsg/token/mode_view_declaration.py
+++ b/vsg/token/mode_view_declaration.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+from vsg import parser
+
+
+class view_keyword(parser.keyword):
+    """
+    unique_id = mode_view_declaration : view_keyword
+    """
+
+    def __init__(self, sString="view"):
+        super().__init__(sString)
+
+
+class identifier(parser.identifier):
+    """
+    unique_id = mode_view_declaration : identifier
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)
+
+
+class of_keyword(parser.keyword):
+    """
+    unique_id = mode_view_declaration : of_keyword
+    """
+
+    def __init__(self, sString="of"):
+        super().__init__(sString)
+
+
+class subtype_indication(parser.subtype_indication):
+    """
+    unique_id = mode_view_declaration : subtype_indication
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)
+
+
+class is_keyword(parser.keyword):
+    """
+    unique_id = mode_view_declaration : is_keyword
+    """
+
+    def __init__(self, sString="is"):
+        super().__init__(sString)
+
+
+class end_keyword(parser.keyword):
+    """
+    unique_id = mode_view_declaration : end_keyword
+    """
+
+    def __init__(self, sString="end"):
+        super().__init__(sString)
+
+
+class end_view_keyword(parser.keyword):
+    """
+    unique_id = mode_view_declaration : end_view_keyword
+    """
+
+    def __init__(self, sString="view"):
+        super().__init__(sString)
+
+
+class end_view_label(parser.label):
+    """
+    unique_id = mode_view_declaration : end_view_label
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)
+
+
+class semicolon(parser.semicolon):
+    """
+    unique_id = mode_view_declaration : semicolon
+    """
+
+    def __init__(self, sString=";"):
+        super().__init__()

--- a/vsg/token/mode_view_element_definition.py
+++ b/vsg/token/mode_view_element_definition.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from vsg import parser
+
+
+class colon(parser.colon):
+    """
+    unique_id = mode_view_element_definition : colon
+    """
+
+    def __init__(self, sString=":"):
+        super().__init__()
+
+
+class semicolon(parser.semicolon):
+    """
+    unique_id = mode_view_element_definition : semicolon
+    """
+
+    def __init__(self, sString=";"):
+        super().__init__()

--- a/vsg/token/mode_view_indication.py
+++ b/vsg/token/mode_view_indication.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from vsg import parser
+
+
+class view_keyword(parser.keyword):
+    """
+    unique_id = mode_view_indication : view_keyword
+    """
+
+    def __init__(self, sString="view"):
+        super().__init__(sString)

--- a/vsg/token/record_element_list.py
+++ b/vsg/token/record_element_list.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from vsg import parser
+
+
+class comma(parser.comma):
+    """
+    unique_id = record_element_list : comma
+    """
+
+    def __init__(self, sString=","):
+        super().__init__()
+
+
+class simple_name(parser.simple_name):
+    """
+    unique_id = record_element_list : record_element_simple_name
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)

--- a/vsg/token/record_mode_view_indication.py
+++ b/vsg/token/record_mode_view_indication.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from vsg import parser
+from vsg.token import mode_view_indication
+
+
+class view_keyword(mode_view_indication.view_keyword):
+    """
+    unique_id = record_mode_view_indication : view_keyword
+    """
+
+    def __init__(self, sString="view"):
+        super().__init__(sString)
+
+
+class name(parser.name):
+    """
+    unique_id = record_mode_view_indication : name
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)
+
+
+class of_keyword(parser.keyword):
+    """
+    unique_id = record_mode_view_indication : of_keyword
+    """
+
+    def __init__(self, sString="of"):
+        super().__init__(sString)
+
+
+class subtype_indication(parser.subtype_indication):
+    """
+    unique_id = record_mode_view_indication : subtype_indication
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)

--- a/vsg/token/simple_mode_indication.py
+++ b/vsg/token/simple_mode_indication.py
@@ -3,15 +3,6 @@
 from vsg import parser
 
 
-class subtype_indication(parser.subtype_indication):
-    """
-    unique_id = subtype_indication : subtype_indication
-    """
-
-    def __init__(self, sString):
-        super().__init__(sString)
-
-
 class bus_keyword(parser.keyword):
     """
     unique_id = simple_mode_indication : bus_keyword
@@ -27,13 +18,4 @@ class assignment(parser.assignment):
     """
 
     def __init__(self, sString=":="):
-        super().__init__(sString)
-
-
-class expression(parser.expression):
-    """
-    unique_id = simple_mode_indication : expression
-    """
-
-    def __init__(self, sString):
         super().__init__(sString)

--- a/vsg/token/simple_mode_indication.py
+++ b/vsg/token/simple_mode_indication.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from vsg import parser
+
+
+class subtype_indication(parser.subtype_indication):
+    """
+    unique_id = subtype_indication : subtype_indication
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)
+
+
+class bus_keyword(parser.keyword):
+    """
+    unique_id = simple_mode_indication : bus_keyword
+    """
+
+    def __init__(self, sString="bus"):
+        super().__init__(sString)
+
+
+class assignment(parser.assignment):
+    """
+    unique_id = simple_mode_indication : assignment
+    """
+
+    def __init__(self, sString=":="):
+        super().__init__(sString)
+
+
+class expression(parser.expression):
+    """
+    unique_id = simple_mode_indication : expression
+    """
+
+    def __init__(self, sString):
+        super().__init__(sString)

--- a/vsg/vhdlFile/classify/array_mode_view_indication.py
+++ b/vsg/vhdlFile/classify/array_mode_view_indication.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+from vsg.token import array_mode_view_indication as token
+from vsg.vhdlFile import utils
+from vsg.vhdlFile.classify import subtype_indication
+
+
+def detect(iToken, lObjects):
+    """
+    array_mode_view_indication ::=
+        view ( mode_view_name ) of unresolved_array_subtype_indication
+    """
+    if utils.are_next_consecutive_tokens(["view", "("], iToken, lObjects):
+        return classify(iToken, lObjects)
+
+    return iToken
+
+
+def classify(iToken, lObjects):
+    iCurrent = utils.assign_next_token_required("view", token.view_keyword, iToken, lObjects)
+    iCurrent = utils.assign_next_token_required("(", token.open_parenthesis, iCurrent, lObjects)
+
+    iCurrent = utils.assign_next_token(token.name, iCurrent, lObjects)
+
+    iCurrent = utils.assign_next_token_required(")", token.close_parenthesis, iCurrent, lObjects)
+
+    if utils.is_next_token("of", iCurrent, lObjects):
+        iCurrent = utils.assign_next_token_required("of", token.of_keyword, iCurrent, lObjects)
+
+        iCurrent = subtype_indication.classify(iCurrent, lObjects)
+
+    return iCurrent

--- a/vsg/vhdlFile/classify/block_declarative_item.py
+++ b/vsg/vhdlFile/classify/block_declarative_item.py
@@ -8,6 +8,7 @@ from vsg.vhdlFile.classify import (
     configuration_specification,
     constant_declaration,
     file_declaration,
+    mode_view_declaration,
     package_body,
     package_declaration,
     package_instantiation_declaration,
@@ -36,6 +37,7 @@ def detect(iToken, lObjects):
       | package_instantiation_declaration
       | type_declaration
       | subtype_declaration
+      | mode_view_declaration
       | constant_declaration
       | signal_declaration
       | *shared*_variable_declaration
@@ -80,6 +82,10 @@ def detect(iToken, lObjects):
         return iReturn
 
     iReturn = subtype_declaration.detect(iToken, lObjects)
+    if iReturn != iToken:
+        return iReturn
+
+    iReturn = mode_view_declaration.detect(iToken, lObjects)
     if iReturn != iToken:
         return iReturn
 

--- a/vsg/vhdlFile/classify/element_array_mode_view_indication.py
+++ b/vsg/vhdlFile/classify/element_array_mode_view_indication.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from vsg.token import element_array_mode_view_indication as token
+from vsg.vhdlFile import utils
+
+
+def detect(iToken, lObjects):
+    """
+    element_array_mode_view_indication ::=
+        view ( mode_view_name )
+    """
+    if utils.are_next_consecutive_tokens(["view", "(", None, ")"], iToken, lObjects):
+        return classify(iToken, lObjects)
+
+    return iToken
+
+
+def classify(iToken, lObjects):
+    iCurrent = utils.assign_next_token_required("view", token.view_keyword, iToken, lObjects)
+    iCurrent = utils.assign_next_token_required("(", token.open_parenthesis, iCurrent, lObjects)
+
+    iCurrent = utils.assign_next_token(token.name, iCurrent, lObjects)
+
+    iCurrent = utils.assign_next_token_required(")", token.close_parenthesis, iCurrent, lObjects)
+
+    return iCurrent

--- a/vsg/vhdlFile/classify/element_mode_indication.py
+++ b/vsg/vhdlFile/classify/element_mode_indication.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from vsg.vhdlFile.classify import element_mode_view_indication, mode
+
+
+def classify(iToken, lObjects):
+    """
+    element_mode_indication ::=
+      mode
+      | element_mode_view_indication
+    """
+    iReturn = mode.detect(iToken, lObjects)
+    if iReturn != iToken:
+        return iReturn
+
+    iReturn = element_mode_view_indication.detect(iToken, lObjects)
+    if iReturn != iToken:
+        return iReturn
+
+    return iToken

--- a/vsg/vhdlFile/classify/element_mode_view_indication.py
+++ b/vsg/vhdlFile/classify/element_mode_view_indication.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+from vsg.vhdlFile import utils
+from vsg.vhdlFile.classify import (
+    element_array_mode_view_indication,
+    element_record_mode_view_indication,
+)
+
+
+def detect(iToken, lObjects):
+    """
+    element_mode_view_indication ::=
+        element_record_mode_view_indication
+      | element_array_mode_view_indication
+    """
+    if utils.is_next_token("view", iToken, lObjects):
+        return classify(iToken, lObjects)
+
+    return iToken
+
+
+def classify(iToken, lObjects):
+    # since element_array_mode_view_indication is more specific, we check it first
+    iReturn = element_array_mode_view_indication.detect(iToken, lObjects)
+    if iReturn != iToken:
+        return iReturn
+
+    iReturn = element_record_mode_view_indication.detect(iToken, lObjects)
+    if iReturn != iToken:
+        return iReturn
+
+    return iToken

--- a/vsg/vhdlFile/classify/element_record_mode_view_indication.py
+++ b/vsg/vhdlFile/classify/element_record_mode_view_indication.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from vsg.token import element_record_mode_view_indication as token
+from vsg.vhdlFile import utils
+
+
+def detect(iToken, lObjects):
+    """
+    element_record_mode_view_indication ::=
+        view mode_view_name
+
+    """
+    if utils.is_next_token("view", iToken, lObjects):
+        return classify(iToken, lObjects)
+
+    return iToken
+
+
+def classify(iToken, lObjects):
+    iCurrent = utils.assign_next_token_required("view", token.view_keyword, iToken, lObjects)
+    iCurrent = utils.assign_next_token(token.name, iCurrent, lObjects)
+
+    return iCurrent

--- a/vsg/vhdlFile/classify/entity_declarative_item.py
+++ b/vsg/vhdlFile/classify/entity_declarative_item.py
@@ -7,6 +7,7 @@ from vsg.vhdlFile.classify import (
     component_declaration,
     constant_declaration,
     file_declaration,
+    mode_view_declaration,
     package_body,
     package_declaration,
     package_instantiation_declaration,
@@ -35,6 +36,7 @@ def detect(iToken, lObjects):
       | package_instantiation_declaration
       | type_declaration
       | subtype_declaration
+      | mode_view_declaration
       | constant_declaration
       | signal_declaration
       | *shared*_variable_declaration
@@ -77,6 +79,10 @@ def detect(iToken, lObjects):
         return iCurrent
 
     iCurrent = subtype_declaration.detect(iToken, lObjects)
+    if iCurrent != iToken:
+        return iCurrent
+
+    iCurrent = mode_view_declaration.detect(iToken, lObjects)
     if iCurrent != iToken:
         return iCurrent
 

--- a/vsg/vhdlFile/classify/interface_signal_declaration.py
+++ b/vsg/vhdlFile/classify/interface_signal_declaration.py
@@ -3,13 +3,13 @@
 
 from vsg.token import interface_signal_declaration as token
 from vsg.vhdlFile import utils
-from vsg.vhdlFile.classify import expression, identifier_list, mode, subtype_indication
+from vsg.vhdlFile.classify import identifier_list, mode_indication
 
 
 def detect(iToken, lObjects):
     """
     interface_signal_declaration ::=
-        [ signal ] identifier_list : [ mode ] subtype_indication [ bus ] [ := *static*_expression ]
+          signal identifier_list : mode_indication
     """
 
     if utils.is_next_token("signal", iToken, lObjects):
@@ -24,15 +24,6 @@ def classify(iToken, lObjects):
 
     iCurrent = utils.assign_next_token_required(":", token.colon, iCurrent, lObjects)
 
-    iCurrent = mode.classify(iCurrent, lObjects)
-
-    iCurrent = subtype_indication.classify(iCurrent, lObjects)
-
-    iCurrent = utils.assign_next_token_if("bus", token.bus_keyword, iCurrent, lObjects)
-
-    if utils.is_next_token(":=", iCurrent, lObjects):
-        iCurrent = utils.assign_next_token_required(":=", token.assignment, iCurrent, lObjects)
-
-        iCurrent = expression.classify_until([";"], iCurrent, lObjects)
+    iCurrent = mode_indication.classify(iCurrent, lObjects)
 
     return iCurrent

--- a/vsg/vhdlFile/classify/interface_unknown_declaration.py
+++ b/vsg/vhdlFile/classify/interface_unknown_declaration.py
@@ -2,17 +2,17 @@
 
 from vsg.token import interface_unknown_declaration as token
 from vsg.vhdlFile import utils
-from vsg.vhdlFile.classify import expression, identifier_list, mode, subtype_indication
+from vsg.vhdlFile.classify import identifier_list, mode_indication
 
 
 def detect(iToken, lObjects):
     """
-    This is a classification if the signal, constant, or variable keywords can not be found.
+    This is a classification if the signal, constant, or variable keywords are not specified.
     This is not in the VHDL LRM.
     It is based off the interface_signal_declaration as it has the most keywords.
 
     interface_unknown_declaration ::=
-        identifier_list : [ mode ] subtype_indication [ bus ] [ := *static*_expression ]
+        identifier_list : mode_indication
     """
 
     if utils.is_next_token_one_of(["type", "file", "function", "procedure", "impure", "pure", "package"], iToken, lObjects):
@@ -26,15 +26,6 @@ def classify(iToken, lObjects):
 
     iCurrent = utils.assign_next_token_required(":", token.colon, iCurrent, lObjects)
 
-    iCurrent = mode.classify(iCurrent, lObjects)
-
-    iCurrent = subtype_indication.classify(iCurrent, lObjects)
-
-    iCurrent = utils.assign_next_token_if("bus", token.bus_keyword, iCurrent, lObjects)
-
-    if utils.is_next_token(":=", iCurrent, lObjects):
-        iCurrent = utils.assign_next_token_required(":=", token.assignment, iCurrent, lObjects)
-
-        iCurrent = expression.classify_until([";"], iCurrent, lObjects)
+    iCurrent = mode_indication.classify(iCurrent, lObjects)
 
     return iCurrent

--- a/vsg/vhdlFile/classify/mode.py
+++ b/vsg/vhdlFile/classify/mode.py
@@ -4,12 +4,18 @@ from vsg.token import mode as token
 from vsg.vhdlFile import utils
 
 
-def classify(iToken, lObjects):
+def detect(iToken, lObjects):
     """
     mode ::=
         in | out | inout | buffer | linkage
     """
+    if utils.is_next_token_in_list(["in", "out", "inout", "buffer", "linkage"], iToken, lObjects):
+        return classify(iToken, lObjects)
 
+    return iToken
+
+
+def classify(iToken, lObjects):
     iCurrent = utils.assign_next_token_if("in", token.in_keyword, iToken, lObjects)
     iCurrent = utils.assign_next_token_if("out", token.out_keyword, iCurrent, lObjects)
     iCurrent = utils.assign_next_token_if("inout", token.inout_keyword, iCurrent, lObjects)

--- a/vsg/vhdlFile/classify/mode_indication.py
+++ b/vsg/vhdlFile/classify/mode_indication.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+
+from vsg.vhdlFile.classify import mode_view_indication, simple_mode_indication
+
+
+def classify(iToken, lObjects):
+    """
+    mode_indication ::=
+        simple_mode_indication
+        | mode_view_indication
+
+    """
+
+    # We need to check mode_view_indication first since it always starts with "view"
+    iReturn = mode_view_indication.detect(iToken, lObjects)
+    if iReturn != iToken:
+        return iReturn
+
+    return simple_mode_indication.classify(iToken, lObjects)

--- a/vsg/vhdlFile/classify/mode_indication.py
+++ b/vsg/vhdlFile/classify/mode_indication.py
@@ -17,4 +17,4 @@ def classify(iToken, lObjects):
     if iReturn != iToken:
         return iReturn
 
-    return simple_mode_indication.classify(iToken, lObjects)
+    return simple_mode_indication.detect(iToken, lObjects)

--- a/vsg/vhdlFile/classify/mode_view_declaration.py
+++ b/vsg/vhdlFile/classify/mode_view_declaration.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from vsg.token import mode_view_declaration as token
+from vsg.vhdlFile import utils
+from vsg.vhdlFile.classify import mode_view_element_definition, subtype_indication
+
+
+def detect(iToken, lObjects):
+    """
+    mode_view_declaration ::=
+      view identifier of unresolved_record_subtype_indication is
+        { mode_view_element_definition }
+      end view [ mode_view_simple_name ] ;
+    """
+    if utils.are_next_consecutive_tokens(["view", None, "of"], iToken, lObjects):
+        return classify(iToken, lObjects)
+
+    return iToken
+
+
+def classify(iToken, lObjects):
+    iCurrent = utils.assign_next_token_required("view", token.view_keyword, iToken, lObjects)
+    iCurrent = utils.assign_next_token(token.identifier, iCurrent, lObjects)
+    iCurrent = utils.assign_next_token_required("of", token.of_keyword, iCurrent, lObjects)
+    iCurrent = subtype_indication.classify(iCurrent, lObjects)
+    iCurrent = utils.assign_next_token_required("is", token.is_keyword, iCurrent, lObjects)
+
+    iCurrent = utils.classify_subelement_until("end", mode_view_element_definition, iCurrent, lObjects)
+
+    iCurrent = utils.assign_next_token_required("end", token.end_keyword, iToken, lObjects)
+    iCurrent = utils.assign_next_token_required("view", token.end_view_keyword, iCurrent, lObjects)
+    iCurrent = utils.assign_next_token_if_not(";", token.end_view_label, iCurrent, lObjects)
+    iCurrent = utils.assign_next_token_required(";", token.semicolon, iCurrent, lObjects)
+    return iCurrent

--- a/vsg/vhdlFile/classify/mode_view_element_definition.py
+++ b/vsg/vhdlFile/classify/mode_view_element_definition.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from vsg.token import mode_view_element_definition as token
+from vsg.vhdlFile import utils
+from vsg.vhdlFile.classify import element_mode_indication, record_element_list
+
+
+def classify(iToken, lObjects):
+    """
+    mode_view_element_definition ::=
+      record_element_list : element_mode_indication ;
+    """
+    iCurrent = record_element_list.classify_until([":"], iToken, lObjects)
+    iCurrent = utils.assign_next_token_required(":", token.colon, iCurrent, lObjects)
+    iCurrent = element_mode_indication.classify(iCurrent, lObjects)
+    iCurrent = utils.assign_next_token_required(";", token.semicolon, iCurrent, lObjects)
+    return iCurrent

--- a/vsg/vhdlFile/classify/mode_view_indication.py
+++ b/vsg/vhdlFile/classify/mode_view_indication.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+from vsg.vhdlFile.classify import (
+    array_mode_view_indication,
+    record_mode_view_indication,
+)
+
+
+def detect(iToken, lObjects):
+    """
+    mode_view_indication ::=
+        record_mode_view_indication
+      | array_mode_view_indication
+    """
+
+    # We need to check array_mode_view_indication first since it has a more specific syntax
+    iReturn = array_mode_view_indication.detect(iToken, lObjects)
+    if iReturn != iToken:
+        return iReturn
+
+    iReturn = record_mode_view_indication.detect(iToken, lObjects)
+    if iReturn != iToken:
+        return iReturn
+
+    return iToken

--- a/vsg/vhdlFile/classify/package_declarative_item.py
+++ b/vsg/vhdlFile/classify/package_declarative_item.py
@@ -7,6 +7,7 @@ from vsg.vhdlFile.classify import (
     component_declaration,
     constant_declaration,
     file_declaration,
+    mode_view_declaration,
     package_declaration,
     package_instantiation_declaration,
     psl_property_declaration,
@@ -30,6 +31,7 @@ def detect(iToken, lObjects):
       | package_instantiation_declaration
       | type_declaration
       | subtype_declaration
+      | mode_view_declaration
       | constant_declaration
       | signal_declaration
       | variable_declaration
@@ -67,6 +69,10 @@ def detect(iToken, lObjects):
         return iReturn
 
     iReturn = subtype_declaration.detect(iToken, lObjects)
+    if iReturn != iToken:
+        return iReturn
+
+    iReturn = mode_view_declaration.detect(iToken, lObjects)
     if iReturn != iToken:
         return iReturn
 

--- a/vsg/vhdlFile/classify/record_element_list.py
+++ b/vsg/vhdlFile/classify/record_element_list.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from vsg.token import record_element_list as token
+from vsg.vhdlFile import utils
+
+
+def classify_until(lUntils, iToken, lObjects, oToken=token.simple_name):
+    """
+    record_element_list ::=
+      record_element_simple_name { , record_element_simple_name }
+
+    """
+    iEnd = len(lObjects) - 1
+    iCurrent = iToken
+
+    while not utils.is_next_token_one_of(lUntils, iCurrent, lObjects):
+        if iCurrent == iEnd:
+            return iCurrent
+        iCurrent = utils.assign_next_token_if_not(",", oToken, iCurrent, lObjects)
+        iCurrent = utils.assign_next_token_if(",", token.comma, iCurrent, lObjects)
+
+    return iCurrent

--- a/vsg/vhdlFile/classify/record_mode_view_indication.py
+++ b/vsg/vhdlFile/classify/record_mode_view_indication.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+from vsg.token import record_mode_view_indication as token
+from vsg.vhdlFile import utils
+from vsg.vhdlFile.classify import subtype_indication
+
+
+def detect(iToken, lObjects):
+    """
+    record_mode_view_indication ::=
+        view mode_view_name [ of unresolved_record_subtype_indication ]
+    """
+    if utils.is_next_token("view", iToken, lObjects):
+        return classify(iToken, lObjects)
+
+    return iToken
+
+
+def classify(iToken, lObjects):
+    iCurrent = utils.assign_next_token_required("view", token.view_keyword, iToken, lObjects)
+
+    iCurrent = utils.assign_next_token(token.name, iCurrent, lObjects)
+
+    if utils.is_next_token("of", iCurrent, lObjects):
+        iCurrent = utils.assign_next_token_required("of", token.of_keyword, iCurrent, lObjects)
+
+        iCurrent = subtype_indication.classify(iCurrent, lObjects)
+
+    return iCurrent

--- a/vsg/vhdlFile/classify/simple_mode_indication.py
+++ b/vsg/vhdlFile/classify/simple_mode_indication.py
@@ -5,10 +5,10 @@ from vsg.vhdlFile import utils
 from vsg.vhdlFile.classify import expression, mode, subtype_indication
 
 
-def classify(iToken, lObjects):
+def detect(iToken, lObjects):
     """
     simple_mode_indication ::=
-        [ mode ] subtype_indication [ bus ] [ := static_expression ]
+        [ mode ] subtype_indication [ bus ] [ := static_conditional_expression ]
     """
 
     iCurrent = mode.classify(iToken, lObjects)

--- a/vsg/vhdlFile/classify/simple_mode_indication.py
+++ b/vsg/vhdlFile/classify/simple_mode_indication.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from vsg.token import simple_mode_indication as token
+from vsg.vhdlFile import utils
+from vsg.vhdlFile.classify import expression, mode, subtype_indication
+
+
+def classify(iToken, lObjects):
+    """
+    simple_mode_indication ::=
+        [ mode ] subtype_indication [ bus ] [ := static_expression ]
+    """
+
+    iCurrent = mode.classify(iToken, lObjects)
+    iCurrent = subtype_indication.classify(iCurrent, lObjects)
+    iCurrent = utils.assign_next_token_if("bus", token.bus_keyword, iCurrent, lObjects)
+
+    if utils.is_next_token(":=", iCurrent, lObjects):
+        iCurrent = utils.assign_next_token_required(":=", token.assignment, iCurrent, lObjects)
+        iCurrent = expression.classify_until([";"], iCurrent, lObjects)
+
+    return iCurrent


### PR DESCRIPTION
Resolves #1475 

- Adds the relevant changes to VHDL's grammar
- Updates relevant tests
- Adds test for view declarations (mode_view_declaration) 

There are probably some additional rules that need to be updated, but my current repo didn't report any issues with these changes. 

I realize that this is a fairly complicated change and am open to feedback on how to do it better.