### PR TITLE
Issue#1510: New rules for multiline variable initialisations.

### DIFF
--- a/docs/configuring_array_multiline_structure_rules.rst
+++ b/docs/configuring_array_multiline_structure_rules.rst
@@ -566,4 +566,5 @@ Rules Enforcing Array Multiline Structure Rules
 * `concurrent_012 <concurrent_rules.html#concurrent-012>`_
 * `constant_016 <constant_rules.html#constant-016>`_
 * `sequential_009 <sequential_rules.html#sequential-009>`_
+* `variable_403 <variable_rules.html#variable-403>`_
 * `variable_assignment_008 <variable_assignment_rules.html#variable-assignment-008>`_

--- a/docs/configuring_multiline_indent_rules.rst
+++ b/docs/configuring_multiline_indent_rules.rst
@@ -128,6 +128,6 @@ Rules Enforcing Multiline Indent Rules
 * `sequential_402 <sequential_rules.html#sequential-402>`_
 * `signal_400 <signal_rules.html#signal-400>`_
 * `variable_400 <signal_rules.html#variable-400>`_
-* `variable_402 <signal_rules.html#variable-402>`_
+* `variable_402 <variable_rules.html#variable-402>`_
 * `variable_assignment_004 <variable_assignment_rules.html#variable-assignment-004>`_
 * `variable_assignment_401 <variable_assignment_rules.html#variable-assignment-401>`_

--- a/docs/configuring_multiline_indent_rules.rst
+++ b/docs/configuring_multiline_indent_rules.rst
@@ -128,5 +128,6 @@ Rules Enforcing Multiline Indent Rules
 * `sequential_402 <sequential_rules.html#sequential-402>`_
 * `signal_400 <signal_rules.html#signal-400>`_
 * `variable_400 <signal_rules.html#variable-400>`_
+* `variable_402 <signal_rules.html#variable-402>`_
 * `variable_assignment_004 <variable_assignment_rules.html#variable-assignment-004>`_
 * `variable_assignment_401 <variable_assignment_rules.html#variable-assignment-401>`_

--- a/docs/rule_groups/alignment_rule_group.rst
+++ b/docs/rule_groups/alignment_rule_group.rst
@@ -80,6 +80,7 @@ Rules Enforcing Alignment Rule Group
 * `type_400 <../type_rules.html#type-400>`_
 * `variable_400 <../variable_rules.html#variable-400>`_
 * `variable_401 <../variable_rules.html#variable-401>`_
+* `variable_402 <../variable_rules.html#variable-402>`_
 * `variable_assignment_004 <../variable_assignment_rules.html#variable-assignment-004>`_
 * `variable_assignment_400 <../variable_assignment_rules.html#variable-assignment-400>`_
 * `variable_assignment_401 <../variable_assignment_rules.html#variable-assignment-401>`_

--- a/docs/rule_groups/structure_rule_group.rst
+++ b/docs/rule_groups/structure_rule_group.rst
@@ -189,6 +189,7 @@ Rules Enforcing Structure Rule Group
 * `variable_015 <../variable_rules.html#variable-015>`_
 * `variable_017 <../variable_rules.html#variable-017>`_
 * `variable_018 <../variable_rules.html#variable-018>`_
+* `variable_403 <../variable_rules.html#variable-403>`_
 * `variable_assignment_006 <../variable_assignment_rules.html#variable-assignment-006>`_
 * `variable_assignment_007 <../variable_assignment_rules.html#variable-assignment-007>`_
 * `variable_assignment_008 <../variable_assignment_rules.html#variable-assignment-008>`_

--- a/docs/variable_rules.rst
+++ b/docs/variable_rules.rst
@@ -472,6 +472,67 @@ This rule checks the alignment of assignment keywords in variable declarations.
      others            => false
    );
 
+variable_402
+############
+
+|phase_5| |error| |alignment|
+
+This rule checks the alignment of multiline variable initializations that contain arrays.
+
+|configuring_multiline_indent_rules_link|
+
+.. NOTE:: The structure of multiline array variables is handled by the rule `variable_403 <variable_rules.html#variable-403>`_.
+
+**Violation**
+
+.. code-block:: vhdl
+
+   variable rom : romq_type :=
+   (
+            0,
+        65535,
+        32768
+     );
+
+**Fix**
+
+.. code-block:: vhdl
+
+   variable rom : romq_type :=
+   (
+     0,
+     65535,
+     32768
+   );
+
+variable_403
+############
+
+|phase_5| |error| |structure|
+
+This rule checks the structure of multiline variable initializations that contain arrays.
+
+|configuring_array_multiline_structure_rules_link|
+
+.. NOTE:: The indenting of multiline array variables is handled by the rule `variable_402 <variable_rules.html#variable-402>`_.
+
+**Violation**
+
+.. code-block:: vhdl
+
+   variable rom : romq_type := (0, 65535, 32768);
+
+**Fix**
+
+.. code-block:: vhdl
+
+   variable rom : romq_type :=
+   (
+     0,
+     65535,
+     32768
+   );
+
 variable_500
 ############
 

--- a/tests/variable/rule_400_test_input.fixed__align_left_no__align_paren_no.vhd
+++ b/tests/variable/rule_400_test_input.fixed__align_left_no__align_paren_no.vhd
@@ -19,10 +19,10 @@ architecture rtl of fifo is
                                     );
 
   variable v : MY_TYPE := (
-                           a => '0',
-                           ddddd => (others => '0'),
-                           ffff => (others => '0')
-                          );
+                    a => '0',
+                                ddddd => (others => '0'),
+        ffff => (others => '0')
+                );
 
   variable AxiMs : axi_ms_t (ar_id(IdRange_c), aw_id(IdRange_c),
                              ar_addr(AddrRange_c), aw_addr(AddrRange_c),

--- a/tests/variable/rule_400_test_input.fixed__align_left_no__align_paren_yes.vhd
+++ b/tests/variable/rule_400_test_input.fixed__align_left_no__align_paren_yes.vhd
@@ -19,10 +19,10 @@ architecture rtl of fifo is
                                     );
 
   variable v : MY_TYPE := (
-                           a => '0',
-                           ddddd => (others => '0'),
-                           ffff => (others => '0')
-                          );
+                    a => '0',
+                                ddddd => (others => '0'),
+        ffff => (others => '0')
+                );
 
   variable AxiMs : axi_ms_t (ar_id(IdRange_c), aw_id(IdRange_c),
                              ar_addr(AddrRange_c), aw_addr(AddrRange_c),

--- a/tests/variable/rule_400_test_input.fixed__align_left_yes__align_paren_no.vhd
+++ b/tests/variable/rule_400_test_input.fixed__align_left_yes__align_paren_no.vhd
@@ -19,10 +19,10 @@ architecture rtl of fifo is
   );
 
   variable v : MY_TYPE := (
-    a => '0',
-    ddddd => (others => '0'),
-    ffff => (others => '0')
-  );
+                    a => '0',
+                                ddddd => (others => '0'),
+        ffff => (others => '0')
+                );
 
   variable AxiMs : axi_ms_t (ar_id(IdRange_c), aw_id(IdRange_c),
     ar_addr(AddrRange_c), aw_addr(AddrRange_c),

--- a/tests/variable/rule_400_test_input.fixed__align_left_yes__align_paren_yes.vhd
+++ b/tests/variable/rule_400_test_input.fixed__align_left_yes__align_paren_yes.vhd
@@ -19,10 +19,10 @@ architecture rtl of fifo is
   );
 
   variable v : MY_TYPE := (
-    a => '0',
-    ddddd => (others => '0'),
-    ffff => (others => '0')
-  );
+                    a => '0',
+                                ddddd => (others => '0'),
+        ffff => (others => '0')
+                );
 
   variable AxiMs : axi_ms_t (ar_id(IdRange_c), aw_id(IdRange_c),
     ar_addr(AddrRange_c), aw_addr(AddrRange_c),

--- a/tests/variable/rule_402_test_input.fixed.vhd
+++ b/tests/variable/rule_402_test_input.fixed.vhd
@@ -1,0 +1,30 @@
+
+architecture rtl of fifo is
+
+begin
+
+  my_proc : process
+
+    variable wr_data : my_type :=
+    (
+      (name => "Hold in reset",
+        clk_in => "01",
+        rst_in => "11",
+        cnt_en_in => "00",
+        cnt_out => "00"),
+      (name => "Not enabled",
+        clk_in => "01",
+        rst_in => "00",
+        cnt_en_in => "00",
+        cnt_out => "00")
+    );
+
+    variable d : my_type :=
+            (d2 xor to_stdulogic(gen2)) &
+            (d1 xor to_stdulogic(gen1));
+
+  begin
+
+  end process;
+
+end architecture rtl;

--- a/tests/variable/rule_402_test_input.vhd
+++ b/tests/variable/rule_402_test_input.vhd
@@ -1,0 +1,30 @@
+
+architecture rtl of fifo is
+
+begin
+
+  my_proc : process
+
+    variable wr_data : my_type :=
+                (
+            (name => "Hold in reset",
+      clk_in => "01",
+                rst_in => "11",
+            cnt_en_in => "00",
+                cnt_out => "00"),
+                        (name => "Not enabled",
+      clk_in => "01",
+      rst_in => "00",
+              cnt_en_in => "00",
+            cnt_out => "00")
+          );
+
+    variable d : my_type :=
+            (d2 xor to_stdulogic(gen2)) &
+            (d1 xor to_stdulogic(gen1));
+
+  begin
+
+  end process;
+
+end architecture rtl;

--- a/tests/variable/rule_403_test_input.fixed.vhd
+++ b/tests/variable/rule_403_test_input.fixed.vhd
@@ -1,0 +1,54 @@
+
+architecture RTL of FIFO is
+
+begin
+
+  my_proc : process
+
+    -- These are passing
+    variable ret : my_type :=
+ (
+      data  => (others => '-'),
+      valid => '0',
+      sop   => '0',
+      eop   => '0',
+      empty => (others => '0'),
+      error => (others => '0')
+    );
+
+    -- These are failing
+
+    variable ret : my_type :=
+ (
+ data  => (others => '-'),
+ valid => '0',
+ sop   => '0',
+ eop   => '0',
+ empty => (others => '0'),
+ error => (others => '0')
+ );
+
+
+  -- This is not an array and should not be "fixed"
+
+  variable d : my_type :=
+       (d2 xor to_stdulogic(gen2)) &
+       (d1 xor to_stdulogic(gen1));
+
+  variable new_phase : my_type := (not sig1) or
+               sig2 or
+               sig3;
+
+  -- Test functions/constant in array
+
+  variable data_concurrent : my_type :=
+  (
+    c_enum_list(ENUM_LITERAL_1) => 1,
+    others       => 'X'
+  );
+
+  begin
+
+  end process;
+
+end architecture RTL;

--- a/tests/variable/rule_403_test_input.vhd
+++ b/tests/variable/rule_403_test_input.vhd
@@ -1,0 +1,45 @@
+
+architecture RTL of FIFO is
+
+begin
+
+  my_proc : process
+
+    -- These are passing
+    variable ret : my_type := (
+      data  => (others => '-'),
+      valid => '0',
+      sop   => '0',
+      eop   => '0',
+      empty => (others => '0'),
+      error => (others => '0')
+    );
+
+    -- These are failing
+
+    variable ret : my_type := (data  => (others => '-'), valid => '0', sop   => '0', eop   => '0', empty => (others => '0'), error => (others => '0'));
+
+
+  -- This is not an array and should not be "fixed"
+
+  variable d : my_type :=
+       (d2 xor to_stdulogic(gen2)) &
+       (d1 xor to_stdulogic(gen1));
+
+  variable new_phase : my_type := (not sig1) or
+               sig2 or
+               sig3;
+
+  -- Test functions/constant in array
+
+  variable data_concurrent : my_type :=
+  (
+    c_enum_list(ENUM_LITERAL_1) => 1,
+    others       => 'X'
+  );
+
+  begin
+
+  end process;
+
+end architecture RTL;

--- a/tests/variable/test_rule_400.py
+++ b/tests/variable/test_rule_400.py
@@ -48,7 +48,7 @@ class test_rule(unittest.TestCase):
 
         lExpected = []
         lExpected.extend(range(5, 20))
-        lExpected.extend(range(22, 26))
+        # lExpected.extend(range(22, 26))
         lExpected.extend(range(28, 32))
         lExpected.extend(range(34, 36))
 
@@ -94,7 +94,7 @@ class test_rule(unittest.TestCase):
 
         lExpected = []
         lExpected.extend(range(4, 20))
-        lExpected.extend(range(22, 26))
+        # lExpected.extend(range(22, 26))
         lExpected.extend(range(28, 32))
         lExpected.extend(range(34, 36))
 
@@ -140,7 +140,7 @@ class test_rule(unittest.TestCase):
 
         lExpected = []
         lExpected.extend(range(4, 20))
-        lExpected.extend(range(22, 26))
+        # lExpected.extend(range(22, 26))
         lExpected.extend(range(28, 32))
         lExpected.extend(range(34, 36))
 
@@ -186,7 +186,7 @@ class test_rule(unittest.TestCase):
 
         lExpected = []
         lExpected.extend(range(5, 20))
-        lExpected.extend(range(22, 26))
+        # lExpected.extend(range(22, 26))
         lExpected.extend(range(28, 32))
         lExpected.extend(range(34, 36))
 

--- a/tests/variable/test_rule_400.py
+++ b/tests/variable/test_rule_400.py
@@ -93,7 +93,6 @@ class test_rule(unittest.TestCase):
 
         lExpected = []
         lExpected.extend(range(4, 20))
-        # lExpected.extend(range(22, 26))
         lExpected.extend(range(28, 32))
         lExpected.extend(range(34, 36))
 

--- a/tests/variable/test_rule_400.py
+++ b/tests/variable/test_rule_400.py
@@ -48,7 +48,6 @@ class test_rule(unittest.TestCase):
 
         lExpected = []
         lExpected.extend(range(5, 20))
-        # lExpected.extend(range(22, 26))
         lExpected.extend(range(28, 32))
         lExpected.extend(range(34, 36))
 
@@ -140,7 +139,6 @@ class test_rule(unittest.TestCase):
 
         lExpected = []
         lExpected.extend(range(4, 20))
-        # lExpected.extend(range(22, 26))
         lExpected.extend(range(28, 32))
         lExpected.extend(range(34, 36))
 
@@ -186,7 +184,6 @@ class test_rule(unittest.TestCase):
 
         lExpected = []
         lExpected.extend(range(5, 20))
-        # lExpected.extend(range(22, 26))
         lExpected.extend(range(28, 32))
         lExpected.extend(range(34, 36))
 

--- a/tests/variable/test_rule_402.py
+++ b/tests/variable/test_rule_402.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from tests import utils
+from vsg import vhdlFile
+from vsg.rules import variable
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_402_test_input.vhd"))
+
+lExpected = []
+lExpected.append("")
+utils.read_file(os.path.join(sTestDir, "rule_402_test_input.fixed.vhd"), lExpected)
+
+
+class test_rule(unittest.TestCase):
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_402(self):
+        oRule = variable.rule_402()
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "variable")
+        self.assertEqual(oRule.identifier, "402")
+        self.assertEqual(oRule.groups, ["alignment"])
+
+        lExpected = [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_402(self):
+        oRule = variable.rule_402()
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/tests/variable/test_rule_403.py
+++ b/tests/variable/test_rule_403.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from tests import utils
+from vsg import vhdlFile
+from vsg.rules import variable
+
+sTestDir = os.path.dirname(__file__)
+
+lFile, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_403_test_input.vhd"))
+
+lExpected = []
+lExpected.append("")
+utils.read_file(os.path.join(sTestDir, "rule_403_test_input.fixed.vhd"), lExpected)
+
+
+class test_rule(unittest.TestCase):
+    def setUp(self):
+        self.oFile = vhdlFile.vhdlFile(lFile)
+        self.assertIsNone(eError)
+
+    def test_rule_403(self):
+        oRule = variable.rule_403()
+        oRule.ignore_single_line = "no"
+        self.assertTrue(oRule)
+        self.assertEqual(oRule.name, "variable")
+        self.assertEqual(oRule.identifier, "403")
+        self.assertEqual(oRule.groups, ["structure"])
+
+        lExpected = [9, 20, 20, 20, 20, 20, 20, 20, 20]
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_fix_rule_403(self):
+        oRule = variable.rule_403()
+        oRule.ignore_single_line = "no"
+
+        oRule.fix(self.oFile)
+
+        lActual = self.oFile.get_lines()
+
+        self.assertEqual(lExpected, lActual)
+
+        oRule.analyze(self.oFile)
+        self.assertEqual(oRule.violations, [])

--- a/vsg/rules/variable/__init__.py
+++ b/vsg/rules/variable/__init__.py
@@ -19,5 +19,7 @@ from .rule_102 import rule_102
 from .rule_103 import rule_103
 from .rule_400 import rule_400
 from .rule_401 import rule_401
+from .rule_402 import rule_402
+from .rule_403 import rule_403
 from .rule_500 import rule_500
 from .rule_600 import rule_600

--- a/vsg/rules/variable/rule_400.py
+++ b/vsg/rules/variable/rule_400.py
@@ -38,4 +38,3 @@ class rule_400(Rule):
         self.subphase = 3
         self.bIgnoreStartParen = True
         self.bConstraint = True
-        self.skip_array = False

--- a/vsg/rules/variable/rule_402.py
+++ b/vsg/rules/variable/rule_402.py
@@ -10,7 +10,7 @@ lTokenPairs.append([token.assignment_operator, token.semicolon])
 
 class rule_402(Rule):
     """
-    This rule checks the alignment of multiline variables that contain arrays.
+    This rule checks the alignment of multiline variable initializations that contain arrays.
 
     |configuring_multiline_indent_rules_link|
 

--- a/vsg/rules/variable/rule_402.py
+++ b/vsg/rules/variable/rule_402.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+
+from vsg.token import variable_declaration as token
+from vsg.rules import multiline_array_alignment as Rule
+
+lTokenPairs = []
+lTokenPairs.append([token.assignment_operator, token.semicolon])
+
+
+class rule_402(Rule):
+    """
+    This rule checks the alignment of multiline variables that contain arrays.
+
+    |configuring_multiline_indent_rules_link|
+
+    .. NOTE:: The structure of multiline array variables is handled by the rule `variable_403 <variable_rules.html#variable-403>`_.
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+       variable rom : romq_type :=
+       (
+                0,
+            65535,
+            32768
+         );
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+       variable rom : romq_type :=
+       (
+         0,
+         65535,
+         32768
+       );
+    """
+
+    def __init__(self):
+        super().__init__(lTokenPairs)
+        self.assignment_operator = token.assignment_operator

--- a/vsg/rules/variable/rule_402.py
+++ b/vsg/rules/variable/rule_402.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 
-from vsg.token import variable_declaration as token
 from vsg.rules import multiline_array_alignment as Rule
+from vsg.token import variable_declaration as token
 
 lTokenPairs = []
 lTokenPairs.append([token.assignment_operator, token.semicolon])

--- a/vsg/rules/variable/rule_403.py
+++ b/vsg/rules/variable/rule_403.py
@@ -9,7 +9,7 @@ lTokenPairs.append([token.variable_keyword, token.semicolon])
 
 class rule_403(Rule):
     """
-    This rule checks the structure of multiline variables that contain arrays.
+    This rule checks the structure of multiline variable initializations that contain arrays.
 
     |configuring_array_multiline_structure_rules_link|
 

--- a/vsg/rules/variable/rule_403.py
+++ b/vsg/rules/variable/rule_403.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from vsg.token import variable_declaration as token
+from vsg.rules import multiline_structure as Rule
+
+lTokenPairs = []
+lTokenPairs.append([token.variable_keyword, token.semicolon])
+
+
+class rule_403(Rule):
+    """
+    This rule checks the structure of multiline variables that contain arrays.
+
+    |configuring_array_multiline_structure_rules_link|
+
+    .. NOTE:: The indenting of multiline array variables is handled by the rule `variable_402 <variable_rules.html#variable-402>`_.
+
+    **Violation**
+
+    .. code-block:: vhdl
+
+       variable rom : romq_type := (0, 65535, 32768);
+
+    **Fix**
+
+    .. code-block:: vhdl
+
+       variable rom : romq_type :=
+       (
+         0,
+         65535,
+         32768
+       );
+    """
+
+    def __init__(self):
+        super().__init__(lTokenPairs)
+        self.assignment_operator = token.assignment_operator
+        self.semicolon = token.semicolon
+        self.phase = 5

--- a/vsg/rules/variable/rule_403.py
+++ b/vsg/rules/variable/rule_403.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from vsg.token import variable_declaration as token
 from vsg.rules import multiline_structure as Rule
+from vsg.token import variable_declaration as token
 
 lTokenPairs = []
 lTokenPairs.append([token.variable_keyword, token.semicolon])


### PR DESCRIPTION
Resolves #1510.

> [!NOTE]
> Note that the behaviour of variable_400 has been modified to remove erroneous overlap with the new rules. FYI @jeremiah-c-leary.  