### PR TITLE
Fix crash in multiline array rules on deferred constants

### DIFF
--- a/tests/constant/rule_016_test_input_deferred_constant.vhd
+++ b/tests/constant/rule_016_test_input_deferred_constant.vhd
@@ -1,0 +1,13 @@
+
+package baz_pkg is
+
+  constant c_baz :
+    integer;
+
+end package baz_pkg;
+
+package body baz_pkg is
+
+  constant c_baz : integer := 42;
+
+end package body baz_pkg;

--- a/tests/constant/test_rule_016.py
+++ b/tests/constant/test_rule_016.py
@@ -14,6 +14,7 @@ lFileOthers, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_
 lFileAssignment, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_016_test_input_assignment.vhd"))
 lFileAssignOnSingleLine, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_016_test_input_assignment.vhd"))
 lFilePositional, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_016_test_input_positional.vhd"))
+lFileDeferredConstant, eError = vhdlFile.utils.read_vhdlfile(os.path.join(sTestDir, "rule_016_test_input_deferred_constant.vhd"))
 
 lExpected_first_paren_new_line_true = []
 lExpected_first_paren_new_line_true.append("")
@@ -248,6 +249,15 @@ class test_rule(unittest.TestCase):
         lExpected.extend(range(84, 88))
 
         oRule.analyze(self.oFile)
+        self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
+
+    def test_rule_016_multiline_deferred_constant(self):
+        oRule = constant.rule_016()
+
+        lExpected = []
+
+        oFile = vhdlFile.vhdlFile(lFileDeferredConstant)
+        oRule.analyze(oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
 
     def test_rule_016_assign_on_single_line(self):

--- a/vsg/rules/utils.py
+++ b/vsg/rules/utils.py
@@ -419,6 +419,8 @@ def is_next_token_ignoring_whitespace(oToken, iToken, lTokens):
 
 def array_detected_after_assignment_operator(assignment_operator, oToi):
     lTokens = oToi.get_tokens()
+    if get_index_of_token_in_list(assignment_operator, lTokens) is None:
+        return False
     if not open_paren_after_assignment_operator(assignment_operator, lTokens):
         return False
     if open_paren_after_assignment_operator_is_aggregate(assignment_operator, lTokens):


### PR DESCRIPTION
**Description**

`constant_012` and `constant_016` crashed with `TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'` whenever a constant declaration spanning multiple lines had no `:=` initializer. This is the case for a deferred constant whose full declaration (with initializer) is supplied in the package body, which is legal per IEEE 1076-2008 4.7/4.8.

`rules/utils.py:array_detected_after_assignment_operator` called `open_paren_after_assignment_operator`, which looked up the assignment-operator token index via `get_index_of_token_in_list` (returns `None` when absent) and then did `iToken + 1`. It now returns `False` early when the assignment operator token is not present.

Repro:

```vhdl
package baz_pkg is
  constant c_baz :
    integer;
end package baz_pkg;

package body baz_pkg is
  constant c_baz : integer := 42;
end package body baz_pkg;
```

`vsg -f file.vhd` crashed before this change.

**Additional context**

Fixes #1549. Added `tests/constant/rule_016_test_input_deferred_constant.vhd` and `test_rule_016_multiline_deferred_constant`, which crashes before the fix and passes after. Full `tests/constant` suite (154 tests) and `tests/vsg` integration suite pass.