### PR TITLE
Issue#1541: Corrected the examples and default value errors in the documentation.

### DIFF
--- a/docs/configuring_indent_rules.rst
+++ b/docs/configuring_indent_rules.rst
@@ -39,7 +39,7 @@ The :code:`indent_style` option can be set globally for all rules and locally fo
 
 .. code-block:: yaml
 
-   rules:
+   rule:
       global:
          indent_style: 'smart_tabs'
          indent_size: 2

--- a/docs/configuring_multiline_assert_rule.rst
+++ b/docs/configuring_multiline_assert_rule.rst
@@ -20,7 +20,7 @@ The method of indenting can be configured using one of the following options:
    :code:`left`, :code:`report`
 
 .. |default_value| replace::
-   :code:`left`
+   :code:`report`
 
 .. |report| replace::
    :code:'report`

--- a/docs/configuring_simple_multiline_structure_rules.rst
+++ b/docs/configuring_simple_multiline_structure_rules.rst
@@ -43,7 +43,7 @@ There are several options to these rules:
 +-------------------------+-------------+---------------+-----------------------------------+
 | Method                  | Values      | Default       | Description                       |
 +=========================+=============+===============+===================================+
-| |new_line_after_assign| | |values1|   | |default_yes| | * |new_line_after_assign__yes|    |
+| |new_line_after_assign| | |values1|   | |default_no|  | * |new_line_after_assign__yes|    |
 |                         |             |               | * |new_line_after_assign__no|     |
 |                         |             |               | * |new_line_after_assign__ignore| |
 +-------------------------+-------------+---------------+-----------------------------------+


### PR DESCRIPTION
**Description**
Issue #1541 

1. On the Configuring/Configuring Indent Rules page, the example should use ‘rule’ rather than ‘rules’. Using ‘rules’ in the configuration file doesn’t work.
2. On the Configuring/Configuring Multiline Assert Rule page, the default value of alignment is 'left' but it is 'report' in the default configuration files. Change to 'report' on docs.
3. On the Configuring/Configuring Simple Multiline Structure Rules poge, the default value of 'new_line_after_assign' is 'yes' but it is 'no' in the default configuration files. Change to 'no' on docs.