### PR TITLE
Remove self.allow_comment on previous_line base rule

### DIFF
--- a/vsg/rules/previous_line.py
+++ b/vsg/rules/previous_line.py
@@ -175,7 +175,7 @@ def _analyze_require_comment(self, lToi, lAllowTokens):
             if isinstance(lTokens[0], parser.blank_line):
                 continue
         elif len(lTokens) == 2:
-            if token_is_whitespace(lTokens[0]) and token_is_comment(lTokens[1]) and self.allow_comment:
+            if token_is_whitespace(lTokens[0]) and token_is_comment(lTokens[1]):
                 continue
         oViolation = violation.New(oToi.get_line_number(), oToi, self.solution)
         dAction = {}


### PR DESCRIPTION
**Description**
Any rule using style: require_comment crashed with AttributeError during --fix.

```
multiprocessing.pool.RemoteTraceback:                                                                                                                   """
Traceback (most recent call last):                                                                                                                        File "/home/zulberti/miniconda3/envs/ingeniars-common-rtl/lib/python3.14/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))                                                                                                                                    ~~~~^^^^^^^^^^^^^^^
  File "/home/zulberti/miniconda3/envs/ingeniars-common-rtl/lib/python3.14/site-packages/vsg/apply_rules.py", line 120, in apply_rules                      oRules.fix(commandLineArguments.fix_phase, commandLineArguments.skip_phase, fix_only)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                 File "/home/zulberti/miniconda3/envs/ingeniars-common-rtl/lib/python3.14/site-packages/vsg/rule_list.py", line 157, in fix
    oRule.fix(self.oVhdlFile, dFixOnly)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zulberti/miniconda3/envs/ingeniars-common-rtl/lib/python3.14/site-packages/vsg/rule.py", line 108, in fix
    self.analyze(oFile)
    ~~~~~~~~~~~~^^^^^^^
  File "/home/zulberti/miniconda3/envs/ingeniars-common-rtl/lib/python3.14/site-packages/vsg/rule.py", line 148, in analyze
    self._analyze(lToi)
    ~~~~~~~~~~~~~^^^^^^
  File "/home/zulberti/miniconda3/envs/ingeniars-common-rtl/lib/python3.14/site-packages/vsg/rules/previous_line.py", line 77, in _analyze
    _analyze_require_comment(self, lToi, self.lAllowTokens)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zulberti/miniconda3/envs/ingeniars-common-rtl/lib/python3.14/site-packages/vsg/rules/previous_line.py", line 185, in _analyze_require_comment
    if token_is_whitespace(lTokens[0]) and token_is_comment(lTokens[1]) and self.allow_comment:
                                                                            ^^^^^^^^^^^^^^^^^^
AttributeError: 'rule_010' object has no attribute 'allow_comment'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/zulberti/work/git-repos/external/vhdl-style-guide/./bin/vsg", line 16, in <module>
    main()
    ~~~~^^
  File "/home/zulberti/miniconda3/envs/ingeniars-common-rtl/lib/python3.14/site-packages/vsg/__main__.py", line 154, in main
    for tResult in pool.imap(f, enumerate(commandLineArguments.filename)):
                   ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zulberti/miniconda3/envs/ingeniars-common-rtl/lib/python3.14/multiprocessing/pool.py", line 873, in next
    raise value
AttributeError: 'rule_010' object has no attribute 'allow_comment'
```
