### PR TITLE
Issue#1547: Corrected library_007 to check library clauses for previous libraries

### DIFF
--- a/tests/library/rule_007_test_input.fixed_no_blank_line.vhd
+++ b/tests/library/rule_007_test_input.fixed_no_blank_line.vhd
@@ -1,4 +1,4 @@
-
+library ieee;
 use stdio.all;
 
 library ieee;

--- a/tests/library/rule_007_test_input.fixed_no_blank_line_unless_different_library.vhd
+++ b/tests/library/rule_007_test_input.fixed_no_blank_line_unless_different_library.vhd
@@ -1,3 +1,4 @@
+library ieee;
 
 use stdio.all;
 

--- a/tests/library/rule_007_test_input.vhd
+++ b/tests/library/rule_007_test_input.vhd
@@ -1,3 +1,4 @@
+library ieee;
 
 use stdio.all;
 

--- a/tests/library/test_rule_007.py
+++ b/tests/library/test_rule_007.py
@@ -25,7 +25,7 @@ class test_rule(unittest.TestCase):
         self.assertEqual(oRule.name, "library")
         self.assertEqual(oRule.identifier, "007")
 
-        lExpected = [11, 16, 22, 24, 27, 33, 42, 51, 60, 69, 78, 87, 96, 106]
+        lExpected = [3, 12, 17, 23, 25, 28, 34, 43, 52, 61, 70, 79, 88, 97, 107]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))
@@ -51,7 +51,7 @@ class test_rule(unittest.TestCase):
         oRule = library.rule_007()
         oRule.style = "no_blank_line_unless_different_library"
 
-        lExpected = [11, 16, 22, 27, 106]
+        lExpected = [12, 17, 23, 28, 107]
 
         oRule.analyze(self.oFile)
         self.assertEqual(lExpected, utils.extract_violation_lines_from_violation_object(oRule.violations))

--- a/vsg/rules/previous_line.py
+++ b/vsg/rules/previous_line.py
@@ -111,14 +111,7 @@ def _analyze_no_blank_line(self, lToi, lAllowTokens):
 
 def _analyze_no_blank_line_unless_different_library(self, lToi, lAllowTokens):
     for oToi in lToi:
-        if oToi.get_meta_data("previous_library") == oToi.get_meta_data("current_library"):
-            sSolution = "Remove blank lines"
-            oViolation = violation.New(oToi.get_line_number(), oToi, sSolution)
-            dAction = {}
-            dAction["action"] = "Remove"
-            oViolation.set_action(dAction)
-            self.add_violation(oViolation)
-        elif oToi.get_meta_data("previous_library") is None:
+        if oToi.get_meta_data("previous_library_is_different"):
             sSolution = "Remove blank lines"
             oViolation = violation.New(oToi.get_line_number(), oToi, sSolution)
             dAction = {}

--- a/vsg/token_map.py
+++ b/vsg/token_map.py
@@ -146,7 +146,13 @@ class New:
         pp.pprint(self.dMap)
 
     def get_index_of_line(self, iLine):
-        return self.dMap["parser"]["carriage_return"][iLine - 2] + 1
+        # This function works by getting the carriage return from the previous line and adding 1 to make it the start of
+        # the next line. If the input is the first line, then there is not previous line, so there is a special case is
+        # required.
+        if iLine == 1:
+            return 0
+        else:
+            return self.dMap["parser"]["carriage_return"][iLine - 2] + 1
 
 
 def extract_unique_id(oToken):

--- a/vsg/vhdlFile/extract/get_blank_lines_above_line_starting_with_use_clause.py
+++ b/vsg/vhdlFile/extract/get_blank_lines_above_line_starting_with_use_clause.py
@@ -22,12 +22,13 @@ def get_previous_library(oToi, lAllTokens, oTokenMap):
     iEndIndex = oToi.get_start_index()
     iLineNumber = oTokenMap.get_line_number_of_index(iEndIndex)
     iStartIndex = oTokenMap.get_index_of_line(iLineNumber)
-    lTokenIndex = oTokenMap.get_token_indexes_between_indexes(token.use_clause.library_name, iStartIndex, iEndIndex)
-    if len(lTokenIndex) == 0:
-        return None
-    else:
-        oToken = lAllTokens[lTokenIndex[0]]
-        return oToken.get_lower_value()
+
+    for oLibraryNameToken in [token.use_clause.library_name, token.logical_name_list.logical_name]:
+        lTokenIndex = oTokenMap.get_token_indexes_between_indexes(oLibraryNameToken, iStartIndex, iEndIndex)
+        if len(lTokenIndex) > 0:
+            oToken = lAllTokens[lTokenIndex[0]]
+            return oToken.get_lower_value()
+    return None
 
 
 def get_current_library(oToi, lAllTokens, oTokenMap):

--- a/vsg/vhdlFile/extract/get_blank_lines_above_line_starting_with_use_clause.py
+++ b/vsg/vhdlFile/extract/get_blank_lines_above_line_starting_with_use_clause.py
@@ -23,11 +23,14 @@ def get_previous_library(oToi, lAllTokens, oTokenMap):
     iLineNumber = oTokenMap.get_line_number_of_index(iEndIndex)
     iStartIndex = oTokenMap.get_index_of_line(iLineNumber)
 
+    # Check for both possible clauses that could contain a library name: use clause and library clause (which includes
+    # the library name in logical_name_list).
     for oLibraryNameToken in [token.use_clause.library_name, token.logical_name_list.logical_name]:
         lTokenIndex = oTokenMap.get_token_indexes_between_indexes(oLibraryNameToken, iStartIndex, iEndIndex)
         if len(lTokenIndex) > 0:
             oToken = lAllTokens[lTokenIndex[0]]
             return oToken.get_lower_value()
+    # If no library name was found, return None.
     return None
 
 

--- a/vsg/vhdlFile/extract/get_blank_lines_above_line_starting_with_use_clause.py
+++ b/vsg/vhdlFile/extract/get_blank_lines_above_line_starting_with_use_clause.py
@@ -9,7 +9,6 @@ def get_blank_lines_above_line_starting_with_use_clause(lTokens, lAllTokens, oTo
     lToi = utils.get_all_blank_lines_above_indexes(lIndexes, lAllTokens, oTokenMap)
     lToi = filter_design_unit(lToi, oTokenMap)
     for oToi in lToi:
-
         previous_library = get_previous_library(oToi, lAllTokens, oTokenMap)
         current_library = get_current_library(oToi, lAllTokens, oTokenMap)
         previous_library_is_different = (previous_library == current_library) or (previous_library is None)

--- a/vsg/vhdlFile/extract/get_blank_lines_above_line_starting_with_use_clause.py
+++ b/vsg/vhdlFile/extract/get_blank_lines_above_line_starting_with_use_clause.py
@@ -9,31 +9,35 @@ def get_blank_lines_above_line_starting_with_use_clause(lTokens, lAllTokens, oTo
     lToi = utils.get_all_blank_lines_above_indexes(lIndexes, lAllTokens, oTokenMap)
     lToi = filter_design_unit(lToi, oTokenMap)
     for oToi in lToi:
-        update_previous_library(oToi, lAllTokens, oTokenMap)
-        update_current_library(oToi, lAllTokens, oTokenMap)
+
+        previous_library = get_previous_library(oToi, lAllTokens, oTokenMap)
+        current_library = get_current_library(oToi, lAllTokens, oTokenMap)
+        previous_library_is_different = (previous_library == current_library) or (previous_library is None)
+        oToi.set_meta_data("previous_library_is_different", previous_library_is_different)
+
     return lToi
 
 
-def update_previous_library(oToi, lAllTokens, oTokenMap):
+def get_previous_library(oToi, lAllTokens, oTokenMap):
     iEndIndex = oToi.get_start_index()
     iLineNumber = oTokenMap.get_line_number_of_index(iEndIndex)
     iStartIndex = oTokenMap.get_index_of_line(iLineNumber)
     lTokenIndex = oTokenMap.get_token_indexes_between_indexes(token.use_clause.library_name, iStartIndex, iEndIndex)
     if len(lTokenIndex) == 0:
-        oToi.set_meta_data("previous_library", None)
+        return None
     else:
         oToken = lAllTokens[lTokenIndex[0]]
-        oToi.set_meta_data("previous_library", oToken.get_lower_value())
+        return oToken.get_lower_value()
 
 
-def update_current_library(oToi, lAllTokens, oTokenMap):
+def get_current_library(oToi, lAllTokens, oTokenMap):
     iLineNumber = oToi.get_line_number()
     iStartIndex = oTokenMap.get_index_of_line(iLineNumber)
     iLineNumber += 1
     iEndIndex = oTokenMap.get_index_of_line(iLineNumber)
     lTokenIndex = oTokenMap.get_token_indexes_between_indexes(token.use_clause.library_name, iStartIndex, iEndIndex)
     oToken = lAllTokens[lTokenIndex[0]]
-    oToi.set_meta_data("current_library", oToken.get_lower_value())
+    return oToken.get_lower_value()
 
 
 def get_list_of_indexes(lTokens, oTokenMap):


### PR DESCRIPTION
Resolves #1547.
Also fixed a corner case in `get_index_of_line` where it would underflow if iLine = 1.