### PR TITLE
Strip whitespace from file path

### DIFF
--- a/vsg/cmd_line_args.py
+++ b/vsg/cmd_line_args.py
@@ -27,7 +27,7 @@ def __is_valid_file(value: str) -> str:
     :param value: String path to analyze.
     :return:
     """
-    lFileNames = glob.glob(utils.expand_filename(value), recursive=True)
+    lFileNames = glob.glob(utils.expand_filename(value.strip()), recursive=True)
     if len(lFileNames) == 0:
         if "*" in value:
             raise argparse.ArgumentTypeError(f"The file glob {value} did not match any files.")


### PR DESCRIPTION
Trim whitespace from the input value before globbing. This caused a problem for me when calling vsg in a subprocess, as a space was inserted before the path for whatever reason

**Description**
The problem is that when calling vsg as a subprocess from a python script, a space was inserted before the file path, and the file wasnt found using the glob. This solves the problem

