### PR TITLE
Typo in example indentation config

### DIFF
--- a/docs/configuring_indent_rules.rst
+++ b/docs/configuring_indent_rules.rst
@@ -39,7 +39,7 @@ The :code:`indent_style` option can be set globally for all rules and locally fo
 
 .. code-block:: yaml
 
-   rules:
+   rule:
       global:
          indent_style: 'smart_tabs'
          indent_size: 2


### PR DESCRIPTION
Remove typo from example indentation config.

**Additional context**
Missing this lead me down a debugging rabbit hole. Turns out the example had a minute typo.
